### PR TITLE
chore: optimize workflow name

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -12,10 +12,25 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+
+    - name: Extract repo name
+      shell: bash
+      run: echo "##[set-output name=repo;]$(echo $(cut -d'/' -f2 <<< ${{ github.repository }} ))"
+      id: extract_repo
+
+    - name: Extract git sha
+      shell: bash
+      run: echo "##[set-output name=sha;]$(sha=${{ github.sha }}; echo ${sha:0:6})"
+      id: extract_sha
+
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v1.1.1
       with:
           token: ${{ secrets.GH_TOKEN }}
           repository: pingcap/website-docs/
-          event-type: triggered
+          event-type: ${{ steps.extract_repo.outputs.repo }}/${{ steps.extract_branch.outputs.branch }}-${{ steps.extract_sha.outputs.sha }}
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "${{ github.repository }}"}'

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -16,8 +16,8 @@ jobs:
       shell: bash
       id: extract_info
       run: |
-        echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
-        echo "::set-output name=repo::$(echo $(cut -d'/' -f2 <<< ${{ github.repository }} ))"
+        echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        echo "::set-output name=repo::$(cut -d'/' -f2 <<< ${{ github.repository }})"
         echo "::set-output name=sha::$(sha=${{ github.sha }}; echo ${sha:0:6})"
 
     - name: Repository Dispatch

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -12,25 +12,18 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Extract branch name
+    - name: Extract branch, repo and sha
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
-
-    - name: Extract repo name
-      shell: bash
-      run: echo "##[set-output name=repo;]$(echo $(cut -d'/' -f2 <<< ${{ github.repository }} ))"
-      id: extract_repo
-
-    - name: Extract git sha
-      shell: bash
-      run: echo "##[set-output name=sha;]$(sha=${{ github.sha }}; echo ${sha:0:6})"
-      id: extract_sha
+      id: extract_info
+      run: |
+        echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+        echo "::set-output name=repo::$(echo $(cut -d'/' -f2 <<< ${{ github.repository }} ))"
+        echo "::set-output name=sha::$(sha=${{ github.sha }}; echo ${sha:0:6})"
 
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v1.1.1
       with:
           token: ${{ secrets.GH_TOKEN }}
           repository: pingcap/website-docs/
-          event-type: ${{ steps.extract_repo.outputs.repo }}/${{ steps.extract_branch.outputs.branch }}-${{ steps.extract_sha.outputs.sha }}
+          event-type: ${{ steps.extract_info.outputs.repo }}/${{ steps.extract_info.outputs.branch }}-${{ steps.extract_info.outputs.sha }}
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "${{ github.repository }}"}'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,6 @@
 name: Incremental Building Triggered By Push Events
-on:
-  repository_dispatch:
-    types: [triggered]
+on: repository_dispatch
+
 jobs:
   build:
     name: Retrieve docs and deploy the website


### PR DESCRIPTION
Remove the `event_type` limit from `update.yaml`, and customize `event_type` message.

The format of workflow name is `${repo}/${branch}-${sha}`, eg:

![image](https://user-images.githubusercontent.com/34967660/105450728-128d8580-5cb6-11eb-9cad-596a7b39ee0f.png)
