### PR TITLE
fix(layout/header): fix home link for mobile

### DIFF
--- a/src/components/Layout/HeaderNav.tsx
+++ b/src/components/Layout/HeaderNav.tsx
@@ -214,7 +214,7 @@ export function HeaderNavStackMobile(props: { buildType?: BuildType }) {
           >
             <LinkComponent
               isI18n
-              to={generateDocsHomeUrl(language)}
+              to="/"
               style={{ width: "100%" }}
               onClick={() =>
                 gtmTrack(GTMEvent.ClickHeadNav, {


### PR DESCRIPTION
This PR fixes the link of the home nav on the header for mobile.