### PR TITLE
Refine retrive md file

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -65,8 +65,9 @@ jobs:
 
       - name: Check file exists
         id: check-file-exists
-        if: github.event.client_payload.download_type != 'full'
         run: |
+          sudo apt install tree
+          tree -L 3 -d ./markdown-pages
           [ "$(ls -A ./markdown-pages)" ] && echo "::set-output name=isEmpty::false" || echo "::set-output name=isEmpty::true"
 
       # if download_type is full, download all docs
@@ -112,6 +113,9 @@ jobs:
           ACT=${{ env.ACT }}
           [[ "${ACT:-false}" = "true" ]] && dryRun="true" || dryRun="false"
           yarn sync ${{ github.event.client_payload.repo }} --ref ${{ github.event.client_payload.ref }} ${{ steps.cache-commit.outputs.base }} ${{ github.event.client_payload.sha }} --dry-run $dryRun
+
+      - run: |
+          tree -L 3 -d ./markdown-pages
 
       - name: Restore gatsby cache
         uses: actions/cache@v2

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,6 +2,8 @@ name: Incremental Build Triggered By Push Events
 
 on: repository_dispatch
 
+concurrency: prod_environment
+
 jobs:
   build:
     name: Retrieve docs and deploy the website
@@ -14,11 +16,6 @@ jobs:
       - name: Bailout
         if: ${{ !github.event.client_payload.sha }}
         run: exit 1
-
-      # make sure there is only one workflow running
-      - name: Turnstyle
-        if: ${{ !env.ACT }}
-        uses: softprops/turnstyle@v1
 
       - name: Set known_hosts
         if: ${{ !env.ACT && github.repository_owner == 'pingcap' }}
@@ -62,18 +59,19 @@ jobs:
         id: docs-cache
         with:
           path: markdown-pages
-          key: ${{ runner.os }}-docs-cache-4-${{ github.event.client_payload.sha }} # You can inc the version number to force cache rebuild
+          key: ${{ runner.os }}-docs-cache-202204-${{ github.event.client_payload.sha }} # You can inc the version number to force cache rebuild
           restore-keys: |
-            ${{ runner.os }}-docs-cache-4-
+            ${{ runner.os }}-docs-cache-202204-
 
       - name: Check file exists
+        id: check-file-exists
         if: github.event.client_payload.download_type != 'full'
         run: |
-          [ "$(ls -A ./markdown-pages)" ] || exit 1
+          [ "$(ls -A ./markdown-pages)" ] && echo "::set-output name=isEmpty::false" || echo "::set-output name=isEmpty::true"
 
       # if download_type is full, download all docs
       - name: Download all docs
-        if: github.event.client_payload.download_type == 'full'
+        if: github.event.client_payload.download_type == 'full' || ${{ steps.check-file-exists.outputs.isEmpty }} == 'true'
         env:
           GITHUB_AUTHORIZATION_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
@@ -122,9 +120,9 @@ jobs:
           path: |
             .cache
             public
-          key: ${{ runner.os }}-gatsby-cache-4-${{ github.event.client_payload.sha }} # You can inc the version number to force cache rebuild
+          key: ${{ runner.os }}-gatsby-cache-202204-${{ github.event.client_payload.sha }} # You can inc the version number to force cache rebuild
           restore-keys: |
-            ${{ runner.os }}-gatsby-cache-4-
+            ${{ runner.os }}-gatsby-cache-202204-
 
       - name: Build website
         env:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -124,9 +124,9 @@ jobs:
           path: |
             .cache
             public
-          key: ${{ runner.os }}-gatsby-cache-202204-${{ github.event.client_payload.sha }} # You can inc the version number to force cache rebuild
+          key: ${{ runner.os }}-gatsby-cache-4-${{ github.event.client_payload.sha }} # You can inc the version number to force cache rebuild
           restore-keys: |
-            ${{ runner.os }}-gatsby-cache-202204-
+            ${{ runner.os }}-gatsby-cache-4-
 
       - name: Build website
         env:

