### PR TITLE
fix: add renamed status to delete previous file

### DIFF
--- a/markdown-pages/download.js
+++ b/markdown-pages/download.js
@@ -113,10 +113,6 @@ async function handleSync(metaInfo, pipelines = []) {
 
       let downloadToPathArrWithoutLang = filename.split('/')
 
-      if (previous_filename) {
-        renamedFilePathArrWithoutLang = previous_filename.split('/')
-      }
-
       switch (repo) {
         case 'docs-dm':
         case 'docs-tidb-operator':
@@ -124,11 +120,6 @@ async function handleSync(metaInfo, pipelines = []) {
           lang = filename.substring(0, 2)
           finalRepo = repo
 
-          if (previous_filename) {
-            renamedFilePathArrWithoutLang = renamedFilePathArrWithoutLang.slice(
-              1
-            )
-          }
           break
 
         case 'dbaas-docs':
@@ -156,14 +147,6 @@ async function handleSync(metaInfo, pipelines = []) {
         ref,
         downloadToPathArrWithoutLang
       )
-      if (previous_filename) {
-        renamedFilePath = generateDistPath(
-          lang,
-          finalRepo,
-          ref,
-          renamedFilePathArrWithoutLang
-        )
-      }
 
       switch (status) {
         case 'added':
@@ -182,6 +165,13 @@ async function handleSync(metaInfo, pipelines = []) {
 
           break
         case 'renamed':
+          renamedFilePathArrWithoutLang = previous_filename.split('/').slice(1)
+          renamedFilePath = generateDistPath(
+            lang,
+            finalRepo,
+            ref,
+            renamedFilePathArrWithoutLang
+          )
           writeContent(raw_url, downloadToPath, pipelines)
           fs.unlink(renamedFilePath, (err) => {
             if (err) {


### PR DESCRIPTION
If a file is renamed, the git info status will be `renamed`. We are missing the `renamed` status check and using markdown content cache for each incremental download, so the previous file won't be deleted.

Now add `renamed` status check, we can delete the previous file and download the new file.