### PR TITLE
Refine browser ctrl+f search results

### DIFF
--- a/src/components/toc.js
+++ b/src/components/toc.js
@@ -20,6 +20,12 @@ const TOC = ({ data, pathPrefix, fullPath }) => {
 
     function fold(li) {
       Array.from(li.children).forEach((list) => {
+        if (list.tagName === 'SPAN') {
+          list.style.display = 'inlin-block'
+        } else if (list.tagName === 'UL') {
+          list.style.display = 'none'
+        }
+
         Array.from(list.children).forEach((el) => {
           if (
             el.classList.contains('can-unfold') &&
@@ -29,6 +35,7 @@ const TOC = ({ data, pathPrefix, fullPath }) => {
             fold(el)
           }
         })
+
         requestAnimationFrame(() => {
           list.style.height = list.scrollHeight + 'px'
 
@@ -40,9 +47,15 @@ const TOC = ({ data, pathPrefix, fullPath }) => {
     }
 
     function unfold(li) {
-      Array.from(li.children).forEach(
-        (el) => (el.style.height = el.scrollHeight + 'px')
-      )
+      Array.from(li.children).forEach((el) => {
+        if (el.tagName === 'SPAN') {
+          el.style.display = 'inlin-block'
+        } else if (el.tagName === 'UL') {
+          el.style.display = 'block'
+        }
+
+        return (el.style.height = el.scrollHeight + 'px')
+      })
     }
 
     function clickEvent(e) {

--- a/src/styles/components/toc.scss
+++ b/src/styles/components/toc.scss
@@ -4,7 +4,7 @@ $navbar-height: 5.25rem; // 84px
 
 .PingCAP-TOC {
   display: none;
-  
+
   &.show-toc {
     display: block;
     transition: display 10ms;
@@ -91,6 +91,10 @@ $navbar-height: 5.25rem; // 84px
           margin-left: 0.5rem;
           background: url(../../../images/toc/add.svg) no-repeat;
           background-size: contain;
+        }
+
+        > ul {
+          display: none;
         }
 
         ul {

--- a/src/styles/templates/doc.scss
+++ b/src/styles/templates/doc.scss
@@ -233,6 +233,10 @@ $navbar-height-mobile: 4.25rem; // 68px
   }
 
   .doc-toc-column {
+    position: sticky;
+    top: calc(#{$navbar-height} + 1rem);
+    max-height: calc(100vh);
+    overflow: auto;
     min-width: 200px;
 
     @include mobile {
@@ -241,11 +245,6 @@ $navbar-height-mobile: 4.25rem; // 68px
   }
 
   .doc-toc {
-    position: sticky;
-    top: calc(#{$navbar-height} + 1rem);
-    max-height: calc(100vh);
-    overflow: auto;
-
     .title {
       margin: 0 0 1rem;
       color: $B3;
@@ -278,7 +277,7 @@ $navbar-height-mobile: 4.25rem; // 68px
         &:first-child {
           padding-top: 10px;
         }
-        
+
         ul {
           padding-left: 1rem;
         }


### PR DESCRIPTION
Add `display: none` on folded content to tell browser not to search folded content.