### PR TITLE
update referrerPolicy

### DIFF
--- a/gatsby/plugin/content/index.ts
+++ b/gatsby/plugin/content/index.ts
@@ -37,7 +37,7 @@ module.exports = function ({
             return [
               {
                 type: 'jsx',
-                value: `<a href="${ele.url}" target="_blank" rel="noreferrer">`,
+                value: `<a href="${ele.url}" target="_blank" referrerPolicy="no-referrer-when-downgrade">`,
               },
               ...node.children,
               { type: 'jsx', value: '</a>' },

--- a/src/layout/comp/Navbar.tsx
+++ b/src/layout/comp/Navbar.tsx
@@ -204,6 +204,7 @@ export function Navbar({ locale }: Props) {
                 <NavbarItem
                   className={main}
                   href={`https://tidbcloud.com/signin`}
+                  referrerPolicy="no-referrer-when-downgrade"
                   target="_blank">
                   Sign In
                 </NavbarItem>
@@ -211,6 +212,8 @@ export function Navbar({ locale }: Props) {
                   <a
                     href="https://tidbcloud.com/signup?_ga=2.92391197.1421016400.1651713063-598142147.1627626898"
                     className={clsx('button', tryTidbCloudBtn)}
+                    // https://developer.chrome.com/blog/referrer-policy-new-chrome-default/
+                    referrerPolicy="no-referrer-when-downgrade"
                     target="_blank">
                     Try TiDB Cloud
                   </a>


### PR DESCRIPTION
 https://developer.chrome.com/blog/referrer-policy-new-chrome-default/

To pass full URL instead of domain in `referer` field.