### PR TITLE
Update the community wording in translation.json

### DIFF
--- a/locale/en/translation.json
+++ b/locale/en/translation.json
@@ -44,7 +44,7 @@
     "download-pdf": "Download PDF",
     "improve": "Edit this page",
     "feedback": "Request docs changes",
-    "feedbackAskTug": "Ask questions on Discord",
+    "feedbackAskTug": "Ask the community",
     "latestCommit": "was last updated",
     "deprecation": {
       "tidb": {


### PR DESCRIPTION
This PR updates the community wording in translation.json, as requested by community operations:

Ask questions on Discord > Ask **the community**

<img width="815" alt="image" src="https://github.com/user-attachments/assets/f9948ffd-8bbc-467f-adf9-dbefe587a1cc">

