### PR TITLE
remarkSyntaxDiagram: fix rendering of (x y z)*

### DIFF
--- a/src/lib/__tests__/remarkSyntaxDiagram.js
+++ b/src/lib/__tests__/remarkSyntaxDiagram.js
@@ -203,6 +203,54 @@ describe('deepEq', () => {
   })
 })
 
+describe('isRTLCapable', () => {
+  it('treats leaf nodes as RTL capable', () => {
+    expect(isRTLCapable({ type: 'Terminal', text: 'a' })).toBeTruthy()
+    expect(isRTLCapable({ type: 'NonTerminal', text: 'a' })).toBeTruthy()
+    expect(isRTLCapable({ type: 'Skip' })).toBeTruthy()
+  })
+  it('treats sequences to be not RTL capable', () => {
+    expect(isRTLCapable({
+      type: 'Sequence',
+      items: [
+        { type: 'Terminal', text: 'a' },
+        { type: 'Terminal', text: 'b' },
+      ],
+    })).toBeFalsy();
+    expect(isRTLCapable({
+      type: 'OptionalSequence',
+      items: [
+        { type: 'Terminal', text: 'a' },
+        { type: 'Terminal', text: 'b' },
+      ],
+    })).toBeFalsy()
+  })
+  it('can see through choices', () => {
+    expect(isRTLCapable({
+      type: 'Choice',
+      normalIndex: 0,
+      options: [
+        { type: 'Terminal', text: 'a' },
+        { type: 'Terminal', text: 'b' },
+      ],
+    })).toBeTruthy()
+    expect(isRTLCapable({
+      type: 'Choice',
+      normalIndex: 0,
+      options: [
+        { type: 'Terminal', text: 'a' },
+        {
+          type: 'Sequence',
+          items: [
+            { type: 'Terminal', text: 'a' },
+            { type: 'Terminal', text: 'b' },
+          ],
+        }
+      ],
+    })).toBeFalsy()
+  })
+})
+
 describe('appendNodeToChoices', () => {
   it('can recognize the `a | a? b` pattern', () => {
     let opts = [
@@ -299,14 +347,17 @@ describe('appendNodeToSequence', () => {
       { type: 'Terminal', text: 'a' },
     ]
     appendNodeToSequence(items, {
-      type: 'OneOrMore',
-      item: { type: 'Skip' },
-      repeat: {
-        type: 'Sequence',
-        items: [
-          { type: 'Terminal', text: ',' },
-          { type: 'Terminal', text: 'a' },
-        ],
+      type: 'Optional',
+      item: {
+        type: 'OneOrMore',
+        item: {
+          type: 'Sequence',
+          items: [
+            { type: 'Terminal', text: ',' },
+            { type: 'Terminal', text: 'a' },
+          ],
+        },
+        repeat: { type: 'Skip' },
       },
     })
     expect(items).toEqual([
@@ -318,36 +369,62 @@ describe('appendNodeToSequence', () => {
       },
     ])
   })
+  it('just appends when repeating part is not RTL capable', () => {
+    let items = [
+      { type: 'Terminal', text: 'x' },
+      { type: 'Terminal', text: 'a' },
+    ]
+    const tail = {
+      type: 'Optional',
+      item: {
+        type: 'OneOrMore',
+        item: {
+          type: 'Sequence',
+          items: [
+            {
+              type: 'Sequence',
+              items: [
+                { type: 'Terminal', text: 'AND' },
+                { type: 'Terminal', text: 'THEN' },
+              ],
+            },
+            { type: 'Terminal', text: 'a' },
+          ],
+        },
+        repeat: { type: 'Skip' },
+      },
+    }
+    appendNodeToSequence(items, tail)
+    expect(items).toEqual([
+      { type: 'Terminal', text: 'x' },
+      { type: 'Terminal', text: 'a' },
+      tail,
+    ])
+  })
   it('just appends without special patterns', () => {
     let items = [
       { type: 'Terminal', text: 'x' },
       { type: 'Terminal', text: 'a' },
     ]
-    appendNodeToSequence(items, {
-      type: 'OneOrMore',
-      item: { type: 'Skip' },
-      repeat: {
-        type: 'Sequence',
-        items: [
-          { type: 'Terminal', text: ',' },
-          { type: 'Terminal', text: 'b' },
-        ],
-      },
-    })
-    expect(items).toEqual([
-      { type: 'Terminal', text: 'x' },
-      { type: 'Terminal', text: 'a' },
-      {
+    const tail = {
+      type: 'Optional',
+      item: {
         type: 'OneOrMore',
-        item: { type: 'Skip' },
-        repeat: {
+        item: {
           type: 'Sequence',
           items: [
             { type: 'Terminal', text: ',' },
             { type: 'Terminal', text: 'b' },
           ],
         },
+        repeat: { type: 'Skip' },
       },
+    }
+    appendNodeToSequence(items, tail)
+    expect(items).toEqual([
+      { type: 'Terminal', text: 'x' },
+      { type: 'Terminal', text: 'a' },
+      tail,
     ])
   })
 })
@@ -449,7 +526,7 @@ describe('remarkSyntaxDiagram', () => {
     })
   })
   it('skip code blocks with syntax error', () => {
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => { })
 
     expect(
       remarkSyntaxDiagram({

--- a/src/lib/__tests__/remarkSyntaxDiagram.js
+++ b/src/lib/__tests__/remarkSyntaxDiagram.js
@@ -526,7 +526,7 @@ describe('remarkSyntaxDiagram', () => {
     })
   })
   it('skip code blocks with syntax error', () => {
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => { })
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     expect(
       remarkSyntaxDiagram({

--- a/src/lib/remarkSyntaxDiagram.js
+++ b/src/lib/remarkSyntaxDiagram.js
@@ -44,7 +44,9 @@ const ebnfParser = pegjs.generate(`
     case '+':
       return {type: 'OneOrMore', item: p, repeat: {type: 'Skip'}};
     case '*':
-      return {type: 'OneOrMore', item: {type: 'Skip'}, repeat: p};
+      return options.context.isRTLCapable(p) ?
+        {type: 'OneOrMore', item: {type: 'Skip'}, repeat: p} :
+        {type: 'Optional', item: {type: 'OneOrMore', item: p, repeat: {type: 'Skip'}}};
     default:
       return p;
     }
@@ -110,6 +112,34 @@ function deepEq(a, b) {
 }
 
 /**
+ * Checks whether the component can be read from right to left. This also means
+ * the component is only one node wide.
+ *
+ * @param {RRComponent} a -
+ *  the railroad component
+ * @returns {boolean} whether the component can be read from right to left
+ */
+function isRTLCapable(a) {
+  switch (a.type) {
+    case 'Skip':
+    case 'Terminal':
+    case 'NonTerminal':
+      return true;
+    case 'Optional':
+      return isRTLCapable(a.item);
+    case 'OneOrMore':
+      return isRTLCapable(a.item) && isRTLCapable(a.repeat);
+    case 'Choice':
+      return a.options.every(isRTLCapable);
+    case 'Sequence':
+    case 'OptionalSequence':
+    case 'Stack':
+      const length = a.items.length;
+      return length === 1 ? isRTLCapable(a.items[0]) : length === 0;
+  }
+}
+
+/**
  * Appends an EBNF node to a Choice container.
  *
  * This function will also try to optimize the pattern `a | a? b` or `b? | a b?`
@@ -156,18 +186,19 @@ function appendNodeToChoices(opts, node) {
  */
 function appendNodeToSequence(items, node) {
   if (
-    node.type === 'OneOrMore' &&
-    node.item.type === 'Skip' &&
-    node.repeat.type === 'Sequence' &&
-    node.repeat.items.length === 2
+    node.type === 'Optional' &&
+    node.item.type === 'OneOrMore' &&
+    node.item.repeat.type === 'Skip' &&
+    node.item.item.type === 'Sequence' &&
+    node.item.item.items.length === 2
   ) {
     const left = items[items.length - 1]
-    const right = node.repeat.items[1]
-    if (deepEq(left, right)) {
+    const [ repeat, right ] = node.item.item.items;
+    if (isRTLCapable(repeat) && deepEq(left, right)) {
       items[items.length - 1] = {
         type: 'OneOrMore',
         item: left,
-        repeat: node.repeat.items[0],
+        repeat,
       }
       return
     }
@@ -245,7 +276,7 @@ function remarkSyntaxDiagram(tree) {
       try {
         /** @type {{name: string, content: RRComponent}[]} */
         const grammar = ebnfParser.parse(node.value, {
-          context: { appendNodeToChoices, appendNodeToSequence },
+          context: { appendNodeToChoices, appendNodeToSequence, isRTLCapable },
         })
         const diagrams = grammar
           .map(({ name, content }) => {

--- a/src/lib/remarkSyntaxDiagram.js
+++ b/src/lib/remarkSyntaxDiagram.js
@@ -177,7 +177,8 @@ function appendNodeToChoices(opts, node) {
  * Appends an EBNF node to a Sequence container.
  *
  * This function will also try to optimize the pattern `a (b a)*` into the
- * specialized railroad component `OneOrMore(item=a, repeat=b)`.
+ * specialized railroad component `OneOrMore(item=a, repeat=b)`, if the node
+ * `b` is capable to be read RTL (e.g. a single terminal, but not a sequence).
  *
  * @param {RRComponent[]} items -
  *  a list of existing items, the new node will be appended here


### PR DESCRIPTION
In an ENBF+diagram, components like `(x y z)*` is [currently rendered](https://github.com/pingcap/docs/issues/4389#issuecomment-762767158) like this:

![](https://user-images.githubusercontent.com/103023/105017827-36b35180-5a7f-11eb-8f83-a57ce023d214.png)

```
>>--->---------------------v---><
    (                       )
     ^--[ x ]-[ y ]-[ z ]--<
```

This is wrong as the lower part is traveled from right to left, so those following the railroad precisely will get the order `z y x` instead.

This PR changes the rendering to something like this instead to keep the LTR order.

![](https://user-images.githubusercontent.com/103023/105022065-441f0a80-5a84-11eb-9dca-56fc3d6af8a9.png)

```
       >---------------------------v
      /                             \
>>---^--->---[ x ]-[ y ]-[ z ]---v--->---><
        (                         )
         ^-----------------------<
```

Single-node-wide components like `x*` are still rendered with the existing layout.
