### PR TITLE
support markdown custom-id & enable `replaceInternalHref`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -77,7 +77,13 @@ module.exports = {
       options: {
         extensions: [`.mdx`, `.md`],
         gatsbyRemarkPlugins: [
-          `gatsby-remark-autolink-headers`,
+          {
+            resolve: `gatsby-remark-autolink-headers`,
+            options: {
+              offsetY: `100`,
+              enableCustomId: true,
+            },
+          },
           {
             resolve: require.resolve('./gatsby/plugin/syntax-diagram'),
           },

--- a/src/doc/comp/Toc.tsx
+++ b/src/doc/comp/Toc.tsx
@@ -6,17 +6,37 @@ interface Props {
 
 const versionMark = /<span class="version-mark">.*<\/span>/
 
-export const Toc = ({ data }: Props) => (
-  <ul>
-    {data.map((item, i) =>
-      item.url ? (
-        <li key={item.url}>
-          <a href={item.url}>{item.title.replace(versionMark, '')}</a>
-          {item.items && <Toc data={item.items} />}
-        </li>
-      ) : (
-        <li key={`item${i}`}>{item.items && <Toc data={item.items} />}</li>
+export const Toc = ({ data }: Props) => {
+  // Support {#custom-id}
+  // Now `#origin-id {#custom-id}` will be transformed to `#custom-id`
+  const transformCustomId = (
+    label: string,
+    anchor: string
+  ): { label: string; anchor: string } => {
+    const customIdMatches = label.match(/(.+) *\{(#.+)\}$/)
+    if (customIdMatches?.length) {
+      const [, newLabel, newAnchor] = customIdMatches
+      return { label: newLabel, anchor: newAnchor }
+    }
+    return { label, anchor }
+  }
+
+  const renderTocItem = (item: TableOfContent): JSX.Element => {
+    const { url, title, items } = item
+    if (url) {
+      const { label: newLabel, anchor: newAnchor } = transformCustomId(
+        title,
+        url
       )
-    )}
-  </ul>
-)
+      return (
+        <li key={url}>
+          <a href={newAnchor}>{newLabel.replace(versionMark, '')}</a>
+          {items && <Toc data={items} />}
+        </li>
+      )
+    }
+    return <li key={`item-${title}-${url}`}>{items && <Toc data={items} />}</li>
+  }
+
+  return <ul>{data.map((item, i) => renderTocItem(item))}</ul>
+}

--- a/src/doc/index.tsx
+++ b/src/doc/index.tsx
@@ -27,6 +27,7 @@ import { FrontMatter, PageContext, Repo, RepoNav, TableOfContent } from 'typing'
 import { getStable } from '../../gatsby/utils'
 import { generateUrl } from '../../gatsby/path'
 import { setDocInfo } from 'state'
+import replaceInternalHref from 'lib/replaceInternalHref'
 
 interface Props {
   pageContext: PageContext
@@ -69,6 +70,10 @@ export default function Doc({
   const dispatch = useDispatch()
 
   useEffect(() => {
+    // https://github.com/pingcap/website-docs/issues/221
+    // md title with html tag will cause anchor mismatch
+    replaceInternalHref(pathConfig.locale, pathConfig.repo, pathConfig.version)
+
     dispatch(
       setDocInfo({
         lang: pathConfig.locale,

--- a/src/lib/replaceInternalHref.js
+++ b/src/lib/replaceInternalHref.js
@@ -12,6 +12,7 @@ export default function replaceInternalHref(
   const aTags = document.querySelectorAll(
     `${simpletab ? '.PingCAP-simpleTab' : '.doc-content'} a`
   )
+  const docTocATags = document.querySelectorAll(`.doc-toc a`)
 
   Array.from(aTags).forEach(a => {
     let href = a.getAttribute('href')
@@ -34,6 +35,19 @@ export default function replaceInternalHref(
         .replace(reAnchor, '')
         .replace(sliceVersionMark, '')
     }
+  })
+
+  // Replace anchor str in doc toc
+  Array.from(docTocATags).forEach(a => {
+    let href = a.getAttribute('href')
+    a.href =
+      '#' +
+      decodeURIComponent(href)
+        .replace(reAnchor, '')
+        .replace(sliceVersionMark, '')
+    a.parentElement.id = a.parentElement.id
+      .replace(reAnchor, '')
+      .replace(sliceVersionMark, '')
   })
 
   if (!simpletab && window.location.hash) {


### PR DESCRIPTION
`## origin title {#custom-id}`
will be translated to
`<path>#custom-id` in html

`replaceInternalHref` will transform `#stmt-summary-span-classversion-marknew-in-v304span` to `#stmt-summary-new-in-v304` under page scope.