### PR TITLE
change the Archived Docs url in version-select dropdowns for kubernetes and dm docs

### DIFF
--- a/src/components/Dropdown/VersionSelect.tsx
+++ b/src/components/Dropdown/VersionSelect.tsx
@@ -220,7 +220,7 @@ const VersionItems = (props: {
       ))}
       <LinkComponent
         isI18n
-        to={generateArchivedWebsiteUrlByLang(language)}
+        to={generateArchivedWebsiteUrlByLangAndType(language, pathConfig.repo)}
         style={{
           width: "100%",
           color: "#666666",
@@ -420,7 +420,7 @@ export function NativeVersionSelect(props: VersionSelectProps) {
 
   const handleChange = (event: { target: { value: string } }) => {
     if (event.target.value === "archive") {
-      gatsbyNavigate(generateArchivedWebsiteUrlByLang(language));
+      gatsbyNavigate(generateArchivedWebsiteUrlByLangAndType(language, pathConfig.repo));
       return;
     }
     // setSelectedVersion(event.target.value);
@@ -456,13 +456,29 @@ export function NativeVersionSelect(props: VersionSelectProps) {
   );
 }
 
-function generateArchivedWebsiteUrlByLang(lang?: string) {
+function generateArchivedWebsiteUrlByLangAndType(lang?: string, type?: string) {
+  let url = ARCHIVE_WEBSITE_URL;
+
   switch (lang) {
     case "zh":
-      return `${ARCHIVE_WEBSITE_URL}/zh`;
+      url = `${ARCHIVE_WEBSITE_URL}/zh`;
+      break;
     case "jp":
-      return `${ARCHIVE_WEBSITE_URL}/jp`;
+      url = `${ARCHIVE_WEBSITE_URL}/jp`;
+      break;
     default:
-      return ARCHIVE_WEBSITE_URL;
+      break;
   }
+  switch (type) {
+    case "tidb-in-kubernetes":
+      url = `${url}/tidb-in-kubernetes/v1.0`;
+      break;
+    case "tidb-data-migration":
+      url = `${url}/tidb-data-migration/v1.0`;
+      break;
+    default:
+      break;
+  }
+
+  return url;
 }


### PR DESCRIPTION
Currently, it's difficult for users to find where are the archived docs of _TiDB in Kubernetes_ or _TiDB data migration_. This is because, when they click on the **Archived Docs** label in the version-select dropdown, they are taken to the archived docs of *TiDB*, rather than Kubernetes/DM.

This PR tries to improve user experience on this issue. If the doc type is tidb-in-kubernetes or dm, the archived URL should be the earliest archived version of the respective docs: v1.0 for TiDB in Kuberenetes and v1.0 for TiDB Data Migration.

<img width="1177" alt="image" src="https://github.com/pingcap/website-docs/assets/59654584/bb5edb11-c25e-4e96-b0f7-77474425d40d">
