### PR TITLE
fix: search redirects to the latest version when on stable version

### DIFF
--- a/src/templates/DocSearchTemplate.tsx
+++ b/src/templates/DocSearchTemplate.tsx
@@ -39,7 +39,7 @@ import {
 import { Locale } from "static/Type";
 import { FeedbackSurveyCampaign } from "components/Campaign/FeedbackSurvey";
 
-// TiDB: get latest two LTS versions + latest DMR version
+// TiDB: get searchable versions from fetchTidbSearchIndcies
 // TiDB Cloud: only has one version
 // TiDB Operator: get stable version
 // TiDB Data Migration: get latest version
@@ -101,10 +101,6 @@ const convertStableToRealVersion = (
   return realVersion;
 };
 
-// TiDB: get latest two LTS versions + latest DMR version
-// TiDB Cloud: only has one version
-// TiDB Operator: get stable version
-// TiDB Data Migration: get latest version
 const getSearchIndexVersion = (
   docType: string,
   docVersion: string,
@@ -113,10 +109,11 @@ const getSearchIndexVersion = (
   switch (docType) {
     case "tidb":
       const versions = fetchVersionListByDocType(docType, lang);
-      const realVersion =
+      let realVersion =
         docVersion === "stable" ? replaceStableVersion(docType) : docVersion;
+      realVersion = realVersion?.replace("release-", "v");
       if (versions.includes(realVersion || "")) {
-        return realVersion?.replace("release-", "v");
+        return realVersion;
       }
 
       const latestVersion = versions[0];


### PR DESCRIPTION
The previous code fails when `versions = ['v8.3', 'v8.1']` and `realVersion = 'release-8.1'`.

