### PR TITLE
feat: set global for plugins use

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -6,9 +6,10 @@ import { IntlProvider } from 'react-intl'
 import Navbar from './navbar'
 import PropTypes from 'prop-types'
 import flat from 'flat'
+import { globalHistory } from '@reach/router'
 import langMap from '../intl'
-import { useDispatch } from 'react-redux'
 import { navigate } from 'gatsby-link'
+import { useDispatch } from 'react-redux'
 
 const Layout = ({
   locale,
@@ -20,6 +21,7 @@ const Layout = ({
 
   const setGlobalForPluginsUse = () => {
     window.DOCS_PINGCAP = {
+      globalHistory,
       navigate,
     }
   }

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types'
 import flat from 'flat'
 import langMap from '../intl'
 import { useDispatch } from 'react-redux'
+import { navigate } from 'gatsby-link'
 
 const Layout = ({
   locale,
@@ -16,6 +17,12 @@ const Layout = ({
   langSwitchable,
 }) => {
   const dispatch = useDispatch()
+
+  const setGlobalForPluginsUse = () => {
+    window.DOCS_PINGCAP = {
+      navigate,
+    }
+  }
 
   useEffect(
     () => {
@@ -29,6 +36,8 @@ const Layout = ({
           })
         )
       }
+
+      setGlobalForPluginsUse()
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []


### PR DESCRIPTION
As the title.

Sometimes, it's useful to provide pluggability in a website codebase so that the outside code (like browser extensions) can easily integrate into the website.

This PR is Is an initial attempt for the above desc.