### PR TITLE
fix: footnotes list style

### DIFF
--- a/src/styles/docTemplate.css
+++ b/src/styles/docTemplate.css
@@ -98,5 +98,9 @@
     pre {
       margin-top: 1rem;
     }
+
+    .footnotes ol {
+      list-style-type: disc;
+    }
   }
 }


### PR DESCRIPTION
Avoid incorrect order of the footnotes list.
We need to use the latest mdx version and render plugin to fix this order problem which requires much more effort. So I prefer we update the unordered list style meanwhile we can get the correct reference as always.

![image](https://github.com/user-attachments/assets/3766715f-bf01-4396-a5f6-6a1e7bd6bce7)
