### PR TITLE
refine filter:tidb-cloud:en

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -64,9 +64,9 @@ jobs:
         id: docs-cache
         with:
           path: markdown-pages
-          key: ${{ runner.os }}-docs-cache-202205-${{ github.event.client_payload.sha }} # You can inc the version number to force cache rebuild
+          key: ${{ runner.os }}-docs-cache-202206-${{ github.event.client_payload.sha }} # You can inc the version number to force cache rebuild
           restore-keys: |
-            ${{ runner.os }}-docs-cache-202205-
+            ${{ runner.os }}-docs-cache-202206-
 
       - name: Check file exists
         id: check-file-exists

--- a/packages/download/index.js
+++ b/packages/download/index.js
@@ -219,4 +219,6 @@ export function filterCloud(argv) {
   const destPath = nPath.resolve(dest, `en/tidbcloud/master`)
   copyFilesFromToc(`${srcPath}/TOC-tidb-cloud.md`, `${destPath}`)
   copyDirectorySync(`${srcPath}/tidb-cloud`, `${destPath}/tidb-cloud/`)
+  fs.existsSync(`${srcPath}/tidb-cloud`) &&
+    fs.rmSync(`${srcPath}/tidb-cloud`, { recursive: true })
 }

--- a/packages/download/utils.js
+++ b/packages/download/utils.js
@@ -217,14 +217,18 @@ export async function retrieveAllMDsFromZip(
 }
 
 export const copySingleFileSync = (srcPath, destPath) => {
-  const dir = path.dirname(destPath)
+  try {
+    const dir = path.dirname(destPath)
 
-  if (!fs.existsSync(dir)) {
-    // console.info(`Create empty dir: ${dir}`);
-    fs.mkdirSync(dir, { recursive: true })
+    if (!fs.existsSync(dir)) {
+      // console.info(`Create empty dir: ${dir}`);
+      fs.mkdirSync(dir, { recursive: true })
+    }
+
+    fs.copyFileSync(srcPath, destPath)
+  } catch (error) {
+    console.log(error)
   }
-
-  fs.copyFileSync(srcPath, destPath)
 }
 
 const getAllFiles = (dirPath, arrayOfFiles) => {
@@ -244,11 +248,15 @@ const getAllFiles = (dirPath, arrayOfFiles) => {
 }
 
 export const copyDirectorySync = (srcPath, destPath) => {
-  const allFiles = getAllFiles(srcPath)
-  allFiles.forEach(filePath => {
-    const relativePath = path.relative(srcPath, filePath)
-    copySingleFileSync(filePath, destPath + relativePath)
-  })
+  try {
+    const allFiles = getAllFiles(srcPath)
+    allFiles.forEach(filePath => {
+      const relativePath = path.relative(srcPath, filePath)
+      copySingleFileSync(filePath, destPath + relativePath)
+    })
+  } catch (error) {
+    console.log(error)
+  }
 }
 
 const generateMdAstFromFile = fileContent => {


### PR DESCRIPTION
Now filter:tidb-cloud:en will remove `tidb-cloud` folder under taget src.

It will fix:
cloud `tidb-cloud/_index.md` will affect tidb index page.