### PR TITLE
Revert "chore: adujst anchor positioning for fixed header layout (#45)"

### DIFF
--- a/src/styles/templates/doc.scss
+++ b/src/styles/templates/doc.scss
@@ -112,15 +112,6 @@ $navbar-height-mobile: 4.25rem; // 68px
           transform: translate(0, $navbar-height);
         }
       }
-
-      &::before {
-        content: '';
-        display: block;
-        position: relative;
-        width: 0;
-        height: $navbar-height;
-        margin-top: -$navbar-height;
-      }
     }
 
     h1 {
@@ -149,10 +140,8 @@ $navbar-height-mobile: 4.25rem; // 68px
       color: $primary;
       &.anchor {
         &.before {
-          transform: translate(-50%, $navbar-height);
-
           @include mobile {
-            transform: translate(0, $navbar-height);
+            transform: translateX(0);
           }
         }
       }


### PR DESCRIPTION
This reverts commit 18c811249d058aa65b94753033e8848c60defad0.

Reverted the commit #45. It is test PR, which will make the code block above the header with anchor not copyable.