### PR TITLE
fix: learning path items gap

### DIFF
--- a/src/components/MDXComponents/LearningPath.tsx
+++ b/src/components/MDXComponents/LearningPath.tsx
@@ -288,9 +288,10 @@ export function LearningPath(props: {
             flexWrap: "wrap",
             justifyContent: "flex-start",
             rowGap: "1rem",
+            columnGap: "8px",
 
             "& > p": {
-              flex: { xs: "50% 1", md: "0 0 33%" },
+              flex: { xs: "50% 1", md: "0 0 32%" },
             },
           }}
         >


### PR DESCRIPTION
Add column gap to learning path

![image](https://github.com/user-attachments/assets/a703464d-98e7-407b-a7ec-3cc414af8c14)
