### PR TITLE
show dmr label for version select in archived docs

### DIFF
--- a/src/components/Dropdown/VersionSelect.tsx
+++ b/src/components/Dropdown/VersionSelect.tsx
@@ -21,12 +21,14 @@ import CONFIG from "../../../docs/docs.json";
 import LinkComponent from "components/Link";
 import { Typography } from "@mui/material";
 
-function renderVersion(version: string | null, pathConfig: PathConfig) {
+function renderVersion(version: string | null, pathConfig: PathConfig, isArchive: boolean = false) {
   const { docs } = CONFIG;
   const isDmr =
     (docs[pathConfig.repo] as { dmr: string[] }).dmr?.includes(version || "") ??
     false;
-  if (isDmr) return `${version}`;
+  if (isDmr) {
+    return isArchive ? `${version} (DMR)` : version;
+  }
   if (version !== "stable") return version;
   return (docs[pathConfig.repo] as { stable: string }).stable.replace(
     "release-",
@@ -288,7 +290,7 @@ const VersionItemsArchived = (props: {
                 lineHeight: "1.25rem",
               }}
             >
-              {renderVersion(version, pathConfig)}
+              {renderVersion(version, pathConfig, true)}
             </Typography>
           </LinkComponent>
         </MenuItem>


### PR DESCRIPTION
Show a `(DMR)` label for DMR versions like this: (only applicable to archived docs)

![6950db4f-d6c6-437a-a5b5-c7533a5f449e](https://github.com/pingcap/website-docs/assets/59654584/f0ace22a-bcc2-4110-b500-d9f6f3589abe)
