### PR TITLE
fix: code high light

### DIFF
--- a/src/components/MDXComponents/Pre.tsx
+++ b/src/components/MDXComponents/Pre.tsx
@@ -46,15 +46,10 @@ export const CodeBlock: React.FC<MdxCodeChildrenProps> = ({
     language = "sh";
   }
   const hlResult = useMemo<HighlightResult>(() => {
-    if (!hljs.getLanguage(language)) {
-      return {
-        language,
-        value: children,
-      } as HighlightResult;
-    }
-    return language
-      ? hljs.highlight(children, { language, ignoreIllegals: true })
-      : hljs.highlightAuto(children);
+    return hljs.highlight(children, {
+      language: hljs.getLanguage(language) ? language : "plaintext",
+      ignoreIllegals: true,
+    });
   }, [children, language]);
   const [isWrapped, setIsWrapped] = useState(false);
   const CodeWrapButton = () => {


### PR DESCRIPTION
use `plaintext` when there's no language tag in the markdown


<img width="880" alt="image" src="https://github.com/pingcap/website-docs/assets/11549583/e08c5cc5-a628-4386-8280-717890a06169">
