### PR TITLE
show dmr label in version select btn

### DIFF
--- a/src/components/Dropdown/VersionSelect.tsx
+++ b/src/components/Dropdown/VersionSelect.tsx
@@ -350,7 +350,11 @@ export default function VersionSelect(props: VersionSelectProps) {
             lineHeight: "1.25rem",
           }}
         >
-          {renderVersion(pathConfig.version, pathConfig)}
+          {
+            buildType === "archive"
+              ? renderVersion(pathConfig.version, pathConfig, true)
+              : renderVersion(pathConfig.version, pathConfig)
+          }
         </Typography>
       </Button>
       <StyledMenu


### PR DESCRIPTION
Show DMR label in version select btn for [**archived docs site**](https://docs-archive.pingcap.com/tidb/v6.6/) only.


- Before: 
<img width="339" alt="image" src="https://github.com/pingcap/website-docs/assets/59654584/fa316719-edb5-4504-8257-a174d7b6478a">


- After:
<img width="340" alt="image" src="https://github.com/pingcap/website-docs/assets/59654584/9320e673-7646-45d2-8c2a-a45daed394e0">

