### PR TITLE
chore(gatsby, nav): update gtm configs and nav links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,7 +29,6 @@ module.exports = {
       options: {
         id: "GTM-TPX49SBK",
         includeInDevelopment: false,
-        routeChangeEventName: "page_view",
       },
     },
     `gatsby-plugin-root-import`,

--- a/src/components/Layout/HeaderNav.tsx
+++ b/src/components/Layout/HeaderNav.tsx
@@ -84,7 +84,7 @@ export default function HeaderNavStack(props: { buildType?: BuildType }) {
       {["en", "ja"].includes(language) && (
         <NavItem
           label={t("navbar.playground")}
-          to={`https://play.tidbcloud.com?utm_source=docs&utm_medium=menu`}
+          to={`https://play.tidbcloud.com`}
           // startIcon={<CodeIcon fontSize="inherit" color="inherit" />}
           onClick={() =>
             gtmTrack(GTMEvent.GotoPlayground, {
@@ -303,7 +303,7 @@ export function HeaderNavStackMobile(props: { buildType?: BuildType }) {
         {["en", "ja"].includes(language) && (
           <MenuItem onClick={handleClose} disableRipple>
             <LinkComponent
-              to={`https://play.tidbcloud.com?utm_source=docs&utm_medium=menu`}
+              to={`https://play.tidbcloud.com`}
               style={{ width: "100%" }}
               onClick={() => {
                 gtmTrack(GTMEvent.ClickHeadNav, {

--- a/src/components/Navigation/RightNav.tsx
+++ b/src/components/Navigation/RightNav.tsx
@@ -150,14 +150,6 @@ export default function RightNav(props: RightNavProps) {
             >
               <TerminalIcon />
               <Trans i18nKey="navbar.playground" />
-              <Chip
-                label={t("doc.new")}
-                size="small"
-                sx={{
-                  color: "#FC5B00",
-                  backgroundColor: "rgba(252, 91, 0, 0.1)",
-                }}
-              />
             </Typography>
             <Typography
               component="a"

--- a/src/components/Navigation/RightNav.tsx
+++ b/src/components/Navigation/RightNav.tsx
@@ -161,7 +161,7 @@ export default function RightNav(props: RightNavProps) {
             </Typography>
             <Typography
               component="a"
-              href={`https://play.tidbcloud.com/?utm_source=docs&utm_medium=right_sidebar`}
+              href={`https://play.tidbcloud.com`}
               target="_blank"
               sx={{
                 display: "flex",


### PR DESCRIPTION
This PR mainly does the following:

- Remove custom route change event name for gtm
- Remove unnecessary url search params for the playground link