### PR TITLE
support railroad diagram

### DIFF
--- a/gatsby/plugin/syntax-diagram/index.ts
+++ b/gatsby/plugin/syntax-diagram/index.ts
@@ -127,6 +127,10 @@ const railroadParser = pegjs.generate(`
     / c:choice { return c }
     / o:oneormore { return o }
 
+  seq = s:stack { return s }
+    / s:sequence { return s }
+    / ops:opSequence { return ops }
+
   nonTerminal = 'NonTerminal(' _ '"' t:[0-9a-zA-Z_() ]+ '"' _ ')' {
     return {type: 'NonTerminal', text: t.join('')};
   }
@@ -134,10 +138,6 @@ const railroadParser = pegjs.generate(`
   comment = 'Comment(' _ '"' t:[0-9a-zA-Z_() ]+ '"' _ ')' {
     return {type: 'Comment', text: t.join('')};
   }
-
-  seq = s:stack { return s }
-    / s:sequence { return s }
-    / ops:opSequence { return ops }
 
   stack = 'Stack(' _ its: items _ ')' {
     return {type: 'Stack', items: its};
@@ -399,7 +399,6 @@ const parsers: {
           isRTLCapable,
         },
       })
-      console.log('grammar', JSON.stringify(grammar, undefined, 2))
       const diagrams = grammar
         .map((node: any) => {
           const diagram = new rr.Diagram(toRailroad(node)).format(2)

--- a/gatsby/plugin/syntax-diagram/index.ts
+++ b/gatsby/plugin/syntax-diagram/index.ts
@@ -16,7 +16,7 @@ interface RRDiagram {
 }
 
 interface RRLeaf {
-  type: 'Terminal' | 'NonTerminal'
+  type: 'Terminal' | 'NonTerminal' | 'Comment'
   text: string
 }
 
@@ -109,6 +109,56 @@ const ebnfParser = pegjs.generate(`
   nonTerminal = [0-9a-zA-Z_]+ {
     return {type: 'NonTerminal', text: text()};
   }
+  _ = [ \\n\\r\\t]*
+`)
+
+const railroadParser = pegjs.generate(`
+  grammar = 'Diagram('_ its:items _')' {
+    return [{type: 'Sequence', items: its}];
+  }
+
+  items = its:(_ item _',')* {
+    return its.map(i => i[1]);
+  }
+
+  item = n:nonTerminal { return n }
+    / c:comment { return c }
+    / s:seq { return s }
+    / c:choice { return c }
+    / o:oneormore { return o }
+
+  nonTerminal = 'NonTerminal(' _ '"' t:[0-9a-zA-Z_() ]+ '"' _ ')' {
+    return {type: 'NonTerminal', text: t.join('')};
+  }
+
+  comment = 'Comment(' _ '"' t:[0-9a-zA-Z_() ]+ '"' _ ')' {
+    return {type: 'Comment', text: t.join('')};
+  }
+
+  seq = s:stack { return s }
+    / s:sequence { return s }
+    / ops:opSequence { return ops }
+
+  stack = 'Stack(' _ its: items _ ')' {
+    return {type: 'Stack', items: its};
+  }
+
+  sequence = 'Sequence(' _ its: items _ ')' {
+    return {type: 'Sequence', items: its};
+  }
+
+  opSequence = 'OptionalSequence(' _ its: items _ ')' {
+    return {type: 'OptionalSequence', items: its};
+  }
+
+  choice = 'Choice(' _ n: [0-9]+ _ ','_ its: items _ ')' {
+    return {type: 'Choice', normalIndex: n, options: its};
+  }
+
+  oneormore = 'OneOrMore(' _ i: item _ ',' _ r: item _ ',' _ ')' {
+    return {type: 'OneOrMore', item: i, repeat: r};
+  }
+
   _ = [ \\n\\r\\t]*
 `)
 
@@ -291,6 +341,8 @@ function toRailroad(node: RRComponent): void {
         Math.round(anafanafo(node.text) * NON_TERMINAL_WIDTH_FACTOR) + 20
       return nt
     }
+    case 'Comment':
+      return new rr.Comment(node.text)
     case 'Optional':
       return new rr.Optional(toRailroad(node.item))
     case 'OneOrMore':
@@ -306,6 +358,65 @@ function toRailroad(node: RRComponent): void {
   }
 }
 
+const parsers: {
+  [key: string]: {
+    lang: String,
+    inner: (node: any) => any,
+  }
+} = {
+  'ebnf+diagram': {
+    lang: 'ebnf',
+    inner: (node: any) => {
+      const grammar = ebnfParser.parse(node.value, {
+        context: {
+          appendNodeToChoices,
+          appendNodeToSequence,
+          isRTLCapable,
+        },
+      })
+      const diagrams = grammar
+        .map(({ name, content }: any) => {
+          const diagram = new rr.Diagram(toRailroad(content)).format(2)
+          return `<dt>${name}</dt><dd>${diagram}</dd>`
+        })
+        .join('')
+
+      return [
+        { type: 'jsx', value: '<SyntaxDiagram>' },
+        { type: 'html', value: `<dl>${diagrams}</dl>` },
+        node,
+        { type: 'jsx', value: '</SyntaxDiagram>' },
+      ]
+    }
+  },
+  'railroad+diagram' : {
+    lang: 'railroad',
+    inner: (node: any) => {
+      const grammar = railroadParser.parse(node.value, {
+        context: {
+          appendNodeToChoices,
+          appendNodeToSequence,
+          isRTLCapable,
+        },
+      })
+      console.log('grammar', JSON.stringify(grammar, undefined, 2))
+      const diagrams = grammar
+        .map((node: any) => {
+          const diagram = new rr.Diagram(toRailroad(node)).format(2)
+          return `<dd>${diagram}</dd>`
+        })
+        .join('')
+
+      return [
+        { type: 'jsx', value: '<SyntaxDiagram>' },
+        { type: 'html', value: `<dl>${diagrams}</dl>` },
+        node,
+        { type: 'jsx', value: '</SyntaxDiagram>' },
+      ]
+    }
+  }
+}
+
 module.exports = ({
   markdownAST,
   markdownNode,
@@ -316,31 +427,13 @@ module.exports = ({
   visit(markdownAST, (node: any) => {
     if (Array.isArray(node.children)) {
       node.children = node.children.flatMap((node: any) => {
-        if (node.type === 'code' && node.lang === 'ebnf+diagram') {
-          node.lang = 'ebnf'
+        const parser = parsers[node.lang]
+        if (node.type === 'code' && parser) {
+          node.lang = parser.lang
           try {
-            const grammar = ebnfParser.parse(node.value, {
-              context: {
-                appendNodeToChoices,
-                appendNodeToSequence,
-                isRTLCapable,
-              },
-            })
-            const diagrams = grammar
-              .map(({ name, content }: any) => {
-                const diagram = new rr.Diagram(toRailroad(content)).format(2)
-                return `<dt>${name}</dt><dd>${diagram}</dd>`
-              })
-              .join('')
-
-            return [
-              { type: 'jsx', value: '<SyntaxDiagram>' },
-              { type: 'html', value: `<dl>${diagrams}</dl>` },
-              node,
-              { type: 'jsx', value: '</SyntaxDiagram>' },
-            ]
+            return parser.inner(node)
           } catch (e) {
-            console.error('invalid EBNF', markdownNode.fileAbsolutePath)
+            console.error(`invalid ${parser.lang}`, e, markdownNode.fileAbsolutePath)
           }
         }
         return node

--- a/gatsby/plugin/syntax-diagram/index.ts
+++ b/gatsby/plugin/syntax-diagram/index.ts
@@ -126,6 +126,7 @@ const railroadParser = pegjs.generate(`
     / s:seq { return s }
     / c:choice { return c }
     / o:oneormore { return o }
+    / o:opt { return o }
 
   seq = s:stack { return s }
     / s:sequence { return s }
@@ -157,6 +158,10 @@ const railroadParser = pegjs.generate(`
 
   oneormore = 'OneOrMore(' _ i: item _ ',' _ r: item _ ',' _ ')' {
     return {type: 'OneOrMore', item: i, repeat: r};
+  }
+
+  opt = 'Optional(' _ '"' t:[^"]* '"' _ ')' {
+    return {type: 'Optional', item: {type: 'NonTerminal', text: t.join('')}};
   }
 
   _ = [ \\n\\r\\t]*

--- a/gatsby/plugin/syntax-diagram/index.ts
+++ b/gatsby/plugin/syntax-diagram/index.ts
@@ -131,11 +131,11 @@ const railroadParser = pegjs.generate(`
     / s:sequence { return s }
     / ops:opSequence { return ops }
 
-  nonTerminal = 'NonTerminal(' _ '"' t:[0-9a-zA-Z_() ]+ '"' _ ')' {
+  nonTerminal = 'NonTerminal(' _ '"' t:[^"]* '"' _ ')' {
     return {type: 'NonTerminal', text: t.join('')};
   }
 
-  comment = 'Comment(' _ '"' t:[0-9a-zA-Z_() ]+ '"' _ ')' {
+  comment = 'Comment(' _ '"' t:[^"]* '"' _ ')' {
     return {type: 'Comment', text: t.join('')};
   }
 


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

Now we transfer enbf into railroad in our doc, this PR support railroad diagram directly. Doc writes can choose either enbf or railroad now.

Source and diagram example:

![image](https://user-images.githubusercontent.com/9587680/182855433-1ed61703-3f75-48e8-bce4-b8c21ed1d159.png)

![image](https://user-images.githubusercontent.com/9587680/182855511-62a97e4e-d2f6-4469-8616-ce8bd337a85e.png)