--- a/packages/download/http.js
+++ b/packages/download/http.js
@@ -86,7 +86,7 @@ export function downloadFile(reqUrl, fileName = '') {
  * @returns Promise
  */
 export function getArchiveFile(repo, ref, fileName) {
-  const url = `https://github.com/${repo}/archive/${ref}.zip`
+  const url = `https://api.github.com/repos/${repo}/zipball/${ref}`
   sig.start(`Get content(ref: ${ref}) from:`, url)
   return downloadFile(url, fileName)
 }

--- a/packages/download/http.js
+++ b/packages/download/http.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
 import dotenv from 'dotenv'
-import nPath from 'path'
+import nPath, { resolve } from 'path'
 import sig from 'signale'
+import fs from 'fs'
 
 dotenv.config()
 
@@ -39,4 +40,53 @@ export function compare(repo, base, head) {
   sig.info(`Compare: ${base}...${head}`)
 
   return http.get(url)
+}
+
+export function downloadFile(reqUrl, fileName = '') {
+  return axios({
+    method: 'GET',
+    url: reqUrl,
+    responseType: 'stream',
+    headers: GITHUB_AUTHORIZATION_TOKEN
+      ? {
+          ...defaultHeaders,
+          Authorization: `token ${GITHUB_AUTHORIZATION_TOKEN}`,
+        }
+      : defaultHeaders,
+  })
+    .then(res => {
+      if (res.status == 200) {
+        fileName = fileName || reqUrl.split('/').pop()
+        const dir = resolve(fileName)
+        sig.start(`Download file(fileName: ${fileName}) reqUrl:${reqUrl}`)
+        res.data.pipe(fs.createWriteStream(dir))
+        // res.data.on('end', () => {
+        //   sig.success('download completed')
+        // })
+        return new Promise((resolve, reject) => {
+          res.data.on('end', () => {
+            sig.success('download completed')
+            resolve()
+          })
+        })
+      } else {
+        sig.error(`ERROR >> ${res.status}`)
+      }
+    })
+    .catch(err => {
+      sig.error('Error ', err)
+    })
+}
+
+/**
+ * Download latest github repo archive(zip) file by specified repo and branch.
+ * @param {string} repo Github repo: pingcap/docs
+ * @param {string} ref branch name: master, release-6.0
+ * @param {string} fileName output zip file name
+ * @returns Promise
+ */
+export function getArchiveFile(repo, ref, fileName) {
+  const url = `https://github.com/${repo}/archive/${ref}.zip`
+  sig.start(`Get content(ref: ${ref}) from:`, url)
+  return downloadFile(url, fileName)
 }

--- a/packages/download/index.js
+++ b/packages/download/index.js
@@ -1,4 +1,9 @@
-import { genDest, imageCDNs, retrieveAllMDs } from './utils.js'
+import {
+  genDest,
+  imageCDNs,
+  retrieveAllMDs,
+  retrieveAllMDsFromZip,
+} from './utils.js'
 import {
   replaceCopyableStream,
   replaceImagePathStream,
@@ -54,7 +59,7 @@ export function download(argv) {
   switch (repo) {
     case 'pingcap/docs':
     case 'pingcap/docs-cn':
-      retrieveAllMDs(
+      retrieveAllMDsFromZip(
         {
           repo,
           path,
@@ -70,7 +75,6 @@ export function download(argv) {
         ),
         options
       )
-
       break
     case 'pingcap/docs-dm':
     case 'pingcap/docs-tidb-operator':

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "adm-zip": "^0.5.9",
     "axios": "^0.24.0",
     "dotenv": "^10.0.0",
     "mdast-util-from-markdown": "^1.2.0",

--- a/packages/download/utils.js
+++ b/packages/download/utils.js
@@ -200,7 +200,7 @@ export async function retrieveAllMDsFromZip(
   } catch (error) {
     sig.error(`unzip ${archiveFileName} error`, error)
     if (retry <= 0) {
-      return
+      throw error
     }
     sig.info(`retry retrieve`, ref)
     sig.info(`retry times left: ${retry - 1}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2608,6 +2608,11 @@ adjust-sourcemap-loader@3.0.0:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
 
+adm-zip@^0.5.9:
+  version "0.5.9"
+  resolved "https://registry.npmmirror.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
+  integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
+
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"


### PR DESCRIPTION
- Use `concurrency` instead of `softprops/turnstyle@v1`: 
  - https://github.com/pingcap/website-docs/issues/216
  - https://github.com/pingcap/website-docs/issues/215

- Rename `docs-cache` key for enable new cache
  - Former cache contains docs that had been deleted(Dirty)

- Add `retrieveAllMDsFromZip`:
  - `retrieveAllMDs` call Github API per file download, which easily exceeds API limit rate
  - Now `retrieveAllMDsFromZip` can download and unzip archive file by calling Github API once per branch
  - Temporarily enable on `pingcap/docs` and `pingcap/docs-cn`