### PR TITLE
static: add zh/llms.txt for zh docs

### DIFF
--- a/static/zh/llms.txt
+++ b/static/zh/llms.txt
@@ -1,1305 +1,1305 @@
 # TiDB 文档中心
 
-- [TiDB 文档中心](https://docs.pingcap.com/zh.md): 欢迎来到 TiDB 文档中心！我们为您提供了丰富的操作指南和详实的参考资料，助您轻松上手 TiDB 产品，顺利完成数据迁移和基于数据库的应用开发等操作。
+- [TiDB 文档中心](https://docs.pingcap.com/zh/): 欢迎来到 TiDB 文档中心！我们为您提供了丰富的操作指南和详实的参考资料，助您轻松上手 TiDB 产品，顺利完成数据迁移和基于数据库的应用开发等操作。
 
 ## TiDB Self-Managed 文档（使用 TiUP 部署）
 
-- [TiDB 版本周期支持策略](https://cn.pingcap.com/tidb-release-support-policy.md): 阐述了 PingCAP 就 TiDB 版本提供支持服务的标准和规则。
-- [50 TiB 数据导入最佳实践](https://docs.pingcap.com/tidb/stable/data-import-best-practices.md): 了解将大规模数据导入 TiDB 的最佳实践。
-- [ADD COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-add-column.md): TiDB 数据库中 ADD COLUMN 的使用概况。
-- [ADD INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-add-index.md): TiDB 数据库中 ADD INDEX 的使用概况。
-- [ADMIN](https://docs.pingcap.com/tidb/stable/sql-statement-admin.md): TiDB的 `ADMIN` 语句是用于查看TiDB状态和对表数据进行校验的扩展语法。其中包括 `ADMIN RELOAD`、`ADMIN PLUGIN`、`ADMIN ... BINDINGS`、`ADMIN REPAIR TABLE` 和 `ADMIN SHOW NEXT_ROW_ID` 等扩展语句。这些语句可以用于重新加载表达式下推的黑名单、启用或禁用插件、持久化 SQL Plan 绑定信息、修复表的元信息以及查看表中特殊列的详情。这些功能对于管理和维护 TiDB 数据库非常有用。
-- [ADMIN [SET|SHOW|UNSET] BDR ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-admin-bdr-role.md): TiDB 数据库中 ADMIN [SET|SHOW|UNSET] BDR ROLE 的使用概况。
-- [ADMIN ALTER DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-alter-ddl.md): TiDB 数据库中 `ADMIN ALTER DDL JOBS` 的使用概况。
-- [ADMIN CANCEL DDL](https://docs.pingcap.com/tidb/stable/sql-statement-admin-cancel-ddl.md): TiDB 数据库中 ADMIN CANCEL DDL 的使用概况。
-- [ADMIN CHECK [TABLE|INDEX]](https://docs.pingcap.com/tidb/stable/sql-statement-admin-check-table-index.md): TiDB 数据库中 ADMIN CHECK [TABLE|INDEX] 的使用概况。
-- [ADMIN CHECKSUM TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-admin-checksum-table.md): TiDB 数据库中 ADMIN CHECKSUM TABLE 的使用概况。
-- [ADMIN CLEANUP INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-admin-cleanup.md): TiDB 数据库中 ADMIN CLEANUP 的使用概况。
-- [ADMIN PAUSE DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-pause-ddl.md): TiDB 数据库中 ADMIN PAUSE DDL JOBS 的使用概况。
-- [ADMIN RECOVER INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-admin-recover.md): TiDB 数据库中 ADMIN RECOVER INDEX 的使用概况。
-- [ADMIN RESUME DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-resume-ddl.md): TiDB 数据库中 ADMIN RESUME DDL 的使用概况。
-- [ADMIN SHOW DDL [JOBS|JOB QUERIES]](https://docs.pingcap.com/tidb/stable/sql-statement-admin-show-ddl.md): TiDB 数据库中 ADMIN SHOW DDL [JOBS|JOB QUERIES] 的使用概况。
-- [ALTER DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-database.md): TiDB 数据库中 ALTER DATABASE 的使用概况。
-- [ALTER INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-alter-index.md): TiDB 数据库中 ALTER INDEX 的使用概况。
-- [ALTER INSTANCE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-instance.md): TiDB 数据库中 ALTER INSTANCE 的使用概况。
-- [ALTER PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-alter-placement-policy.md): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
-- [ALTER RANGE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-range.md): TiDB 数据库中 ALTER RANGE 的使用概况。
-- [ALTER RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-alter-resource-group.md): TiDB 数据库中 ALTER RESOURCE GROUP 的使用概况。
-- [ALTER SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-sequence.md): 介绍 ALTER SEQUENCE 在 TiDB 中的使用概况。
-- [ALTER TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-table.md): TiDB 数据库中 ALTER TABLE 的使用概况。
-- [ALTER TABLE ... COMPACT](https://docs.pingcap.com/tidb/stable/sql-statement-alter-table-compact.md): TiDB 数据库中 ALTER TABLE ... COMPACT 语句的使用概况。
-- [ALTER USER](https://docs.pingcap.com/tidb/stable/sql-statement-alter-user.md): TiDB 数据库中 ALTER USER 的使用概况。
-- [ANALYZE](https://docs.pingcap.com/tidb/stable/sql-statement-analyze-table.md): TiDB 数据库中 ANALYZE 的使用概况。
-- [ANALYZE_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-analyze-status.md): 了解 information_schema 表 `ANALYZE_STATUS`。
-- [AUTO_INCREMENT](https://docs.pingcap.com/tidb/stable/auto-increment.md): 介绍 TiDB 的 `AUTO_INCREMENT` 列属性。
-- [AUTO_RANDOM](https://docs.pingcap.com/tidb/stable/auto-random.md): 本文介绍了 TiDB 的 `AUTO_RANDOM` 列属性。
-- [BACKUP](https://docs.pingcap.com/tidb/stable/sql-statement-backup.md): TiDB 数据库中 BACKUP 的使用概况。
-- [BATCH](https://docs.pingcap.com/tidb/stable/sql-statement-batch.md): TiDB 数据库中 BATCH 的使用概况。
-- [BEGIN](https://docs.pingcap.com/tidb/stable/sql-statement-begin.md): TiDB 数据库中 BEGIN 的使用概况。
-- [Bookshop 应用](https://docs.pingcap.com/tidb/stable/dev-guide-bookshop-schema-design.md): Bookshop 应用设计、数据导入、连接数据库等操作。
-- [br 命令行手册](https://docs.pingcap.com/tidb/stable/use-br-command-line-tool.md): 了解 br 命令行的定义、组成与使用。
-- [CALIBRATE RESOURCE](https://docs.pingcap.com/tidb/stable/sql-statement-calibrate-resource.md): TiDB 数据库中 CALIBRATE RESOURCE 的使用概况。
-- [CANCEL IMPORT](https://docs.pingcap.com/tidb/stable/sql-statement-cancel-import-job.md): TiDB 数据库中 CANCEL IMPORT 的使用概况。
-- [Cast 函数和操作符](https://docs.pingcap.com/tidb/stable/cast-functions-and-operators.md): Cast 函数和操作符用于将某种数据类型的值转换为另一种数据类型。TiDB 支持使用 MySQL 8.0 中提供的所有 Cast 函数和操作符。
-- [CHANGE COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-change-column.md): TiDB 数据库中 CHANGE COLUMN 的使用概况。
-- [Changefeed DDL 同步](https://docs.pingcap.com/tidb/stable/ticdc-ddl.md): 了解 TiCDC 支持同步的 DDL 和一些特殊情况
-- [Changefeed 日志过滤器](https://docs.pingcap.com/tidb/stable/ticdc-filter.md): 了解 TiCDC 的表过滤器和事件过滤器使用方法。
-- [Changefeed 概述](https://docs.pingcap.com/tidb/stable/ticdc-changefeed-overview.md): 了解 Changefeed 的基本概念和 Changefeed 状态的定义与流转
-- [CHARACTER_SETS](https://docs.pingcap.com/tidb/stable/information-schema-character-sets.md): 了解 INFORMATION_SCHEMA 表 `CHARACTER_SETS`。
-- [CHECK_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-check-constraints.md): 了解 INFORMATION_SCHEMA 表 `CHECK_CONSTRAINTS`。
-- [CLIENT_ERRORS_SUMMARY_BY_HOST](https://docs.pingcap.com/tidb/stable/client-errors-summary-by-host.md): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_HOST`。
-- [CLIENT_ERRORS_SUMMARY_BY_USER](https://docs.pingcap.com/tidb/stable/client-errors-summary-by-user.md): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_USER`。
-- [CLIENT_ERRORS_SUMMARY_GLOBAL](https://docs.pingcap.com/tidb/stable/client-errors-summary-global.md): 了解 information_schema 表 `CLIENT_ERRORS_SUMMARY_GLOBAL`。
-- [CLUSTER_CONFIG](https://docs.pingcap.com/tidb/stable/information-schema-cluster-config.md): 了解 information_schema 表 `CLUSTER_CONFIG`。
-- [CLUSTER_HARDWARE](https://docs.pingcap.com/tidb/stable/information-schema-cluster-hardware.md): 了解 TiDB 集群硬件表 `CLUSTER_HARDWARE`。
-- [CLUSTER_INFO](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info.md): 了解 TiDB 集群拓扑表 `CLUSTER_INFO`。
-- [CLUSTER_LOAD](https://docs.pingcap.com/tidb/stable/information-schema-cluster-load.md): 了解 information_schema 表 `CLUSTER_LOAD`。
-- [CLUSTER_LOG](https://docs.pingcap.com/tidb/stable/information-schema-cluster-log.md): 了解 information_schema 表 `CLUSTER_LOG`。
-- [CLUSTER_SYSTEMINFO](https://docs.pingcap.com/tidb/stable/information-schema-cluster-systeminfo.md): 了解 TiDB 集群负载表 `CLUSTER_SYSTEMINFO`。
-- [COLLATION_CHARACTER_SET_APPLICABILITY](https://docs.pingcap.com/tidb/stable/information-schema-collation-character-set-applicability.md): 了解 INFORMATION_SCHEMA 表 `COLLATION_CHARACTER_SET_APPLICABILITY`。
-- [COLLATIONS](https://docs.pingcap.com/tidb/stable/information-schema-collations.md): 了解 information_schema 表 `COLLATIONS`。
-- [COLUMNS](https://docs.pingcap.com/tidb/stable/information-schema-columns.md): 了解 INFORMATION_SCHEMA 表 `COLUMNS`。
-- [COMMIT](https://docs.pingcap.com/tidb/stable/sql-statement-commit.md): TiDB 数据库中 COMMIT 的使用概况。
-- [CREATE [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/tidb/stable/sql-statement-create-binding.md): TiDB 数据库中 CREATE [GLOBAL|SESSION] BINDING 的使用概况。
-- [CREATE DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-create-database.md): TiDB 数据库中 CREATE DATABASE 的使用概况。
-- [CREATE INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-create-index.md): CREATE INDEX 在 TiDB 中的使用概况
-- [CREATE PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-create-placement-policy.md): TiDB 数据库中 CREATE PLACEMENT POLICY 的使用概况。
-- [CREATE RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group.md): TiDB 数据库中 CREATE RESOURCE GROUP 的使用概况。
-- [CREATE ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-create-role.md): TiDB 数据库中 CREATE ROLE 的使用概况。
-- [CREATE SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-create-sequence.md): CREATE SEQUENCE 在 TiDB 中的使用概况
-- [CREATE TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-create-table.md): TiDB 数据库中 CREATE TABLE 的使用概况
-- [CREATE TABLE LIKE](https://docs.pingcap.com/tidb/stable/sql-statement-create-table-like.md): TiDB 数据库中 CREATE TABLE LIKE 的使用概况。
-- [CREATE USER](https://docs.pingcap.com/tidb/stable/sql-statement-create-user.md): TiDB 数据库中 CREATE USER 的使用概况。
-- [CREATE VIEW](https://docs.pingcap.com/tidb/stable/sql-statement-create-view.md): TiDB 数据库中 CREATE VIEW 的使用概况。
-- [Data Migration DDL 特殊处理说明](https://docs.pingcap.com/tidb/stable/dm-ddl-compatible.md): 数据迁移中，根据不同的 DDL 语句和场景，采用不同处理方式。DM 不支持的 DDL 语句会直接跳过。部分 DDL 语句在同步到下游前会进行改写。在合库合表迁移任务中，DDL 同步行为存在变更。Online DDL 特性也会对 DDL 事件进行特殊处理。
-- [Data Migration 中的 DML 同步机制](https://docs.pingcap.com/tidb/stable/dm-dml-replication-logic.md): 了解 DM 核心处理单元 Sync 如何同步 DML 语句。
-- [Data Migration 常见问题](https://docs.pingcap.com/tidb/stable/dm-faq.md): 数据迁移常见问题包括：DM 是否支持迁移阿里 RDS 和其他云数据库的数据、task 配置中的黑白名单的正则表达式是否支持非获取匹配、处理不兼容的 DDL 语句、重置数据迁移任务、全量导入过程中遇到报错等。
-- [Data Migration 架构](https://docs.pingcap.com/tidb/stable/dm-arch.md): Data Migration 架构包括三个组件：DM-master，DM-worker 和 dmctl。DM-master 负责管理和调度数据迁移任务的各项操作。DM-worker 执行具体的数据迁移任务。dmctl 是用来控制 DM 集群的命令行工具。 DM 集群的拓扑信息、数据迁移任务的运行状态和管理统一入口都由 DM-master 负责。DM-worker 负责持久化保存 binlog 数据、保存数据迁移子任务的配置信息和监控数据迁移子任务的运行状态。dmctl 用来创建、更新或删除数据迁移任务、查看数据迁移任务状态、处理数据迁移任务错误和校验数据迁移任务配置的正确性。 Data Migration 高可用机制可以进一步探索。
-- [Data Migration 高可用机制](https://docs.pingcap.com/tidb/stable/dm-high-availability.md): 了解 Data Migration (DM) 高可用的内部机制，以及对迁移任务的影响。
-- [DATA_LOCK_WAITS](https://docs.pingcap.com/tidb/stable/information-schema-data-lock-waits.md): 了解 information_schema 表 `DATA_LOCK_WAITS`。
-- [DDL 语句的执行原理及最佳实践](https://docs.pingcap.com/tidb/stable/ddl-introduction.md): 介绍 TiDB 中 DDL 语句的实现原理、在线变更过程、最佳实践等内容。
-- [DDL_JOBS](https://docs.pingcap.com/tidb/stable/information-schema-ddl-jobs.md): 了解 information_schema 表 `DDL_JOBS`。
-- [DEADLOCKS](https://docs.pingcap.com/tidb/stable/information-schema-deadlocks.md): 了解 INFORMATION_SCHEMA 表 `DEADLOCKS`。
-- [DEALLOCATE](https://docs.pingcap.com/tidb/stable/sql-statement-deallocate.md): TiDB 数据库中 DEALLOCATE 的使用概况。
-- [DELETE](https://docs.pingcap.com/tidb/stable/sql-statement-delete.md): TiDB 数据库中 DELETE 的使用概况。
+- [TiDB 版本周期支持策略](https://cn.pingcap.com/tidb-release-support-policy/): 阐述了 PingCAP 就 TiDB 版本提供支持服务的标准和规则。
+- [50 TiB 数据导入最佳实践](https://docs.pingcap.com/zh/tidb/stable/data-import-best-practices.md): 了解将大规模数据导入 TiDB 的最佳实践。
+- [ADD COLUMN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-add-column.md): TiDB 数据库中 ADD COLUMN 的使用概况。
+- [ADD INDEX](https://docs.pingcap.com/zh/tidb/stable/sql-statement-add-index.md): TiDB 数据库中 ADD INDEX 的使用概况。
+- [ADMIN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin.md): TiDB的 `ADMIN` 语句是用于查看TiDB状态和对表数据进行校验的扩展语法。其中包括 `ADMIN RELOAD`、`ADMIN PLUGIN`、`ADMIN ... BINDINGS`、`ADMIN REPAIR TABLE` 和 `ADMIN SHOW NEXT_ROW_ID` 等扩展语句。这些语句可以用于重新加载表达式下推的黑名单、启用或禁用插件、持久化 SQL Plan 绑定信息、修复表的元信息以及查看表中特殊列的详情。这些功能对于管理和维护 TiDB 数据库非常有用。
+- [ADMIN [SET|SHOW|UNSET] BDR ROLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-bdr-role.md): TiDB 数据库中 ADMIN [SET|SHOW|UNSET] BDR ROLE 的使用概况。
+- [ADMIN ALTER DDL JOBS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-alter-ddl.md): TiDB 数据库中 `ADMIN ALTER DDL JOBS` 的使用概况。
+- [ADMIN CANCEL DDL](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-cancel-ddl.md): TiDB 数据库中 ADMIN CANCEL DDL 的使用概况。
+- [ADMIN CHECK [TABLE|INDEX]](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-check-table-index.md): TiDB 数据库中 ADMIN CHECK [TABLE|INDEX] 的使用概况。
+- [ADMIN CHECKSUM TABLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-checksum-table.md): TiDB 数据库中 ADMIN CHECKSUM TABLE 的使用概况。
+- [ADMIN CLEANUP INDEX](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-cleanup.md): TiDB 数据库中 ADMIN CLEANUP 的使用概况。
+- [ADMIN PAUSE DDL JOBS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-pause-ddl.md): TiDB 数据库中 ADMIN PAUSE DDL JOBS 的使用概况。
+- [ADMIN RECOVER INDEX](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-recover.md): TiDB 数据库中 ADMIN RECOVER INDEX 的使用概况。
+- [ADMIN RESUME DDL JOBS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-resume-ddl.md): TiDB 数据库中 ADMIN RESUME DDL 的使用概况。
+- [ADMIN SHOW DDL [JOBS|JOB QUERIES]](https://docs.pingcap.com/zh/tidb/stable/sql-statement-admin-show-ddl.md): TiDB 数据库中 ADMIN SHOW DDL [JOBS|JOB QUERIES] 的使用概况。
+- [ALTER DATABASE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-database.md): TiDB 数据库中 ALTER DATABASE 的使用概况。
+- [ALTER INDEX](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-index.md): TiDB 数据库中 ALTER INDEX 的使用概况。
+- [ALTER INSTANCE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-instance.md): TiDB 数据库中 ALTER INSTANCE 的使用概况。
+- [ALTER PLACEMENT POLICY](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-placement-policy.md): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
+- [ALTER RANGE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-range.md): TiDB 数据库中 ALTER RANGE 的使用概况。
+- [ALTER RESOURCE GROUP](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-resource-group.md): TiDB 数据库中 ALTER RESOURCE GROUP 的使用概况。
+- [ALTER SEQUENCE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-sequence.md): 介绍 ALTER SEQUENCE 在 TiDB 中的使用概况。
+- [ALTER TABLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-table.md): TiDB 数据库中 ALTER TABLE 的使用概况。
+- [ALTER TABLE ... COMPACT](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-table-compact.md): TiDB 数据库中 ALTER TABLE ... COMPACT 语句的使用概况。
+- [ALTER USER](https://docs.pingcap.com/zh/tidb/stable/sql-statement-alter-user.md): TiDB 数据库中 ALTER USER 的使用概况。
+- [ANALYZE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-analyze-table.md): TiDB 数据库中 ANALYZE 的使用概况。
+- [ANALYZE_STATUS](https://docs.pingcap.com/zh/tidb/stable/information-schema-analyze-status.md): 了解 information_schema 表 `ANALYZE_STATUS`。
+- [AUTO_INCREMENT](https://docs.pingcap.com/zh/tidb/stable/auto-increment.md): 介绍 TiDB 的 `AUTO_INCREMENT` 列属性。
+- [AUTO_RANDOM](https://docs.pingcap.com/zh/tidb/stable/auto-random.md): 本文介绍了 TiDB 的 `AUTO_RANDOM` 列属性。
+- [BACKUP](https://docs.pingcap.com/zh/tidb/stable/sql-statement-backup.md): TiDB 数据库中 BACKUP 的使用概况。
+- [BATCH](https://docs.pingcap.com/zh/tidb/stable/sql-statement-batch.md): TiDB 数据库中 BATCH 的使用概况。
+- [BEGIN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-begin.md): TiDB 数据库中 BEGIN 的使用概况。
+- [Bookshop 应用](https://docs.pingcap.com/zh/tidb/stable/dev-guide-bookshop-schema-design.md): Bookshop 应用设计、数据导入、连接数据库等操作。
+- [br 命令行手册](https://docs.pingcap.com/zh/tidb/stable/use-br-command-line-tool.md): 了解 br 命令行的定义、组成与使用。
+- [CALIBRATE RESOURCE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-calibrate-resource.md): TiDB 数据库中 CALIBRATE RESOURCE 的使用概况。
+- [CANCEL IMPORT](https://docs.pingcap.com/zh/tidb/stable/sql-statement-cancel-import-job.md): TiDB 数据库中 CANCEL IMPORT 的使用概况。
+- [Cast 函数和操作符](https://docs.pingcap.com/zh/tidb/stable/cast-functions-and-operators.md): Cast 函数和操作符用于将某种数据类型的值转换为另一种数据类型。TiDB 支持使用 MySQL 8.0 中提供的所有 Cast 函数和操作符。
+- [CHANGE COLUMN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-change-column.md): TiDB 数据库中 CHANGE COLUMN 的使用概况。
+- [Changefeed DDL 同步](https://docs.pingcap.com/zh/tidb/stable/ticdc-ddl.md): 了解 TiCDC 支持同步的 DDL 和一些特殊情况
+- [Changefeed 日志过滤器](https://docs.pingcap.com/zh/tidb/stable/ticdc-filter.md): 了解 TiCDC 的表过滤器和事件过滤器使用方法。
+- [Changefeed 概述](https://docs.pingcap.com/zh/tidb/stable/ticdc-changefeed-overview.md): 了解 Changefeed 的基本概念和 Changefeed 状态的定义与流转
+- [CHARACTER_SETS](https://docs.pingcap.com/zh/tidb/stable/information-schema-character-sets.md): 了解 INFORMATION_SCHEMA 表 `CHARACTER_SETS`。
+- [CHECK_CONSTRAINTS](https://docs.pingcap.com/zh/tidb/stable/information-schema-check-constraints.md): 了解 INFORMATION_SCHEMA 表 `CHECK_CONSTRAINTS`。
+- [CLIENT_ERRORS_SUMMARY_BY_HOST](https://docs.pingcap.com/zh/tidb/stable/client-errors-summary-by-host.md): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_HOST`。
+- [CLIENT_ERRORS_SUMMARY_BY_USER](https://docs.pingcap.com/zh/tidb/stable/client-errors-summary-by-user.md): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_USER`。
+- [CLIENT_ERRORS_SUMMARY_GLOBAL](https://docs.pingcap.com/zh/tidb/stable/client-errors-summary-global.md): 了解 information_schema 表 `CLIENT_ERRORS_SUMMARY_GLOBAL`。
+- [CLUSTER_CONFIG](https://docs.pingcap.com/zh/tidb/stable/information-schema-cluster-config.md): 了解 information_schema 表 `CLUSTER_CONFIG`。
+- [CLUSTER_HARDWARE](https://docs.pingcap.com/zh/tidb/stable/information-schema-cluster-hardware.md): 了解 TiDB 集群硬件表 `CLUSTER_HARDWARE`。
+- [CLUSTER_INFO](https://docs.pingcap.com/zh/tidb/stable/information-schema-cluster-info.md): 了解 TiDB 集群拓扑表 `CLUSTER_INFO`。
+- [CLUSTER_LOAD](https://docs.pingcap.com/zh/tidb/stable/information-schema-cluster-load.md): 了解 information_schema 表 `CLUSTER_LOAD`。
+- [CLUSTER_LOG](https://docs.pingcap.com/zh/tidb/stable/information-schema-cluster-log.md): 了解 information_schema 表 `CLUSTER_LOG`。
+- [CLUSTER_SYSTEMINFO](https://docs.pingcap.com/zh/tidb/stable/information-schema-cluster-systeminfo.md): 了解 TiDB 集群负载表 `CLUSTER_SYSTEMINFO`。
+- [COLLATION_CHARACTER_SET_APPLICABILITY](https://docs.pingcap.com/zh/tidb/stable/information-schema-collation-character-set-applicability.md): 了解 INFORMATION_SCHEMA 表 `COLLATION_CHARACTER_SET_APPLICABILITY`。
+- [COLLATIONS](https://docs.pingcap.com/zh/tidb/stable/information-schema-collations.md): 了解 information_schema 表 `COLLATIONS`。
+- [COLUMNS](https://docs.pingcap.com/zh/tidb/stable/information-schema-columns.md): 了解 INFORMATION_SCHEMA 表 `COLUMNS`。
+- [COMMIT](https://docs.pingcap.com/zh/tidb/stable/sql-statement-commit.md): TiDB 数据库中 COMMIT 的使用概况。
+- [CREATE [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-binding.md): TiDB 数据库中 CREATE [GLOBAL|SESSION] BINDING 的使用概况。
+- [CREATE DATABASE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-database.md): TiDB 数据库中 CREATE DATABASE 的使用概况。
+- [CREATE INDEX](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-index.md): CREATE INDEX 在 TiDB 中的使用概况
+- [CREATE PLACEMENT POLICY](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-placement-policy.md): TiDB 数据库中 CREATE PLACEMENT POLICY 的使用概况。
+- [CREATE RESOURCE GROUP](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-resource-group.md): TiDB 数据库中 CREATE RESOURCE GROUP 的使用概况。
+- [CREATE ROLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-role.md): TiDB 数据库中 CREATE ROLE 的使用概况。
+- [CREATE SEQUENCE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-sequence.md): CREATE SEQUENCE 在 TiDB 中的使用概况
+- [CREATE TABLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-table.md): TiDB 数据库中 CREATE TABLE 的使用概况
+- [CREATE TABLE LIKE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-table-like.md): TiDB 数据库中 CREATE TABLE LIKE 的使用概况。
+- [CREATE USER](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-user.md): TiDB 数据库中 CREATE USER 的使用概况。
+- [CREATE VIEW](https://docs.pingcap.com/zh/tidb/stable/sql-statement-create-view.md): TiDB 数据库中 CREATE VIEW 的使用概况。
+- [Data Migration DDL 特殊处理说明](https://docs.pingcap.com/zh/tidb/stable/dm-ddl-compatible.md): 数据迁移中，根据不同的 DDL 语句和场景，采用不同处理方式。DM 不支持的 DDL 语句会直接跳过。部分 DDL 语句在同步到下游前会进行改写。在合库合表迁移任务中，DDL 同步行为存在变更。Online DDL 特性也会对 DDL 事件进行特殊处理。
+- [Data Migration 中的 DML 同步机制](https://docs.pingcap.com/zh/tidb/stable/dm-dml-replication-logic.md): 了解 DM 核心处理单元 Sync 如何同步 DML 语句。
+- [Data Migration 常见问题](https://docs.pingcap.com/zh/tidb/stable/dm-faq.md): 数据迁移常见问题包括：DM 是否支持迁移阿里 RDS 和其他云数据库的数据、task 配置中的黑白名单的正则表达式是否支持非获取匹配、处理不兼容的 DDL 语句、重置数据迁移任务、全量导入过程中遇到报错等。
+- [Data Migration 架构](https://docs.pingcap.com/zh/tidb/stable/dm-arch.md): Data Migration 架构包括三个组件：DM-master，DM-worker 和 dmctl。DM-master 负责管理和调度数据迁移任务的各项操作。DM-worker 执行具体的数据迁移任务。dmctl 是用来控制 DM 集群的命令行工具。 DM 集群的拓扑信息、数据迁移任务的运行状态和管理统一入口都由 DM-master 负责。DM-worker 负责持久化保存 binlog 数据、保存数据迁移子任务的配置信息和监控数据迁移子任务的运行状态。dmctl 用来创建、更新或删除数据迁移任务、查看数据迁移任务状态、处理数据迁移任务错误和校验数据迁移任务配置的正确性。 Data Migration 高可用机制可以进一步探索。
+- [Data Migration 高可用机制](https://docs.pingcap.com/zh/tidb/stable/dm-high-availability.md): 了解 Data Migration (DM) 高可用的内部机制，以及对迁移任务的影响。
+- [DATA_LOCK_WAITS](https://docs.pingcap.com/zh/tidb/stable/information-schema-data-lock-waits.md): 了解 information_schema 表 `DATA_LOCK_WAITS`。
+- [DDL 语句的执行原理及最佳实践](https://docs.pingcap.com/zh/tidb/stable/ddl-introduction.md): 介绍 TiDB 中 DDL 语句的实现原理、在线变更过程、最佳实践等内容。
+- [DDL_JOBS](https://docs.pingcap.com/zh/tidb/stable/information-schema-ddl-jobs.md): 了解 information_schema 表 `DDL_JOBS`。
+- [DEADLOCKS](https://docs.pingcap.com/zh/tidb/stable/information-schema-deadlocks.md): 了解 INFORMATION_SCHEMA 表 `DEADLOCKS`。
+- [DEALLOCATE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-deallocate.md): TiDB 数据库中 DEALLOCATE 的使用概况。
+- [DELETE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-delete.md): TiDB 数据库中 DELETE 的使用概况。
 - [在 Kubernetes 上部署 DM](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tidb-dm.md): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/deploy-tidb-dm
-- [DESC](https://docs.pingcap.com/tidb/stable/sql-statement-desc.md): TiDB 数据库中 DESC 的使用概况。
-- [DESCRIBE](https://docs.pingcap.com/tidb/stable/sql-statement-describe.md): TiDB 数据库中 DESCRIBE 的使用概况。
-- [Distinct 优化](https://docs.pingcap.com/tidb/stable/agg-distinct-optimization.md): 本文介绍了对于 DISTINCT 的优化，包括简单 DISTINCT 和聚合函数 DISTINCT 的优化。简单的 DISTINCT 通常会被优化成 GROUP BY 来执行。而带有 DISTINCT 的聚合函数会在 TiDB 侧单线程执行，可以通过系统变量或 TiDB 配置项控制优化器是否执行。在优化后，DISTINCT 被下推到了 Coprocessor，在 HashAgg 里新增了一个 group by 列。
-- [DM 5.4.0 性能测试报告](https://docs.pingcap.com/tidb/stable/dm-benchmark-v5.4.0.md): 了解 DM 5.4.0 版本的性能。
-- [DM Relay Log](https://docs.pingcap.com/tidb/stable/relay-log.md): 了解目录结构、初始迁移规则和 DM relay log 的数据清理。
-- [DM Table Selector](https://docs.pingcap.com/tidb/stable/table-selector.md): 介绍 DM 的 Table Selector
-- [DM 任务完整配置文件介绍](https://docs.pingcap.com/tidb/stable/task-configuration-file-full.md): 本文介绍了 Data Migration (DM) 的任务完整配置文件，包括全局配置和实例配置两部分。全局配置包括任务基本信息配置和功能配置集，功能配置集包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers。实例配置定义了具体的数据迁移子任务，包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers 的配置名称。
-- [DM 告警信息](https://docs.pingcap.com/tidb/stable/dm-alert-rules.md): 介绍 DM 的告警信息。
-- [DM 增量数据校验](https://docs.pingcap.com/tidb/stable/dm-continuous-data-validation.md): 了解增量数据校验的原理，以及如何使用增量数据校验功能。
-- [DM 安全模式](https://docs.pingcap.com/tidb/stable/dm-safe-mode.md): 介绍 DM safe mode 作用和原理
-- [DM 数据迁移最佳实践](https://docs.pingcap.com/tidb/stable/dm-best-practices.md): 了解使用 TiDB Data Migration (DM) 进行数据迁移的一些最佳实践。
-- [DM 监控指标](https://docs.pingcap.com/tidb/stable/monitor-a-dm-cluster.md): 介绍 DM 的监控指标
-- [DM 自定义加解密 key](https://docs.pingcap.com/tidb/stable/dm-customized-secret-key.md): 介绍如何自定义密钥，用于加密和解密 DM（Data Migration）数据源和迁移任务配置中的密码。
-- [DM 配置优化](https://docs.pingcap.com/tidb/stable/dm-tune-configuration.md): 介绍如何通过优化配置来提高数据迁移性能。
-- [DM 配置简介](https://docs.pingcap.com/tidb/stable/dm-config-overview.md): 本文简要介绍了 DM（数据迁移）的配置文件和数据迁移任务的配置。配置文件包括 dm-master.toml、dm-worker.toml 和 source.yaml，分别用于配置 DM-master 进程、DM-worker 进程和上游数据库 MySQL/MariaDB。创建数据迁移任务的具体步骤包括使用 dmctl 加载数据源配置、参考数据任务配置向导创建 your_task.yaml 文件，以及使用 dmctl 创建数据迁移任务。关键概念包括 source-id、DM-master ID 和 DM-worker ID，分别用于唯一确定 MySQL 或 MariaDB 实例、DM-master 和 DM-worker。
-- [DM 集群性能测试](https://docs.pingcap.com/tidb/stable/dm-performance-test.md): 了解如何测试 DM 集群的性能。
-- [DM-master 配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-master-configuration-file.md): 本文介绍了 DM-master 的配置文件，包括示例配置和配置项说明。示例配置包括日志配置、DM-master 监听地址、集群配置等。配置项说明包括全局配置，如标识 DM-master、日志级别、日志文件、地址等。另外还包括 SSL 证书路径、证书检查 Common Name 列表和加解密密钥路径等内容。
-- [DM-worker 简介](https://docs.pingcap.com/tidb/stable/dm-worker-intro.md): DM-worker 是 DM (Data Migration) 的一个组件，负责执行数据迁移任务。主要功能包括注册为 MySQL 或 MariaDB 服务器的 slave，读取 binlog event 并持久化保存在本地，支持迁移一个 MySQL 或 MariaDB 实例的数据到多个 TiDB 实例，以及支持迁移多个 MySQL 或 MariaDB 实例的数据到一个 TiDB 实例。处理单元包括 Relay log、dump、load 和 Binlog replication/sync。上游数据库用户需具有 SELECT、RELOAD、REPLICATION SLAVE 和 REPLICATION CLIENT 权限，下游数据库用户需具有 SELECT、INSERT、UPDATE、DELETE、CREATE、DROP 和 INDEX 权限。处理单元所需的最小权限根据具体情况可能会改变。
-- [DM-worker 配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-worker-configuration-file.md): 本文介绍了 DM-worker 的配置文件，包括配置文件示例和配置项说明。配置文件示例包括了 worker 的名称、日志配置、worker 的地址等内容。配置项说明包括了全局配置中的各个配置项的说明，如 name、log-level、log-file 等。同时还介绍了一些新增的配置项，如 relay-keepalive-ttl 和 relay-dir。SSL 相关的配置项也有详细说明。
-- [DO | TiDB SQL Statement Reference](https://docs.pingcap.com/tidb/stable/sql-statement-do.md): TiDB 数据库中 DO 的使用概况。
-- [DROP [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/tidb/stable/sql-statement-drop-binding.md): TiDB 数据库中 DROP [GLOBAL|SESSION] BINDING 的使用概况。
-- [DROP COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-drop-column.md): TiDB 数据库中 DROP COLUMN 的使用概况。
-- [DROP DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-database.md): TiDB 数据库中 DROP DATABASE 的使用概况。
-- [DROP INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-drop-index.md): TiDB 数据库中 DROP INDEX 的使用概况。
-- [DROP PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-drop-placement-policy.md): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
-- [DROP RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-drop-resource-group.md): TiDB 数据库中 DROP RESOURCE GROUP 的使用概况。
-- [DROP ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-role.md): TiDB 数据库中 DROP ROLE 的使用概况。
-- [DROP SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-sequence.md): TiDB 数据库中 DROP SEQUENCE 的使用概况。
-- [DROP STATS](https://docs.pingcap.com/tidb/stable/sql-statement-drop-stats.md): TiDB 数据库中 DROP STATS 的使用概况。
-- [DROP TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-table.md): TiDB 数据库中 DROP TABLE 的使用概况。
-- [DROP USER](https://docs.pingcap.com/tidb/stable/sql-statement-drop-user.md): TiDB 数据库中 DROP USER 的使用概况。
-- [DROP VIEW](https://docs.pingcap.com/tidb/stable/sql-statement-drop-view.md): TiDB 数据库中 DROP VIEW 的使用概况。
-- [ENGINES](https://docs.pingcap.com/tidb/stable/information-schema-engines.md): 了解 information_schema 表 `ENGINES`。
-- [EXECUTE](https://docs.pingcap.com/tidb/stable/sql-statement-execute.md): TiDB 数据库中 EXECUTE 的使用概况。
-- [EXPLAIN](https://docs.pingcap.com/tidb/stable/sql-statement-explain.md): TiDB 数据库中 EXPLAIN 的使用概况。
-- [EXPLAIN ANALYZE](https://docs.pingcap.com/tidb/stable/sql-statement-explain-analyze.md): TiDB 数据库中 EXPLAIN ANALYZE 的使用概况。
-- [FLASHBACK CLUSTER](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-cluster.md): TiDB 数据库中 FLASHBACK CLUSTER 的使用概况。
-- [FLASHBACK DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-database.md): TiDB 数据库中 FLASHBACK DATABASE 的使用概况。
-- [FLASHBACK TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-table.md): TiDB 4.0 引入了 `FLASHBACK TABLE` 语法，可在 GC 生命周期内恢复被 `DROP` 或 `TRUNCATE` 删除的表和数据。使用系统变量 `tidb_gc_life_time` 配置历史版本保留时间，默认为 `10m0s`。查询当前`safePoint`：`SELECT * FROM mysql.tidb WHERE variable_name = 'tikv_gc_safe_point'`。注意，过了 GC 生命周期就无法恢复被删除的数据。
-- [FLUSH PRIVILEGES](https://docs.pingcap.com/tidb/stable/sql-statement-flush-privileges.md): TiDB 数据库中 FLUSH PRIVILEGES 的使用概况。
-- [FLUSH STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-flush-status.md): TiDB 数据库中 FLUSH STATUS 的使用概况。
-- [FLUSH TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-flush-tables.md): TiDB 数据库中 FLUSH TABLES 的使用概况。
-- [Follower Read](https://docs.pingcap.com/tidb/stable/dev-guide-use-follower-read.md): 使用 Follower Read 在特定情况下加速查询。
-- [Follower Read](https://docs.pingcap.com/tidb/stable/follower-read.md): 了解 Follower Read 的使用与实现。
-- [GBK](https://docs.pingcap.com/tidb/stable/character-set-gbk.md): 本文介绍 TiDB 对 GBK 字符集的支持情况。
-- [GC 机制简介](https://docs.pingcap.com/tidb/stable/garbage-collection-overview.md): TiDB 的事务实现采用了 MVCC 机制，GC 的任务是清理不再需要的旧数据。整体流程包括 GC leader 控制 GC 的运行，定期触发 GC，以及三个步骤：Resolve Locks 清理锁，Delete Ranges 删除区间，Do GC 进行 GC 清理。Resolve Locks 清理锁有两种执行模式：LEGACY 和 PHYSICAL。Delete Ranges 删除区间会快速物理删除待删除的区间及删除操作的时间戳。Do GC 进行 GC 清理会删除所有 key 的过期版本。GC 每 10 分钟触发一次，默认保留最近 10 分钟内的数据。
-- [GC 配置](https://docs.pingcap.com/tidb/stable/garbage-collection-configuration.md): TiDB 的 GC 配置可以通过系统变量进行设置，包括启用 GC、运行间隔、数据保留时限、并发线程数量等。此外，TiDB 还支持 GC 流控，可以限制每秒数据写入量。从 TiDB 5.0 版本开始，建议使用系统变量进行配置，避免异常行为。在 TiDB 6.1.0 版本引入了新的系统变量 `tidb_gc_max_wait_time`，用于控制活跃事务阻塞 GC safe point 推进的最长时间。另外，GC in Compaction Filter 机制可以通过配置文件或在线配置开启，但可能会影响 TiKV 扫描性能。
-- [Gitpod](https://docs.pingcap.com/tidb/stable/dev-guide-playground-gitpod.md): Gitpod 是一个开源 Kubernetes 应用程序，可在浏览器中获得完整的开发环境，并立即编写代码。它能够为云中的每个任务提供全新的自动化开发环境，无需本地配置。Gitpod 提供了完整的、自动化的、预配置的云原生开发环境，让你可以直接在浏览器中开发、运行、测试代码。
-- [GRANT <privileges>](https://docs.pingcap.com/tidb/stable/sql-statement-grant-privileges.md): TiDB 数据库中 GRANT <privileges> 的使用概况。
-- [GRANT <role>](https://docs.pingcap.com/tidb/stable/sql-statement-grant-role.md): TiDB 数据库中 GRANT <role> 的使用概况。
-- [GROUP BY 修饰符](https://docs.pingcap.com/tidb/stable/group-by-modifier.md): 了解如何使用 TiDB GROUP BY 修饰符。
-- [GROUP BY 聚合函数](https://docs.pingcap.com/tidb/stable/aggregate-group-by-functions.md): TiDB支持的聚合函数包括 COUNT、COUNT(DISTINCT)、SUM、AVG、MAX、MIN、GROUP_CONCAT、VARIANCE、VAR_POP、STD、STDDEV、VAR_SAMP、STDDEV_SAMP 和 JSON_OBJECTAGG。除了 GROUP_CONCAT 和 APPROX_PERCENTILE 外，这些聚合函数可以作为窗口函数使用。另外，TiDB 的 GROUP BY 子句支持 WITH ROLLUP 修饰符，还支持 SQL 模式 ONLY_FULL_GROUP_BY。与 MySQL 的区别在于 TiDB 对标准 SQL 有一些扩展，允许在 HAVING 子句中使用别名和非列表达式。
-- [HAProxy 在 TiDB 中的最佳实践](https://docs.pingcap.com/tidb/stable/haproxy-best-practices.md): HAProxy 是 TiDB 中实现负载均衡的最佳实践。它提供 TCP 协议下的负载均衡能力，通过连接 HAProxy 提供的浮动 IP 对数据进行操作，实现 TiDB Server 层的负载均衡。HAProxy 提供高可用性、负载均衡、健康检查、会话保持、SSL 支持和监控统计等核心功能。部署 HAProxy 需要满足一定的硬件和软件要求，配置和启动 HAProxy 后即可实现数据库负载均衡。
-- [HTAP 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-htap.md): 本文介绍如何快速上手体验 TiDB 的 HTAP 功能。
-- [HTAP 查询](https://docs.pingcap.com/tidb/stable/dev-guide-hybrid-oltp-and-olap-queries.md): 介绍 TiDB 中的 HTAP 查询功能。
-- [HTAP 深入探索指南](https://docs.pingcap.com/tidb/stable/explore-htap.md): 本文介绍如何深入探索并使用 TiDB 的 HTAP 功能。
-- [IMPORT INTO](https://docs.pingcap.com/tidb/stable/sql-statement-import-into.md): TiDB 数据库中 IMPORT INTO 的使用概况。
-- [IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性](https://docs.pingcap.com/tidb/stable/tidb-lightning-compatibility-and-scenarios.md): 了解 IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性及使用场景。
-- [IMPORT INTO 和 TiDB Lightning 对比](https://docs.pingcap.com/tidb/stable/import-into-vs-tidb-lightning.md): 了解 `IMPORT INTO` 和 TiDB Lightning 的差异。
-- [Information Schema](https://docs.pingcap.com/tidb/stable/information-schema.md): Information Schema 是一种查看系统元数据的 ANSI 标准方法。TiDB 提供了许多自定义的 `INFORMATION_SCHEMA` 表，包括与 MySQL 兼容的表和 TiDB 中的扩展表。这些表提供了关于字符集、排序规则、列、存储引擎、索引、表大小、慢查询等信息，帮助用户进行系统监控和优化。
-- [INSERT](https://docs.pingcap.com/tidb/stable/sql-statement-insert.md): TiDB 数据库中 INSERT 的使用概况。
-- [INSPECTION_RESULT](https://docs.pingcap.com/tidb/stable/information-schema-inspection-result.md): 了解 TiDB 系统表 `INSPECTION_RESULT`。
-- [INSPECTION_RULES](https://docs.pingcap.com/tidb/stable/information-schema-inspection-rules.md): 了解 information_schema 表 `INSPECTION_RULES`。
-- [INSPECTION_SUMMARY](https://docs.pingcap.com/tidb/stable/information-schema-inspection-summary.md): 了解 TiDB 系统表 `INSPECTION_SUMMARY`。
-- [Join Reorder 算法简介](https://docs.pingcap.com/tidb/stable/join-reorder.md): Join Reorder 算法决定了多表 Join 的顺序，影响执行效率。TiDB 中有贪心算法和动态规划算法两种实现。贪心算法选择行数最小的表与其他表做 Join，直到所有节点完成 Join。动态规划算法枚举所有可能的 Join 顺序，选择最优的。算法受系统变量控制，且存在一些限制，如无法保证一定选到合适的 Join 顺序。
-- [JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分 JSON 函数。
-- [JSON 效用函数](https://docs.pingcap.com/tidb/stable/json-functions-utility.md): 了解 JSON 效用函数。
-- [JSON 数据类型](https://docs.pingcap.com/tidb/stable/data-type-json.md): JSON 类型存储半结构化数据，使用 Binary 格式序列化，加快查询和解析速度。JSON 字段不能创建索引，但可以对 JSON 文档中的子字段创建索引。TiDB 仅支持下推部分 JSON 函数到 TiFlash，不建议使用 BR 恢复包含 JSON 列的数据到 v6.3.0 之前的 TiDB 集群。请勿同步非标准 JSON 类型的数据。MySQL 误标记二进制类型数据为 STRING 类型，TiDB 保持正确的二进制类型。ENUM 或 SET 数据类型转换为 JSON 时，TiDB 会检查格式正确性。TiDB 支持使用 ORDER BY 对 JSON Array 或 JSON Object 进行排序。在 INSERT JSON 列时，TiDB 会将值隐式转换为 JSON。
-- [KEY_COLUMN_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-key-column-usage.md): 了解 information_schema 表 `KEY_COLUMN_USAGE`。
-- [KEYWORDS](https://docs.pingcap.com/tidb/stable/information-schema-keywords.md): 了解 INFORMATION_SCHEMA 表 `KEYWORDS`。
-- [KILL](https://docs.pingcap.com/tidb/stable/sql-statement-kill.md): TiDB 数据库中 KILL 的使用概况。
-- [Load Base Split](https://docs.pingcap.com/tidb/stable/configure-load-base-split.md): 介绍 Load Base Split 功能。
-- [LOAD DATA](https://docs.pingcap.com/tidb/stable/sql-statement-load-data.md): TiDB 数据库中 LOAD DATA 的使用概况。
-- [LOAD STATS](https://docs.pingcap.com/tidb/stable/sql-statement-load-stats.md): TiDB 数据库中 LOAD STATS 的使用概况。
-- [LOCK STATS](https://docs.pingcap.com/tidb/stable/sql-statement-lock-stats.md): TiDB 数据库中 LOCK STATS 的使用概况。
-- [LOCK TABLES 和 UNLOCK TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-lock-tables-and-unlock-tables.md): TiDB 数据库中 LOCK TABLES 和 UNLOCK TABLES 的使用概况。
-- [Max/Min 函数消除规则](https://docs.pingcap.com/tidb/stable/max-min-eliminate.md): SQL 中的 max/min 函数消除规则能够将 max/min 聚合函数转换为 TopN 算子，利用索引进行查询。当只有一个 max/min 函数时，会重写为 select max(a) from (select a from t where a is not null order by a desc limit 1) t，利用索引只扫描一行数据。存在多个 max/min 函数时，会先检查列是否有索引能够保序，然后重写为两个子查询的笛卡尔积，最终避免对整个表的扫描。
-- [MEMORY_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-memory-usage.md): 了解 information_schema 表 `MEMORY_USAGE`。
-- [MEMORY_USAGE_OPS_HISTORY](https://docs.pingcap.com/tidb/stable/information-schema-memory-usage-ops-history.md): 了解 information_schema 表 `MEMORY_USAGE_OPS_HISTORY`。
-- [Metrics Schema](https://docs.pingcap.com/tidb/stable/metrics-schema.md): 了解 TiDB `METRICS SCHEMA` 系统数据库。
-- [METRICS_SUMMARY](https://docs.pingcap.com/tidb/stable/information-schema-metrics-summary.md): 了解 TiDB 系统表 `METRICS_SUMMARY`。
-- [METRICS_TABLES](https://docs.pingcap.com/tidb/stable/information-schema-metrics-tables.md): 了解 TiDB 系统表 `METRICS_TABLES`。
-- [MODIFY COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-modify-column.md): TiDB 数据库中 MODIFY COLUMN 的使用概况。
-- [mysql Schema](https://docs.pingcap.com/tidb/stable/mysql-schema.md): 了解 TiDB 系统表。
-- [mysql.tidb_mdl_view](https://docs.pingcap.com/tidb/stable/mysql-schema-tidb-mdl-view.md): 了解 `mysql` schema 中的 `tidb_mdl_view` 视图。
-- [mysql.user](https://docs.pingcap.com/tidb/stable/mysql-schema-user.md): 了解 `mysql` 系统表 `user`。
-- [OLTP 负载性能优化实践](https://docs.pingcap.com/tidb/stable/performance-tuning-practices.md): 本文档介绍了如何对 OLTP 负载进行性能分析和优化。
-- [Online Unsafe Recovery 使用文档](https://docs.pingcap.com/tidb/stable/online-unsafe-recovery.md): 如何使用 Online Unsafe Recovery。
-- [Optimizer Fix Controls](https://docs.pingcap.com/tidb/stable/optimizer-fix-controls.md): 了解 Optimizer Fix Controls 以及如何使用 `tidb_opt_fix_control` 细粒度地控制 TiDB 优化器的行为。
-- [Optimizer Hints](https://docs.pingcap.com/tidb/stable/optimizer-hints.md): 介绍 TiDB 中 Optimizer Hints 的语法和不同生效范围的 Hint 的使用方法。
-- [Oracle 与 TiDB 函数和语法差异对照](https://docs.pingcap.com/tidb/stable/oracle-functions-to-tidb.md): 了解 Oracle 与 TiDB 函数和语法差异对照。
-- [Overview 面板重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-overview-dashboard.md): TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview。重要监控指标包括服务在线节点数量、PD 角色、存储容量、Region 数量、TiDB 执行数量、CPU 使用率、内存大小、网络流量等。详细监控说明可参见文章。
-- [Partitioned Raft KV](https://docs.pingcap.com/tidb/stable/partitioned-raft-kv.md): 了解 TiKV 的 Partitioned Raft KV 特性。
-- [PARTITIONS](https://docs.pingcap.com/tidb/stable/information-schema-partitions.md): 了解 INFORMATION_SCHEMA 表 `PARTITIONS`。
-- [PD Control 使用说明](https://docs.pingcap.com/tidb/stable/pd-control.md): PD Control 是 PD 的命令行工具，用于获取集群状态信息和调整集群。
-- [PD Recover 使用文档](https://docs.pingcap.com/tidb/stable/pd-recover.md): PD Recover 是用于恢复无法正常启动或服务的 PD 集群的工具。安装方式包括从源代码编译和下载 TiDB 工具包。恢复集群的方式有两种：从存活的 PD 节点重建和完全重建。从存活的 PD 节点重建集群需要停止所有节点，启动存活的 PD 节点，并使用 pd-recover 修复元数据。完全重建 PD 集群需要获取 Cluster ID 和已分配 ID，部署新的 PD 集群，使用 pd-recover 修复，然后重启整个集群。
-- [PD 微服务](https://docs.pingcap.com/tidb/stable/pd-microservices.md): 介绍如何开启 PD 微服务模式，以提高服务质量。
-- [PD 微服务部署拓扑](https://docs.pingcap.com/tidb/stable/pd-microservices-deployment-topology.md): 了解在部署最小拓扑集群的基础上，部署 PD 微服务的拓扑结构。
-- [PD 调度策略最佳实践](https://docs.pingcap.com/tidb/stable/pd-scheduling-best-practices.md): 了解 PD 调度策略的最佳实践和调优方式
-- [PD 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-pd-configuration.md): PD 配置参数可以通过命令行参数或环境变量配置。包括外部访问 PD 的 URL 列表，其他 PD 节点访问某个 PD 节点的 URL 列表，PD 监听的客户端 URL 列表，PD 节点监听其他 PD 节点的 URL 列表，配置文件，PD 存储数据路径，初始化 PD 集群配置，动态加入 PD 集群，Log 级别，Log 文件，是否开启日志切割，当前 PD 的名字，CA 文件路径，包含 X509 证书的 PEM 文件路径，包含 X509 key 的 PEM 文件路径，指定 Prometheus Pushgateway 的地址，强制使用当前节点创建新的集群，输出版本信息并退出。
-- [PD 配置文件描述](https://docs.pingcap.com/tidb/stable/pd-configuration-file.md): PD 配置文件包含了许多参数，如节点名称、数据路径、客户端 URL、广告客户端 URL、节点 URL 等。还包括了一些实验性特性的配置项，如内存限制、GC 触发阈值、GOGC Tuner 等。此外，还有监控、调度、副本、标签、Dashboard、同步模式和资源控制等相关配置项。
-- [PD 重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-pd-dashboard.md): PD 重要监控指标详解：使用 TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构参见 [TiDB 监控框架概述]。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。通过观察 PD 面板上的 Metrics，可以了解 PD 当前的状态。监控包括 PD role、Storage capacity、Current storage size、Current storage usage、Normal stores、Number of Regions、Abnormal stores、Region health、Current peer count 等。Cluster、Operator、Statistics - Balance、Statistics - hot write、Statistics - hot read、Scheduler、gRPC、etcd、TiDB、Heartbeat、Region storage 等指标也很重要。
-- [Performance Overview 面板重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-performance-overview-dashboard.md): 本文介绍 Performance Overview 面板上监控指标的含义。
-- [Performance Schema](https://docs.pingcap.com/tidb/stable/performance-schema.md): 了解 TiDB `performance_schema` 系统数据库。
-- [PingCAP Clinic 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-clinic.md): 了解如何使用 PingCAP Clinic 诊断服务快速采集、上传、查看集群诊断数据。
-- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/tidb/stable/clinic-data-instruction-for-tiup.md): 详细说明 PingCAP Clinic 诊断服务在使用 TiUP 部署的 TiDB 集群和 DM 集群中能够采集哪些诊断数据。
-- [PingCAP Clinic 诊断服务简介](https://docs.pingcap.com/tidb/stable/clinic-introduction.md): 介绍 PingCAP Clinic 诊断服务，包括工具组件、使用场景和工作原理。
-- [Pipelined DML](https://docs.pingcap.com/tidb/stable/pipelined-dml.md): 介绍 Pipelined DML 的使用场景、使用方法、使用限制和使用该功能的常见问题。Pipelined DML 增强了 TiDB 批量处理的能力，使得事务大小不再受到 TiDB 内存限制。
-- [Placement Rules in SQL](https://docs.pingcap.com/tidb/stable/placement-rules-in-sql.md): 了解如何通过 SQL 接口调度表和分区的放置位置。
-- [Placement Rules 使用文档](https://docs.pingcap.com/tidb/stable/configure-placement-rules.md): 如何配置 Placement Rules
-- [PLACEMENT_POLICIES](https://docs.pingcap.com/tidb/stable/information-schema-placement-policies.md): 了解 information_schema 表 `PLACEMENT_POLICIES`。
-- [PREPARE](https://docs.pingcap.com/tidb/stable/sql-statement-prepare.md): TiDB 数据库中 PREPARE 的使用概况。
-- [Prepare 语句执行计划缓存](https://docs.pingcap.com/tidb/stable/sql-prepared-plan-cache.md): Prepare 语句执行计划缓存功能默认打开，可通过变量启用或关闭。缓存功能仅针对 Prepare/Execute 请求，对普通查询无效。缓存功能会有一定内存开销，可通过监控查看内存使用情况。可手动清空计划缓存，但不支持一次性清空整个集群的计划缓存。忽略 COM_STMT_CLOSE 指令和 DEALLOCATE PREPARE 语句，可解决计划被立即清理的问题。监控 Queries Using Plan Cache OPS 和 Plan Cache Miss OPS，以确保 SQL 执行计划缓存正常工作。Prepared Statement Count 图表显示非零值，表示应用使用了预处理语句。
-- [PROCESSLIST](https://docs.pingcap.com/tidb/stable/information-schema-processlist.md): 了解 information_schema 表 `PROCESSLIST`。
-- [ProxySQL 集成指南](https://docs.pingcap.com/tidb/stable/dev-guide-proxysql-integration.md): 了解如何将本地部署的 TiDB 或 TiDB Cloud 集群与 ProxySQL 集成。
-- [QUERY WATCH](https://docs.pingcap.com/tidb/stable/sql-statement-query-watch.md): TiDB 数据库中 QUERY WATCH 的使用概况。
-- [RECOVER TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-recover-table.md): RECOVER TABLE 是用来恢复被删除的表及其数据的功能。在 DROP TABLE 后，在 GC life time 时间内，可以使用 RECOVER TABLE 语句来恢复被删除的表以及其数据。如果删除表后并过了 GC lifetime，就不能再用 RECOVER TABLE 来恢复被删除的表了。
-- [REFERENTIAL_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-referential-constraints.md): 了解 INFORMATION_SCHEMA 表 `REFERENTIAL_CONSTRAINTS`。
-- [Region 性能调优](https://docs.pingcap.com/tidb/stable/tune-region-performance.md): 了解如何通过调整 Region 大小等方法对 Region 进行性能调优以及如何在大 Region 下使用 bucket 进行并发查询优化。
-- [RENAME INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-rename-index.md): TiDB 数据库中 RENAME INDEX 的使用概况。
-- [RENAME TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-rename-table.md): TiDB 数据库中 RENAME TABLE 的使用概况。
-- [RENAME USER](https://docs.pingcap.com/tidb/stable/sql-statement-rename-user.md): TiDB 数据库中 RENAME USER 的使用概况。
-- [REPLACE](https://docs.pingcap.com/tidb/stable/sql-statement-replace.md): TiDB 数据库中 REPLACE 的使用概况。
-- [RESOURCE_GROUPS](https://docs.pingcap.com/tidb/stable/information-schema-resource-groups.md): 了解 information_schema 表 `RESOURCE_GROUPS`。
-- [RESTORE](https://docs.pingcap.com/tidb/stable/sql-statement-restore.md): TiDB 数据库中 RESTORE 的使用概况。
-- [REVOKE <privileges>](https://docs.pingcap.com/tidb/stable/sql-statement-revoke-privileges.md): TiDB 数据库中 REVOKE <privileges> 的使用概况。
-- [REVOKE <role>](https://docs.pingcap.com/tidb/stable/sql-statement-revoke-role.md): TiDB 数据库中 REVOKE <role> 的使用概况。
-- [RocksDB 简介](https://docs.pingcap.com/tidb/stable/rocksdb-overview.md): RocksDB 是 Facebook 基于 LevelDB 开发的 LSM-tree 架构引擎，提供键值存储与读写功能。数据先写入磁盘上的 WAL，再写入内存中的跳表。内存数据达到阈值后刷到磁盘生成 SST 文件，分为多层，90% 数据存储在最后一层。RocksDB 允许创建多个 ColumnFamily，共享同一个 WAL 文件。为提高读取性能，文件按大小切分成 block，存在 BlockCache 中。后台线程执行 MemTable 转化为 SST 文件和合并操作。L0 文件数量过多会触发 WriteStall 阻塞写入。
-- [ROLLBACK](https://docs.pingcap.com/tidb/stable/sql-statement-rollback.md): TiDB 数据库中 ROLLBACK 的使用概况。
-- [RUNAWAY_WATCHES](https://docs.pingcap.com/tidb/stable/information-schema-runaway-watches.md): 了解 INFORMATION_SCHEMA 表 `RUNAWAY_WATCHES`。
-- [Runtime Filter](https://docs.pingcap.com/tidb/stable/runtime-filter.md): 介绍 Runtime Filter 的原理及使用方式。
-- [SaaS 多租户场景最佳实践](https://docs.pingcap.com/tidb/stable/saas-best-practices.md): 介绍 TiDB 在 SaaS (Software as a service) 多租户场景的最佳实践，特别适用于单集群表数量超过百万级别的场景。
-- [SAVEPOINT](https://docs.pingcap.com/tidb/stable/sql-statement-savepoint.md): TiDB 数据库中 SAVEPOINT 的使用概况。
+- [DESC](https://docs.pingcap.com/zh/tidb/stable/sql-statement-desc.md): TiDB 数据库中 DESC 的使用概况。
+- [DESCRIBE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-describe.md): TiDB 数据库中 DESCRIBE 的使用概况。
+- [Distinct 优化](https://docs.pingcap.com/zh/tidb/stable/agg-distinct-optimization.md): 本文介绍了对于 DISTINCT 的优化，包括简单 DISTINCT 和聚合函数 DISTINCT 的优化。简单的 DISTINCT 通常会被优化成 GROUP BY 来执行。而带有 DISTINCT 的聚合函数会在 TiDB 侧单线程执行，可以通过系统变量或 TiDB 配置项控制优化器是否执行。在优化后，DISTINCT 被下推到了 Coprocessor，在 HashAgg 里新增了一个 group by 列。
+- [DM 5.4.0 性能测试报告](https://docs.pingcap.com/zh/tidb/stable/dm-benchmark-v5.4.0.md): 了解 DM 5.4.0 版本的性能。
+- [DM Relay Log](https://docs.pingcap.com/zh/tidb/stable/relay-log.md): 了解目录结构、初始迁移规则和 DM relay log 的数据清理。
+- [DM Table Selector](https://docs.pingcap.com/zh/tidb/stable/table-selector.md): 介绍 DM 的 Table Selector
+- [DM 任务完整配置文件介绍](https://docs.pingcap.com/zh/tidb/stable/task-configuration-file-full.md): 本文介绍了 Data Migration (DM) 的任务完整配置文件，包括全局配置和实例配置两部分。全局配置包括任务基本信息配置和功能配置集，功能配置集包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers。实例配置定义了具体的数据迁移子任务，包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers 的配置名称。
+- [DM 告警信息](https://docs.pingcap.com/zh/tidb/stable/dm-alert-rules.md): 介绍 DM 的告警信息。
+- [DM 增量数据校验](https://docs.pingcap.com/zh/tidb/stable/dm-continuous-data-validation.md): 了解增量数据校验的原理，以及如何使用增量数据校验功能。
+- [DM 安全模式](https://docs.pingcap.com/zh/tidb/stable/dm-safe-mode.md): 介绍 DM safe mode 作用和原理
+- [DM 数据迁移最佳实践](https://docs.pingcap.com/zh/tidb/stable/dm-best-practices.md): 了解使用 TiDB Data Migration (DM) 进行数据迁移的一些最佳实践。
+- [DM 监控指标](https://docs.pingcap.com/zh/tidb/stable/monitor-a-dm-cluster.md): 介绍 DM 的监控指标
+- [DM 自定义加解密 key](https://docs.pingcap.com/zh/tidb/stable/dm-customized-secret-key.md): 介绍如何自定义密钥，用于加密和解密 DM（Data Migration）数据源和迁移任务配置中的密码。
+- [DM 配置优化](https://docs.pingcap.com/zh/tidb/stable/dm-tune-configuration.md): 介绍如何通过优化配置来提高数据迁移性能。
+- [DM 配置简介](https://docs.pingcap.com/zh/tidb/stable/dm-config-overview.md): 本文简要介绍了 DM（数据迁移）的配置文件和数据迁移任务的配置。配置文件包括 dm-master.toml、dm-worker.toml 和 source.yaml，分别用于配置 DM-master 进程、DM-worker 进程和上游数据库 MySQL/MariaDB。创建数据迁移任务的具体步骤包括使用 dmctl 加载数据源配置、参考数据任务配置向导创建 your_task.yaml 文件，以及使用 dmctl 创建数据迁移任务。关键概念包括 source-id、DM-master ID 和 DM-worker ID，分别用于唯一确定 MySQL 或 MariaDB 实例、DM-master 和 DM-worker。
+- [DM 集群性能测试](https://docs.pingcap.com/zh/tidb/stable/dm-performance-test.md): 了解如何测试 DM 集群的性能。
+- [DM-master 配置文件介绍](https://docs.pingcap.com/zh/tidb/stable/dm-master-configuration-file.md): 本文介绍了 DM-master 的配置文件，包括示例配置和配置项说明。示例配置包括日志配置、DM-master 监听地址、集群配置等。配置项说明包括全局配置，如标识 DM-master、日志级别、日志文件、地址等。另外还包括 SSL 证书路径、证书检查 Common Name 列表和加解密密钥路径等内容。
+- [DM-worker 简介](https://docs.pingcap.com/zh/tidb/stable/dm-worker-intro.md): DM-worker 是 DM (Data Migration) 的一个组件，负责执行数据迁移任务。主要功能包括注册为 MySQL 或 MariaDB 服务器的 slave，读取 binlog event 并持久化保存在本地，支持迁移一个 MySQL 或 MariaDB 实例的数据到多个 TiDB 实例，以及支持迁移多个 MySQL 或 MariaDB 实例的数据到一个 TiDB 实例。处理单元包括 Relay log、dump、load 和 Binlog replication/sync。上游数据库用户需具有 SELECT、RELOAD、REPLICATION SLAVE 和 REPLICATION CLIENT 权限，下游数据库用户需具有 SELECT、INSERT、UPDATE、DELETE、CREATE、DROP 和 INDEX 权限。处理单元所需的最小权限根据具体情况可能会改变。
+- [DM-worker 配置文件介绍](https://docs.pingcap.com/zh/tidb/stable/dm-worker-configuration-file.md): 本文介绍了 DM-worker 的配置文件，包括配置文件示例和配置项说明。配置文件示例包括了 worker 的名称、日志配置、worker 的地址等内容。配置项说明包括了全局配置中的各个配置项的说明，如 name、log-level、log-file 等。同时还介绍了一些新增的配置项，如 relay-keepalive-ttl 和 relay-dir。SSL 相关的配置项也有详细说明。
+- [DO | TiDB SQL Statement Reference](https://docs.pingcap.com/zh/tidb/stable/sql-statement-do.md): TiDB 数据库中 DO 的使用概况。
+- [DROP [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-binding.md): TiDB 数据库中 DROP [GLOBAL|SESSION] BINDING 的使用概况。
+- [DROP COLUMN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-column.md): TiDB 数据库中 DROP COLUMN 的使用概况。
+- [DROP DATABASE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-database.md): TiDB 数据库中 DROP DATABASE 的使用概况。
+- [DROP INDEX](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-index.md): TiDB 数据库中 DROP INDEX 的使用概况。
+- [DROP PLACEMENT POLICY](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-placement-policy.md): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
+- [DROP RESOURCE GROUP](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-resource-group.md): TiDB 数据库中 DROP RESOURCE GROUP 的使用概况。
+- [DROP ROLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-role.md): TiDB 数据库中 DROP ROLE 的使用概况。
+- [DROP SEQUENCE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-sequence.md): TiDB 数据库中 DROP SEQUENCE 的使用概况。
+- [DROP STATS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-stats.md): TiDB 数据库中 DROP STATS 的使用概况。
+- [DROP TABLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-table.md): TiDB 数据库中 DROP TABLE 的使用概况。
+- [DROP USER](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-user.md): TiDB 数据库中 DROP USER 的使用概况。
+- [DROP VIEW](https://docs.pingcap.com/zh/tidb/stable/sql-statement-drop-view.md): TiDB 数据库中 DROP VIEW 的使用概况。
+- [ENGINES](https://docs.pingcap.com/zh/tidb/stable/information-schema-engines.md): 了解 information_schema 表 `ENGINES`。
+- [EXECUTE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-execute.md): TiDB 数据库中 EXECUTE 的使用概况。
+- [EXPLAIN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-explain.md): TiDB 数据库中 EXPLAIN 的使用概况。
+- [EXPLAIN ANALYZE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-explain-analyze.md): TiDB 数据库中 EXPLAIN ANALYZE 的使用概况。
+- [FLASHBACK CLUSTER](https://docs.pingcap.com/zh/tidb/stable/sql-statement-flashback-cluster.md): TiDB 数据库中 FLASHBACK CLUSTER 的使用概况。
+- [FLASHBACK DATABASE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-flashback-database.md): TiDB 数据库中 FLASHBACK DATABASE 的使用概况。
+- [FLASHBACK TABLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-flashback-table.md): TiDB 4.0 引入了 `FLASHBACK TABLE` 语法，可在 GC 生命周期内恢复被 `DROP` 或 `TRUNCATE` 删除的表和数据。使用系统变量 `tidb_gc_life_time` 配置历史版本保留时间，默认为 `10m0s`。查询当前`safePoint`：`SELECT * FROM mysql.tidb WHERE variable_name = 'tikv_gc_safe_point'`。注意，过了 GC 生命周期就无法恢复被删除的数据。
+- [FLUSH PRIVILEGES](https://docs.pingcap.com/zh/tidb/stable/sql-statement-flush-privileges.md): TiDB 数据库中 FLUSH PRIVILEGES 的使用概况。
+- [FLUSH STATUS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-flush-status.md): TiDB 数据库中 FLUSH STATUS 的使用概况。
+- [FLUSH TABLES](https://docs.pingcap.com/zh/tidb/stable/sql-statement-flush-tables.md): TiDB 数据库中 FLUSH TABLES 的使用概况。
+- [Follower Read](https://docs.pingcap.com/zh/tidb/stable/dev-guide-use-follower-read.md): 使用 Follower Read 在特定情况下加速查询。
+- [Follower Read](https://docs.pingcap.com/zh/tidb/stable/follower-read.md): 了解 Follower Read 的使用与实现。
+- [GBK](https://docs.pingcap.com/zh/tidb/stable/character-set-gbk.md): 本文介绍 TiDB 对 GBK 字符集的支持情况。
+- [GC 机制简介](https://docs.pingcap.com/zh/tidb/stable/garbage-collection-overview.md): TiDB 的事务实现采用了 MVCC 机制，GC 的任务是清理不再需要的旧数据。整体流程包括 GC leader 控制 GC 的运行，定期触发 GC，以及三个步骤：Resolve Locks 清理锁，Delete Ranges 删除区间，Do GC 进行 GC 清理。Resolve Locks 清理锁有两种执行模式：LEGACY 和 PHYSICAL。Delete Ranges 删除区间会快速物理删除待删除的区间及删除操作的时间戳。Do GC 进行 GC 清理会删除所有 key 的过期版本。GC 每 10 分钟触发一次，默认保留最近 10 分钟内的数据。
+- [GC 配置](https://docs.pingcap.com/zh/tidb/stable/garbage-collection-configuration.md): TiDB 的 GC 配置可以通过系统变量进行设置，包括启用 GC、运行间隔、数据保留时限、并发线程数量等。此外，TiDB 还支持 GC 流控，可以限制每秒数据写入量。从 TiDB 5.0 版本开始，建议使用系统变量进行配置，避免异常行为。在 TiDB 6.1.0 版本引入了新的系统变量 `tidb_gc_max_wait_time`，用于控制活跃事务阻塞 GC safe point 推进的最长时间。另外，GC in Compaction Filter 机制可以通过配置文件或在线配置开启，但可能会影响 TiKV 扫描性能。
+- [Gitpod](https://docs.pingcap.com/zh/tidb/stable/dev-guide-playground-gitpod.md): Gitpod 是一个开源 Kubernetes 应用程序，可在浏览器中获得完整的开发环境，并立即编写代码。它能够为云中的每个任务提供全新的自动化开发环境，无需本地配置。Gitpod 提供了完整的、自动化的、预配置的云原生开发环境，让你可以直接在浏览器中开发、运行、测试代码。
+- [GRANT <privileges>](https://docs.pingcap.com/zh/tidb/stable/sql-statement-grant-privileges.md): TiDB 数据库中 GRANT <privileges> 的使用概况。
+- [GRANT <role>](https://docs.pingcap.com/zh/tidb/stable/sql-statement-grant-role.md): TiDB 数据库中 GRANT <role> 的使用概况。
+- [GROUP BY 修饰符](https://docs.pingcap.com/zh/tidb/stable/group-by-modifier.md): 了解如何使用 TiDB GROUP BY 修饰符。
+- [GROUP BY 聚合函数](https://docs.pingcap.com/zh/tidb/stable/aggregate-group-by-functions.md): TiDB支持的聚合函数包括 COUNT、COUNT(DISTINCT)、SUM、AVG、MAX、MIN、GROUP_CONCAT、VARIANCE、VAR_POP、STD、STDDEV、VAR_SAMP、STDDEV_SAMP 和 JSON_OBJECTAGG。除了 GROUP_CONCAT 和 APPROX_PERCENTILE 外，这些聚合函数可以作为窗口函数使用。另外，TiDB 的 GROUP BY 子句支持 WITH ROLLUP 修饰符，还支持 SQL 模式 ONLY_FULL_GROUP_BY。与 MySQL 的区别在于 TiDB 对标准 SQL 有一些扩展，允许在 HAVING 子句中使用别名和非列表达式。
+- [HAProxy 在 TiDB 中的最佳实践](https://docs.pingcap.com/zh/tidb/stable/haproxy-best-practices.md): HAProxy 是 TiDB 中实现负载均衡的最佳实践。它提供 TCP 协议下的负载均衡能力，通过连接 HAProxy 提供的浮动 IP 对数据进行操作，实现 TiDB Server 层的负载均衡。HAProxy 提供高可用性、负载均衡、健康检查、会话保持、SSL 支持和监控统计等核心功能。部署 HAProxy 需要满足一定的硬件和软件要求，配置和启动 HAProxy 后即可实现数据库负载均衡。
+- [HTAP 快速上手指南](https://docs.pingcap.com/zh/tidb/stable/quick-start-with-htap.md): 本文介绍如何快速上手体验 TiDB 的 HTAP 功能。
+- [HTAP 查询](https://docs.pingcap.com/zh/tidb/stable/dev-guide-hybrid-oltp-and-olap-queries.md): 介绍 TiDB 中的 HTAP 查询功能。
+- [HTAP 深入探索指南](https://docs.pingcap.com/zh/tidb/stable/explore-htap.md): 本文介绍如何深入探索并使用 TiDB 的 HTAP 功能。
+- [IMPORT INTO](https://docs.pingcap.com/zh/tidb/stable/sql-statement-import-into.md): TiDB 数据库中 IMPORT INTO 的使用概况。
+- [IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-compatibility-and-scenarios.md): 了解 IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性及使用场景。
+- [IMPORT INTO 和 TiDB Lightning 对比](https://docs.pingcap.com/zh/tidb/stable/import-into-vs-tidb-lightning.md): 了解 `IMPORT INTO` 和 TiDB Lightning 的差异。
+- [Information Schema](https://docs.pingcap.com/zh/tidb/stable/information-schema.md): Information Schema 是一种查看系统元数据的 ANSI 标准方法。TiDB 提供了许多自定义的 `INFORMATION_SCHEMA` 表，包括与 MySQL 兼容的表和 TiDB 中的扩展表。这些表提供了关于字符集、排序规则、列、存储引擎、索引、表大小、慢查询等信息，帮助用户进行系统监控和优化。
+- [INSERT](https://docs.pingcap.com/zh/tidb/stable/sql-statement-insert.md): TiDB 数据库中 INSERT 的使用概况。
+- [INSPECTION_RESULT](https://docs.pingcap.com/zh/tidb/stable/information-schema-inspection-result.md): 了解 TiDB 系统表 `INSPECTION_RESULT`。
+- [INSPECTION_RULES](https://docs.pingcap.com/zh/tidb/stable/information-schema-inspection-rules.md): 了解 information_schema 表 `INSPECTION_RULES`。
+- [INSPECTION_SUMMARY](https://docs.pingcap.com/zh/tidb/stable/information-schema-inspection-summary.md): 了解 TiDB 系统表 `INSPECTION_SUMMARY`。
+- [Join Reorder 算法简介](https://docs.pingcap.com/zh/tidb/stable/join-reorder.md): Join Reorder 算法决定了多表 Join 的顺序，影响执行效率。TiDB 中有贪心算法和动态规划算法两种实现。贪心算法选择行数最小的表与其他表做 Join，直到所有节点完成 Join。动态规划算法枚举所有可能的 Join 顺序，选择最优的。算法受系统变量控制，且存在一些限制，如无法保证一定选到合适的 Join 顺序。
+- [JSON 函数](https://docs.pingcap.com/zh/tidb/stable/json-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分 JSON 函数。
+- [JSON 效用函数](https://docs.pingcap.com/zh/tidb/stable/json-functions-utility.md): 了解 JSON 效用函数。
+- [JSON 数据类型](https://docs.pingcap.com/zh/tidb/stable/data-type-json.md): JSON 类型存储半结构化数据，使用 Binary 格式序列化，加快查询和解析速度。JSON 字段不能创建索引，但可以对 JSON 文档中的子字段创建索引。TiDB 仅支持下推部分 JSON 函数到 TiFlash，不建议使用 BR 恢复包含 JSON 列的数据到 v6.3.0 之前的 TiDB 集群。请勿同步非标准 JSON 类型的数据。MySQL 误标记二进制类型数据为 STRING 类型，TiDB 保持正确的二进制类型。ENUM 或 SET 数据类型转换为 JSON 时，TiDB 会检查格式正确性。TiDB 支持使用 ORDER BY 对 JSON Array 或 JSON Object 进行排序。在 INSERT JSON 列时，TiDB 会将值隐式转换为 JSON。
+- [KEY_COLUMN_USAGE](https://docs.pingcap.com/zh/tidb/stable/information-schema-key-column-usage.md): 了解 information_schema 表 `KEY_COLUMN_USAGE`。
+- [KEYWORDS](https://docs.pingcap.com/zh/tidb/stable/information-schema-keywords.md): 了解 INFORMATION_SCHEMA 表 `KEYWORDS`。
+- [KILL](https://docs.pingcap.com/zh/tidb/stable/sql-statement-kill.md): TiDB 数据库中 KILL 的使用概况。
+- [Load Base Split](https://docs.pingcap.com/zh/tidb/stable/configure-load-base-split.md): 介绍 Load Base Split 功能。
+- [LOAD DATA](https://docs.pingcap.com/zh/tidb/stable/sql-statement-load-data.md): TiDB 数据库中 LOAD DATA 的使用概况。
+- [LOAD STATS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-load-stats.md): TiDB 数据库中 LOAD STATS 的使用概况。
+- [LOCK STATS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-lock-stats.md): TiDB 数据库中 LOCK STATS 的使用概况。
+- [LOCK TABLES 和 UNLOCK TABLES](https://docs.pingcap.com/zh/tidb/stable/sql-statement-lock-tables-and-unlock-tables.md): TiDB 数据库中 LOCK TABLES 和 UNLOCK TABLES 的使用概况。
+- [Max/Min 函数消除规则](https://docs.pingcap.com/zh/tidb/stable/max-min-eliminate.md): SQL 中的 max/min 函数消除规则能够将 max/min 聚合函数转换为 TopN 算子，利用索引进行查询。当只有一个 max/min 函数时，会重写为 select max(a) from (select a from t where a is not null order by a desc limit 1) t，利用索引只扫描一行数据。存在多个 max/min 函数时，会先检查列是否有索引能够保序，然后重写为两个子查询的笛卡尔积，最终避免对整个表的扫描。
+- [MEMORY_USAGE](https://docs.pingcap.com/zh/tidb/stable/information-schema-memory-usage.md): 了解 information_schema 表 `MEMORY_USAGE`。
+- [MEMORY_USAGE_OPS_HISTORY](https://docs.pingcap.com/zh/tidb/stable/information-schema-memory-usage-ops-history.md): 了解 information_schema 表 `MEMORY_USAGE_OPS_HISTORY`。
+- [Metrics Schema](https://docs.pingcap.com/zh/tidb/stable/metrics-schema.md): 了解 TiDB `METRICS SCHEMA` 系统数据库。
+- [METRICS_SUMMARY](https://docs.pingcap.com/zh/tidb/stable/information-schema-metrics-summary.md): 了解 TiDB 系统表 `METRICS_SUMMARY`。
+- [METRICS_TABLES](https://docs.pingcap.com/zh/tidb/stable/information-schema-metrics-tables.md): 了解 TiDB 系统表 `METRICS_TABLES`。
+- [MODIFY COLUMN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-modify-column.md): TiDB 数据库中 MODIFY COLUMN 的使用概况。
+- [mysql Schema](https://docs.pingcap.com/zh/tidb/stable/mysql-schema.md): 了解 TiDB 系统表。
+- [mysql.tidb_mdl_view](https://docs.pingcap.com/zh/tidb/stable/mysql-schema-tidb-mdl-view.md): 了解 `mysql` schema 中的 `tidb_mdl_view` 视图。
+- [mysql.user](https://docs.pingcap.com/zh/tidb/stable/mysql-schema-user.md): 了解 `mysql` 系统表 `user`。
+- [OLTP 负载性能优化实践](https://docs.pingcap.com/zh/tidb/stable/performance-tuning-practices.md): 本文档介绍了如何对 OLTP 负载进行性能分析和优化。
+- [Online Unsafe Recovery 使用文档](https://docs.pingcap.com/zh/tidb/stable/online-unsafe-recovery.md): 如何使用 Online Unsafe Recovery。
+- [Optimizer Fix Controls](https://docs.pingcap.com/zh/tidb/stable/optimizer-fix-controls.md): 了解 Optimizer Fix Controls 以及如何使用 `tidb_opt_fix_control` 细粒度地控制 TiDB 优化器的行为。
+- [Optimizer Hints](https://docs.pingcap.com/zh/tidb/stable/optimizer-hints.md): 介绍 TiDB 中 Optimizer Hints 的语法和不同生效范围的 Hint 的使用方法。
+- [Oracle 与 TiDB 函数和语法差异对照](https://docs.pingcap.com/zh/tidb/stable/oracle-functions-to-tidb.md): 了解 Oracle 与 TiDB 函数和语法差异对照。
+- [Overview 面板重要监控指标详解](https://docs.pingcap.com/zh/tidb/stable/grafana-overview-dashboard.md): TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview。重要监控指标包括服务在线节点数量、PD 角色、存储容量、Region 数量、TiDB 执行数量、CPU 使用率、内存大小、网络流量等。详细监控说明可参见文章。
+- [Partitioned Raft KV](https://docs.pingcap.com/zh/tidb/stable/partitioned-raft-kv.md): 了解 TiKV 的 Partitioned Raft KV 特性。
+- [PARTITIONS](https://docs.pingcap.com/zh/tidb/stable/information-schema-partitions.md): 了解 INFORMATION_SCHEMA 表 `PARTITIONS`。
+- [PD Control 使用说明](https://docs.pingcap.com/zh/tidb/stable/pd-control.md): PD Control 是 PD 的命令行工具，用于获取集群状态信息和调整集群。
+- [PD Recover 使用文档](https://docs.pingcap.com/zh/tidb/stable/pd-recover.md): PD Recover 是用于恢复无法正常启动或服务的 PD 集群的工具。安装方式包括从源代码编译和下载 TiDB 工具包。恢复集群的方式有两种：从存活的 PD 节点重建和完全重建。从存活的 PD 节点重建集群需要停止所有节点，启动存活的 PD 节点，并使用 pd-recover 修复元数据。完全重建 PD 集群需要获取 Cluster ID 和已分配 ID，部署新的 PD 集群，使用 pd-recover 修复，然后重启整个集群。
+- [PD 微服务](https://docs.pingcap.com/zh/tidb/stable/pd-microservices.md): 介绍如何开启 PD 微服务模式，以提高服务质量。
+- [PD 微服务部署拓扑](https://docs.pingcap.com/zh/tidb/stable/pd-microservices-deployment-topology.md): 了解在部署最小拓扑集群的基础上，部署 PD 微服务的拓扑结构。
+- [PD 调度策略最佳实践](https://docs.pingcap.com/zh/tidb/stable/pd-scheduling-best-practices.md): 了解 PD 调度策略的最佳实践和调优方式
+- [PD 配置参数](https://docs.pingcap.com/zh/tidb/stable/command-line-flags-for-pd-configuration.md): PD 配置参数可以通过命令行参数或环境变量配置。包括外部访问 PD 的 URL 列表，其他 PD 节点访问某个 PD 节点的 URL 列表，PD 监听的客户端 URL 列表，PD 节点监听其他 PD 节点的 URL 列表，配置文件，PD 存储数据路径，初始化 PD 集群配置，动态加入 PD 集群，Log 级别，Log 文件，是否开启日志切割，当前 PD 的名字，CA 文件路径，包含 X509 证书的 PEM 文件路径，包含 X509 key 的 PEM 文件路径，指定 Prometheus Pushgateway 的地址，强制使用当前节点创建新的集群，输出版本信息并退出。
+- [PD 配置文件描述](https://docs.pingcap.com/zh/tidb/stable/pd-configuration-file.md): PD 配置文件包含了许多参数，如节点名称、数据路径、客户端 URL、广告客户端 URL、节点 URL 等。还包括了一些实验性特性的配置项，如内存限制、GC 触发阈值、GOGC Tuner 等。此外，还有监控、调度、副本、标签、Dashboard、同步模式和资源控制等相关配置项。
+- [PD 重要监控指标详解](https://docs.pingcap.com/zh/tidb/stable/grafana-pd-dashboard.md): PD 重要监控指标详解：使用 TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构参见 [TiDB 监控框架概述]。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。通过观察 PD 面板上的 Metrics，可以了解 PD 当前的状态。监控包括 PD role、Storage capacity、Current storage size、Current storage usage、Normal stores、Number of Regions、Abnormal stores、Region health、Current peer count 等。Cluster、Operator、Statistics - Balance、Statistics - hot write、Statistics - hot read、Scheduler、gRPC、etcd、TiDB、Heartbeat、Region storage 等指标也很重要。
+- [Performance Overview 面板重要监控指标详解](https://docs.pingcap.com/zh/tidb/stable/grafana-performance-overview-dashboard.md): 本文介绍 Performance Overview 面板上监控指标的含义。
+- [Performance Schema](https://docs.pingcap.com/zh/tidb/stable/performance-schema.md): 了解 TiDB `performance_schema` 系统数据库。
+- [PingCAP Clinic 快速上手指南](https://docs.pingcap.com/zh/tidb/stable/quick-start-with-clinic.md): 了解如何使用 PingCAP Clinic 诊断服务快速采集、上传、查看集群诊断数据。
+- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/zh/tidb/stable/clinic-data-instruction-for-tiup.md): 详细说明 PingCAP Clinic 诊断服务在使用 TiUP 部署的 TiDB 集群和 DM 集群中能够采集哪些诊断数据。
+- [PingCAP Clinic 诊断服务简介](https://docs.pingcap.com/zh/tidb/stable/clinic-introduction.md): 介绍 PingCAP Clinic 诊断服务，包括工具组件、使用场景和工作原理。
+- [Pipelined DML](https://docs.pingcap.com/zh/tidb/stable/pipelined-dml.md): 介绍 Pipelined DML 的使用场景、使用方法、使用限制和使用该功能的常见问题。Pipelined DML 增强了 TiDB 批量处理的能力，使得事务大小不再受到 TiDB 内存限制。
+- [Placement Rules in SQL](https://docs.pingcap.com/zh/tidb/stable/placement-rules-in-sql.md): 了解如何通过 SQL 接口调度表和分区的放置位置。
+- [Placement Rules 使用文档](https://docs.pingcap.com/zh/tidb/stable/configure-placement-rules.md): 如何配置 Placement Rules
+- [PLACEMENT_POLICIES](https://docs.pingcap.com/zh/tidb/stable/information-schema-placement-policies.md): 了解 information_schema 表 `PLACEMENT_POLICIES`。
+- [PREPARE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-prepare.md): TiDB 数据库中 PREPARE 的使用概况。
+- [Prepare 语句执行计划缓存](https://docs.pingcap.com/zh/tidb/stable/sql-prepared-plan-cache.md): Prepare 语句执行计划缓存功能默认打开，可通过变量启用或关闭。缓存功能仅针对 Prepare/Execute 请求，对普通查询无效。缓存功能会有一定内存开销，可通过监控查看内存使用情况。可手动清空计划缓存，但不支持一次性清空整个集群的计划缓存。忽略 COM_STMT_CLOSE 指令和 DEALLOCATE PREPARE 语句，可解决计划被立即清理的问题。监控 Queries Using Plan Cache OPS 和 Plan Cache Miss OPS，以确保 SQL 执行计划缓存正常工作。Prepared Statement Count 图表显示非零值，表示应用使用了预处理语句。
+- [PROCESSLIST](https://docs.pingcap.com/zh/tidb/stable/information-schema-processlist.md): 了解 information_schema 表 `PROCESSLIST`。
+- [ProxySQL 集成指南](https://docs.pingcap.com/zh/tidb/stable/dev-guide-proxysql-integration.md): 了解如何将本地部署的 TiDB 或 TiDB Cloud 集群与 ProxySQL 集成。
+- [QUERY WATCH](https://docs.pingcap.com/zh/tidb/stable/sql-statement-query-watch.md): TiDB 数据库中 QUERY WATCH 的使用概况。
+- [RECOVER TABLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-recover-table.md): RECOVER TABLE 是用来恢复被删除的表及其数据的功能。在 DROP TABLE 后，在 GC life time 时间内，可以使用 RECOVER TABLE 语句来恢复被删除的表以及其数据。如果删除表后并过了 GC lifetime，就不能再用 RECOVER TABLE 来恢复被删除的表了。
+- [REFERENTIAL_CONSTRAINTS](https://docs.pingcap.com/zh/tidb/stable/information-schema-referential-constraints.md): 了解 INFORMATION_SCHEMA 表 `REFERENTIAL_CONSTRAINTS`。
+- [Region 性能调优](https://docs.pingcap.com/zh/tidb/stable/tune-region-performance.md): 了解如何通过调整 Region 大小等方法对 Region 进行性能调优以及如何在大 Region 下使用 bucket 进行并发查询优化。
+- [RENAME INDEX](https://docs.pingcap.com/zh/tidb/stable/sql-statement-rename-index.md): TiDB 数据库中 RENAME INDEX 的使用概况。
+- [RENAME TABLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-rename-table.md): TiDB 数据库中 RENAME TABLE 的使用概况。
+- [RENAME USER](https://docs.pingcap.com/zh/tidb/stable/sql-statement-rename-user.md): TiDB 数据库中 RENAME USER 的使用概况。
+- [REPLACE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-replace.md): TiDB 数据库中 REPLACE 的使用概况。
+- [RESOURCE_GROUPS](https://docs.pingcap.com/zh/tidb/stable/information-schema-resource-groups.md): 了解 information_schema 表 `RESOURCE_GROUPS`。
+- [RESTORE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-restore.md): TiDB 数据库中 RESTORE 的使用概况。
+- [REVOKE <privileges>](https://docs.pingcap.com/zh/tidb/stable/sql-statement-revoke-privileges.md): TiDB 数据库中 REVOKE <privileges> 的使用概况。
+- [REVOKE <role>](https://docs.pingcap.com/zh/tidb/stable/sql-statement-revoke-role.md): TiDB 数据库中 REVOKE <role> 的使用概况。
+- [RocksDB 简介](https://docs.pingcap.com/zh/tidb/stable/rocksdb-overview.md): RocksDB 是 Facebook 基于 LevelDB 开发的 LSM-tree 架构引擎，提供键值存储与读写功能。数据先写入磁盘上的 WAL，再写入内存中的跳表。内存数据达到阈值后刷到磁盘生成 SST 文件，分为多层，90% 数据存储在最后一层。RocksDB 允许创建多个 ColumnFamily，共享同一个 WAL 文件。为提高读取性能，文件按大小切分成 block，存在 BlockCache 中。后台线程执行 MemTable 转化为 SST 文件和合并操作。L0 文件数量过多会触发 WriteStall 阻塞写入。
+- [ROLLBACK](https://docs.pingcap.com/zh/tidb/stable/sql-statement-rollback.md): TiDB 数据库中 ROLLBACK 的使用概况。
+- [RUNAWAY_WATCHES](https://docs.pingcap.com/zh/tidb/stable/information-schema-runaway-watches.md): 了解 INFORMATION_SCHEMA 表 `RUNAWAY_WATCHES`。
+- [Runtime Filter](https://docs.pingcap.com/zh/tidb/stable/runtime-filter.md): 介绍 Runtime Filter 的原理及使用方式。
+- [SaaS 多租户场景最佳实践](https://docs.pingcap.com/zh/tidb/stable/saas-best-practices.md): 介绍 TiDB 在 SaaS (Software as a service) 多租户场景的最佳实践，特别适用于单集群表数量超过百万级别的场景。
+- [SAVEPOINT](https://docs.pingcap.com/zh/tidb/stable/sql-statement-savepoint.md): TiDB 数据库中 SAVEPOINT 的使用概况。
 - [Scale A Tidb Cluster](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/scale-a-tidb-cluster): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/scale-a-tidb-cluster
-- [Scheduling 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-scheduling-configuration.md): Scheduling 配置参数可以通过命令行参数或环境变量配置。
-- [Scheduling 配置文件描述](https://docs.pingcap.com/tidb/stable/scheduling-configuration-file.md): Scheduling 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
-- [Schema 对象名](https://docs.pingcap.com/tidb/stable/schema-object-names.md): 本文介绍 TiDB SQL 语句中的模式对象名。
-- [Schema 缓存](https://docs.pingcap.com/tidb/stable/schema-cache.md): TiDB 对于 schema 信息采用基于 LRU 的缓存机制，在大量数据库和表的场景下能够显著减少 schema 信息的内存占用以及提高性能。
-- [schema_unused_indexes](https://docs.pingcap.com/tidb/stable/sys-schema-unused-indexes.md): 了解 TiDB `sys` 系统数据库中的 `schema_unused_indexes` 表。
-- [SCHEMATA](https://docs.pingcap.com/tidb/stable/information-schema-schemata.md): 了解 information_schema 表 `SCHEMATA`。
-- [SELECT](https://docs.pingcap.com/tidb/stable/sql-statement-select.md): TiDB 数据库中 SELECT 的使用概况。
-- [SEQUENCES](https://docs.pingcap.com/tidb/stable/information-schema-sequences.md): 了解 INFORMATION_SCHEMA 表 `SEQUENCES`。
-- [SESSION_CONNECT_ATTRS](https://docs.pingcap.com/tidb/stable/performance-schema-session-connect-attrs.md): 了解 performance_schema 表 `SESSION_CONNECT_ATTRS`。
-- [SESSION_VARIABLES](https://docs.pingcap.com/tidb/stable/information-schema-session-variables.md): 了解 INFORMATION_SCHEMA 表 `SESSION_VARIABLES`。
-- [SET [GLOBAL|SESSION] <variable>](https://docs.pingcap.com/tidb/stable/sql-statement-set-variable.md): TiDB 数据库中 SET [GLOBAL|SESSION] <variable> 的使用概况。
-- [SET [NAMES|CHARACTER SET]](https://docs.pingcap.com/tidb/stable/sql-statement-set-names.md): TiDB 数据库中 SET [NAMES|CHARACTER SET] 的使用概况。
-- [SET DEFAULT ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-set-default-role.md): TiDB 数据库中 SET DEFAULT ROLE 的使用概况。
-- [SET PASSWORD](https://docs.pingcap.com/tidb/stable/sql-statement-set-password.md): TiDB 数据库中 SET PASSWORD 的使用概况。
-- [SET RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-set-resource-group.md): TiDB 数据库中 SET RESOURCE GROUP 的使用概况。
-- [SET ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-set-role.md): TiDB 数据库中 SET ROLE 的使用概况。
-- [SET TRANSACTION](https://docs.pingcap.com/tidb/stable/sql-statement-set-transaction.md): TiDB 数据库中 SET TRANSACTION 的使用概况。
-- [SHARD_ROW_ID_BITS](https://docs.pingcap.com/tidb/stable/shard-row-id-bits.md): 介绍 TiDB 的 `SHARD_ROW_ID_BITS` 表属性。
-- [SHOW [BACKUPS|RESTORES]](https://docs.pingcap.com/tidb/stable/sql-statement-show-backups.md): TiDB 数据库中 SHOW [BACKUPS|RESTORES] 的使用概况。
-- [SHOW [FULL] COLUMNS FROM](https://docs.pingcap.com/tidb/stable/sql-statement-show-columns-from.md): TiDB 数据库中 SHOW [FULL] COLUMNS FROM 的使用概况。
-- [SHOW [FULL] FIELDS FROM](https://docs.pingcap.com/tidb/stable/sql-statement-show-fields-from.md): TiDB 数据库中 SHOW [FULL] FIELDS FROM 的使用概况。
-- [SHOW [FULL] PROCESSLIST](https://docs.pingcap.com/tidb/stable/sql-statement-show-processlist.md): TiDB 数据库中 SHOW [FULL] PROCESSLIST 的使用概况。
-- [SHOW [FULL] TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-show-tables.md): TiDB 数据库中 SHOW [FULL] TABLES 的使用概况。
-- [SHOW [GLOBAL|SESSION] BINDINGS](https://docs.pingcap.com/tidb/stable/sql-statement-show-bindings.md): TiDB 数据库中 SHOW [GLOBAL|SESSION] BINDINGS 的使用概况。
-- [SHOW [GLOBAL|SESSION] STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-status.md): TiDB 数据库中 SHOW [GLOBAL|SESSION] STATUS 的使用概况。
-- [SHOW [GLOBAL|SESSION] VARIABLES](https://docs.pingcap.com/tidb/stable/sql-statement-show-variables.md): TiDB 数据库中 SHOW [GLOBAL|SESSION] VARIABLES 的使用概况。
-- [SHOW ANALYZE STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-analyze-status.md): TiDB 数据库中 SHOW ANALYZE STATUS 的使用概况。
-- [SHOW BUILTINS](https://docs.pingcap.com/tidb/stable/sql-statement-show-builtins.md): TiDB 数据库中 SHOW BUILTINS 的使用概况。
-- [SHOW CHARACTER SET](https://docs.pingcap.com/tidb/stable/sql-statement-show-character-set.md): TiDB 数据库中 SHOW CHARACTER SET 的使用概况。
-- [SHOW COLLATION](https://docs.pingcap.com/tidb/stable/sql-statement-show-collation.md): TiDB 数据库中 SHOW COLLATION 的使用概况。
-- [SHOW COLUMN_STATS_USAGE](https://docs.pingcap.com/tidb/stable/sql-statement-show-column-stats-usage.md): TiDB 数据库中 SHOW COLUMN_STATS_USAGE 的使用概况。
-- [SHOW CONFIG](https://docs.pingcap.com/tidb/stable/sql-statement-show-config.md): TiDB 数据库中 SHOW CONFIG 的使用概况。
-- [SHOW CREATE DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-database.md): TiDB 数据库中 SHOW CREATE DATABASE 的使用概况。
-- [SHOW CREATE PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-placement-policy.md): TiDB 数据库中 SHOW CREATE PLACEMENT POLICY 的使用概况。
-- [SHOW CREATE RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-resource-group.md): TiDB 数据库中 SHOW CREATE RESOURCE GROUP 的使用概况。
-- [SHOW CREATE SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-sequence.md): TiDB 数据库中 SHOW CREATE SEQUENCE 的使用概况。
-- [SHOW CREATE TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-table.md): TiDB 数据库中 SHOW CREATE TABLE 的使用概况。
-- [SHOW CREATE USER](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-user.md): TiDB 数据库中 SHOW CREATE USER 的使用概况。
-- [SHOW DATABASES](https://docs.pingcap.com/tidb/stable/sql-statement-show-databases.md): TiDB 数据库中 SHOW DATABASES 的使用概况。
-- [SHOW ENGINES](https://docs.pingcap.com/tidb/stable/sql-statement-show-engines.md): TiDB 数据库中 SHOW ENGINES 的使用概况。
-- [SHOW ERRORS](https://docs.pingcap.com/tidb/stable/sql-statement-show-errors.md): TiDB 数据库中 SHOW ERRORS 的使用概况。
-- [SHOW GRANTS](https://docs.pingcap.com/tidb/stable/sql-statement-show-grants.md): TiDB 数据库中 SHOW GRANTS 的使用概况。
-- [SHOW IMPORT](https://docs.pingcap.com/tidb/stable/sql-statement-show-import-job.md): TiDB 数据库中 SHOW IMPORT 的使用概况。
-- [SHOW INDEXES [FROM|IN]](https://docs.pingcap.com/tidb/stable/sql-statement-show-indexes.md): TiDB 数据库中 SHOW INDEXES [FROM|IN] 的使用概况。
-- [SHOW MASTER STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-master-status.md): TiDB 数据库中 SHOW MASTER STATUS 的使用概况。
-- [SHOW PLACEMENT](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement.md): TiDB 数据库中 SHOW PLACEMENT 的使用概况。
-- [SHOW PLACEMENT FOR](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-for.md): TiDB 数据库中 SHOW PLACEMENT FOR 的使用概况。
-- [SHOW PLACEMENT LABELS](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-labels.md): TiDB 数据库中 SHOW PLACEMENT LABELS 的使用概况。
-- [SHOW PLUGINS](https://docs.pingcap.com/tidb/stable/sql-statement-show-plugins.md): TiDB 数据库中 SHOW PLUGINS 的使用概况。
-- [SHOW PRIVILEGES](https://docs.pingcap.com/tidb/stable/sql-statement-show-privileges.md): TiDB 数据库中 SHOW PRIVILEGES 的使用概况。
-- [SHOW PROFILES](https://docs.pingcap.com/tidb/stable/sql-statement-show-profiles.md): TiDB 数据库中 SHOW PROFILES 的使用概况。
-- [SHOW SCHEMAS](https://docs.pingcap.com/tidb/stable/sql-statement-show-schemas.md): TiDB 数据库中 SHOW SCHEMAS 的使用概况。
-- [SHOW STATS_BUCKETS](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-buckets.md): TiDB 数据库中 SHOW STATS_BUCKETS 的使用概况。
-- [SHOW STATS_HEALTHY](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-healthy.md): TiDB 数据库中 SHOW STATS_HEALTHY 的使用概况。
-- [SHOW STATS_HISTOGRAMS](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-histograms.md): TiDB 数据库中 SHOW STATS_HISTOGRAMS 语句的简单说明。
-- [SHOW STATS_LOCKED](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-locked.md): TiDB 数据库中 SHOW STATS_LOCKED 的使用概况。
-- [SHOW STATS_META](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-meta.md): TiDB 数据库中 SHOW STATS_META 语句的简单说明。
-- [SHOW STATS_TOPN](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-topn.md): TiDB 数据库中 SHOW STATS_TOPN 的使用概况。
-- [SHOW TABLE NEXT_ROW_ID](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-next-rowid.md): TiDB 数据库中 SHOW TABLE NEXT_ROW_ID 的使用概况。
-- [SHOW TABLE REGIONS](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-regions.md): 了解如何使用 TiDB 数据库中的 SHOW TABLE REGIONS。
-- [SHOW TABLE STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-status.md): TiDB 数据库中 SHOW TABLE STATUS 的使用概况。
-- [SHOW WARNINGS](https://docs.pingcap.com/tidb/stable/sql-statement-show-warnings.md): TiDB 数据库中 SHOW WARNINGS 的使用概况。
-- [SHUTDOWN](https://docs.pingcap.com/tidb/stable/sql-statement-shutdown.md): TiDB 数据库中 SHUTDOWN 的使用概况。
-- [SLOW_QUERY](https://docs.pingcap.com/tidb/stable/information-schema-slow-query.md): 了解 INFORMATION_SCHEMA 表 `SLOW_QUERY`。
-- [Split Region 使用文档](https://docs.pingcap.com/tidb/stable/sql-statement-split-region.md): TiDB 中的 Split Region 功能可以解决表数据超过默认 Region 大小限制后的热点问题。预切分 Region 可以根据指定的参数，预先为某个表切分出多个 Region，并打散到各个 TiKV 上去。使用 `SPLIT` 语句可以实现均匀切分和不均匀切分，返回结果包括新增预切分的 Region 数量和打散完成的比率。需要注意 `tidb_wait_split_region_finish` 和 `tidb_wait_split_region_timeout` 会影响 `SPLIT` 语句的行为。
-- [SQL 优化流程简介](https://docs.pingcap.com/tidb/stable/sql-optimization-concepts.md): TiDB 中的 SQL 优化流程包括查询文本解析、逻辑等价变化和最终执行计划生成。经过 parser 解析和合法性验证后，TiDB 会对查询进行逻辑上的等价变化，使得查询在逻辑执行计划上更易处理。之后根据数据分布和执行开销生成最终执行计划。同时，TiDB 在执行 PREPARE 语句时可以选择开启缓存来降低执行计划生成的开销。
-- [SQL 基本操作](https://docs.pingcap.com/tidb/stable/basic-sql-operations.md): TiDB 是一个兼容 MySQL 的数据库，可以执行 DDL、DML、DQL 和 DCL 操作。可以使用 SHOW DATABASES 查看数据库列表，使用 CREATE DATABASE 创建数据库，使用 DROP DATABASE 删除数据库。使用 CREATE TABLE 创建表，使用 SHOW CREATE TABLE 查看建表语句，使用 DROP TABLE 删除表。使用 CREATE INDEX 创建索引，使用 SHOW INDEX 查看表内所有索引，使用 DROP INDEX 删除索引。使用 INSERT 向表内插入记录，使用 UPDATE 修改记录，使用 DELETE 删除记录。使用 SELECT 检索表内数据，使用 WHERE 子句进行筛选。使用 CREATE USER 创建用户，使用 GRANT 授权用户，使用 DROP USER 删除用户。
-- [SQL 开发规范](https://docs.pingcap.com/tidb/stable/dev-guide-sql-development-specification.md): TiDB 的 SQL 开发规范。
-- [SQL 性能调优](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql.md): 介绍 TiDB 的 SQL 性能调优方案和分析办法。
-- [SQL 性能调优](https://docs.pingcap.com/tidb/stable/sql-tuning-overview.md): SQL 性能调优是重要的，TiDB 会优化 SQL 语句的执行，以最省时的方式返回结果。这个过程类似于 GPS 导航，利用统计信息和实时交通信息规划最佳路线。了解 TiDB 执行计划、SQL 优化流程和控制执行计划可以帮助提高查询性能。
-- [SQL 或事务问题](https://docs.pingcap.com/tidb/stable/dev-guide-troubleshoot-overview.md): 学习诊断在应用开发过程中可能产生的 SQL 或事务问题的方法。
-- [SQL 操作常见问题](https://docs.pingcap.com/tidb/stable/sql-faq.md): 介绍 SQL 操作相关的常见问题。
-- [SQL 模式](https://docs.pingcap.com/tidb/stable/sql-mode.md): TiDB 服务器采用不同 SQL 模式来操作，可以使用 `SET [SESSION | GLOBAL] sql_mode='modes'` 语句设置 SQL 模式。`GLOBAL` 级别的 SQL 模式需要 `SUPER` 权限，影响新连接；`SESSION` 级别的 SQL 模式只影响当前客户端。重要的 sql_mode 值包括 `ANSI`、`STRICT_TRANS_TABLES` 和 `TRADITIONAL`。SQL mode 列表包括 `PIPES_AS_CONCAT`、`ANSI_QUOTES`、`IGNORE_SPACE`、`ONLY_FULL_GROUP_BY` 等。
-- [SQL 诊断](https://docs.pingcap.com/tidb/stable/information-schema-sql-diagnostics.md): 了解 SQL 诊断功能。
-- [SQL 语句概述](https://docs.pingcap.com/tidb/stable/sql-statement-overview.md): 介绍 TiDB 支持的 SQL 语句。
-- [Stale Read](https://docs.pingcap.com/tidb/stable/dev-guide-use-stale-read.md): 使用 Stale Read 在特定情况下加速查询。
-- [Stale Read 功能的使用场景](https://docs.pingcap.com/tidb/stable/stale-read.md): 介绍 Stale Read 功能和使用场景。
-- [START TRANSACTION](https://docs.pingcap.com/tidb/stable/sql-statement-start-transaction.md): TiDB 数据库中 START TRANSACTION 的使用概况。
-- [Statement Summary Tables](https://docs.pingcap.com/tidb/stable/statement-summary-tables.md): MySQL 的 `performance_schema` 提供了 `statement summary tables`，用于监控和统计 SQL 性能。TiDB 在 `information_schema` 中提供了类似功能的系统表，包括 `statements_summary`、`statements_summary_history`、`cluster_statements_summary` 和 `cluster_statements_summary_history`。这些表用于保存 SQL 监控指标聚合后的结果，帮助用户定位 SQL 问题。同时，还提供了参数配置来控制 statement summary 的功能，如清空周期、保存历史的数量等。
-- [STATISTICS](https://docs.pingcap.com/tidb/stable/information-schema-statistics.md): 了解 information_schema 表 `STATISTICS`。
-- [Storage sink 消费程序开发指引](https://docs.pingcap.com/tidb/stable/ticdc-storage-consumer-dev-guide.md): 了解如何设计与实现一个消费程序来消费 storage sink 中的变更数据。
-- [Store Limit](https://docs.pingcap.com/tidb/stable/configure-store-limit.md): 介绍 Store Limit 功能。
-- [sync-diff-inspector 用户文档](https://docs.pingcap.com/tidb/stable/sync-diff-inspector-overview.md): sync-diff-inspector 是一个用于校验 MySQL/TiDB 中数据一致性的工具，提供修复数据的功能。它支持对比表结构和数据，生成用于修复数据的 SQL 语句。需要注意的是，在校验数据时会消耗一定的服务器资源，需要避免在业务高峰期间校验。生成的 SQL 文件仅作为修复数据的参考，需要确认后再执行这些 SQL 修复数据。
-- [sys Schema](https://docs.pingcap.com/tidb/stable/sys-schema.md): 了解 TiDB `sys` 系统数据库。
-- [TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-table.md): TiDB 数据库中 TABLE 语句的使用概况。
-- [TABLE_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-table-constraints.md): 了解 information_schema 表 `TABLE_CONSTRAINTS`。
-- [TABLE_STORAGE_STATS](https://docs.pingcap.com/tidb/stable/information-schema-table-storage-stats.md): 了解 INFORMATION_SCHEMA 表 `TABLE_STORAGE_STATS`。
-- [TABLES](https://docs.pingcap.com/tidb/stable/information-schema-tables.md): 了解 information_schema 表 `TABLES`。
-- [TiCDC Avro Protocol](https://docs.pingcap.com/tidb/stable/ticdc-avro-protocol.md): 了解 TiCDC Avro Protocol 的概念和使用方法。
-- [TiCDC Canal-JSON Protocol](https://docs.pingcap.com/tidb/stable/ticdc-canal-json.md): 了解 TiCDC Canal-JSON Protocol 的概念和使用方法。
-- [TiCDC Changefeed 命令行参数和配置参数](https://docs.pingcap.com/tidb/stable/ticdc-changefeed-config.md): 了解 TiCDC Changefeed 详细的命令行参数和配置文件定义。
-- [TiCDC CSV Protocol](https://docs.pingcap.com/tidb/stable/ticdc-csv.md): 了解 TiCDC CSV Protocol 的概念和使用方法。
-- [TiCDC Debezium Protocol](https://docs.pingcap.com/tidb/stable/ticdc-debezium.md): 了解 TiCDC Debezium Protocol 的概念和使用方法。
-- [TiCDC Open Protocol](https://docs.pingcap.com/tidb/stable/ticdc-open-protocol.md): 了解 TiCDC Open Protocol 的概念和使用方法。
-- [TiCDC OpenAPI v1](https://docs.pingcap.com/tidb/stable/ticdc-open-api.md): 了解如何使用 OpenAPI 接口来管理集群状态和数据同步。
-- [TiCDC OpenAPI v2](https://docs.pingcap.com/tidb/stable/ticdc-open-api-v2.md): 了解如何使用 OpenAPI v2 接口来管理集群状态和数据同步。
-- [TiCDC Server 配置](https://docs.pingcap.com/tidb/stable/ticdc-server-config.md): 了解 TiCDC 详细的命令行参数和配置文件定义。
-- [TiCDC Simple Protocol](https://docs.pingcap.com/tidb/stable/ticdc-simple-protocol.md): 本文介绍了 TiCDC Simple Protocol 的使用方法和数据格式实现。
-- [TiCDC 兼容性](https://docs.pingcap.com/tidb/stable/ticdc-compatibility.md): 了解 TiCDC 兼容性相关限制和问题处理。
-- [TiCDC 单行数据正确性校验](https://docs.pingcap.com/tidb/stable/ticdc-integrity-check.md): 介绍 TiCDC 数据正确性校验功能的实现原理和使用方法。
-- [TiCDC 双向复制](https://docs.pingcap.com/tidb/stable/ticdc-bidirectional-replication.md): 了解 TiCDC 双向复制的使用方法。
-- [TiCDC 基本监控指标](https://docs.pingcap.com/tidb/stable/ticdc-summary-monitor.md): 了解 TiCDC 基本的监控指标。
-- [TiCDC 安装部署与集群运维](https://docs.pingcap.com/tidb/stable/deploy-ticdc.md): 了解 TiCDC 软硬件环境要求以及如何安装部署和运维 TiCDC 集群。
-- [TiCDC 客户端鉴权](https://docs.pingcap.com/tidb/stable/ticdc-client-authentication.md): 介绍使用 TiCDC 命令行工具或通过 OpenAPI 访问 TiCDC 时，如何进行客户端鉴权。
-- [TiCDC 常见问题解答](https://docs.pingcap.com/tidb/stable/ticdc-faq.md): 了解 TiCDC 相关的常见问题。
-- [TiCDC 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/ticdc-performance-tuning-methods.md): 本文介绍了 Performance Overview 面板中的 TiCDC 部分，帮助你了解和监控 TiCDC 工作负载。
-- [TiCDC 拆分 UPDATE 事件行为说明](https://docs.pingcap.com/tidb/stable/ticdc-split-update-behavior.md): 介绍 TiCDC changefeed 拆分 UPDATE 事件的行为变更，说明变更原因以及影响范围。
-- [TiCDC 故障处理](https://docs.pingcap.com/tidb/stable/troubleshoot-ticdc.md): 了解如何解决使用 TiCDC 时经常遇到的问题。
-- [TiCDC 术语表](https://docs.pingcap.com/tidb/stable/ticdc-glossary.md): 了解 TiCDC 相关的术语及定义。
-- [TiCDC 架构设计与原理](https://docs.pingcap.com/tidb/stable/ticdc-architecture.md): 了解 TiCDC 软件的架构设计和运行原理。
-- [TiCDC 简介](https://docs.pingcap.com/tidb/stable/ticdc-overview.md): TiCDC 是一款 TiDB 增量数据同步工具，适用于多 TiDB 集群的高可用和容灾方案，以及实时同步变更数据到异构系统。其主要特性包括数据容灾复制、双向复制、低延迟的增量数据同步能力等。TiCDC 架构包括 TiKV Server、TiCDC 和 PD，支持将数据同步到 TiDB、MySQL 数据库、Kafka 以及存储服务。目前暂不支持单独使用 RawKV 的 TiKV 集群，创建 SEQUENCE 的 DDL 操作和在同步过程中对 TiCDC 正在同步的表和库进行 BR 数据恢复和 TiDB Lightning 导入。
-- [TiCDC 详细监控指标](https://docs.pingcap.com/tidb/stable/monitor-ticdc.md): 了解 TiCDC 详细的监控指标。
-- [TiCDC 部署拓扑](https://docs.pingcap.com/tidb/stable/ticdc-deployment-topology.md): 介绍 TiCDC 部署 TiDB 集群的拓扑结构。
-- [TiCDC 集群监控报警规则](https://docs.pingcap.com/tidb/stable/ticdc-alert-rules.md): 了解 TiCDC 集群监控报警规则以及处理方法。
-- [TiDB 1.0 release notes](https://docs.pingcap.com/tidb/stable/release-1.0-ga.md): TiDB 1.0 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 优化了 SQL 查询优化器、内部数据格式、MySQL 兼容性，并支持 `NO_SQL_CACHE` 语法。PD 支持基于读流量的热点调度和设置 Store 权重。TiKV 支持更多下推函数和手动触发数据 Compact。TiSpark Beta 版本支持可配置框架和 ThriftSever/JDBC 和 Spark SQL 脚本入口。感谢参与项目的企业和团队，以及提供出色开源软件/服务的组织/个人。
-- [TiDB 1.1 Alpha Release Notes](https://docs.pingcap.com/tidb/stable/release-1.1-alpha.md): TiDB 1.1 Alpha 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。包括 SQL parser 兼容更多语法，SQL 查询优化器优化统计信息、代价估算，使用 `Count-Min Sketch` 更精确地估算点查的代价，SQL 执行器重构执行器算子，优化 `INSERT IGNORE` 语句性能，下推更多类型和函数，支持更多 `SQL_MODE`，优化 `Load Data` 性能，支持对物理算子内存使用进行统计。PD 增加更多 API，支持 TLS，调度适应不同的 Region size，修复调度 bug。TiKV 支持 Raft learner，优化 Raft Snapshot，支持 TLS，优化 RocksDB 配置，优化 Coprocessor 性能，增加 Failpoint 和稳定性测试 case，解决 PD 和 TiKV 重连问题，增强数据恢复工具功能，Region 支持按 table 分裂，支持 `Delete Range` 功能，支持设置 snapshot 导致的 I/O 上限，完善流控机制。
-- [TiDB 1.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-1.1-beta.md): TiDB 1.1 Beta 版本在 MySQL 兼容性和系统稳定性方面有多项改进。TiDB 新增监控项和优化日志，兼容更多 MySQL 语法，支持显示建表时间，加快查询速度，控制 Join 产生的中间结果集大小，修复多项问题，优化 SQL 引擎查询性能。PD 新增调试接口和 metrics，提高 TiKV 宕机时数据恢复优先级和恢复速度，优化 Region heartbeat 性能，修复热点调度问题。TiKV 消除潜在的 GC 问题，支持批量 resolve lock 和并行 GC，使用 RocksDB compaction listener 更新 Region Size，设置 Raft snapshot max size，支持更多修复操作，优化有序流式聚合操作，完善 metrics，修复 bug。
-- [TiDB 2.0 RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.1.md): TiDB 2.0 RC1 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持限制单条 SQL 语句内存使用，下推流式聚合算子到 TiKV，配置文件合法性检测，HTTP API 获取参数信息。Parser 兼容更多 MySQL 语法，提升对 Navicat 的兼容性。优化器提升，提取多个 OR 条件的公共表达式，选取更优执行计划。PD 优化检查 Region 状态的代码逻辑，异常情况下日志信息输出，修复监控中 TiKV 节点磁盘空间不足统计。TiKV 修复 PD leader 切换 gRPC call 问题，增加获取 metrics 的 gRPC API，启动时检查是否使用 SSD，使用 ReadPool 优化读性能。
-- [TiDB 2.0 RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.3.md): TiDB 2.0 RC3 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 修复了 MAX/MIN 结果错误、Sort Merge Join 排序问题、uint 和 int 比较错误等。PD 支持 Region Merge 和忽略有大量 pending peer 的节点。TiKV 支持 Region Merge、Raft snapshot 通知 PD 加速调度、增加 Raw DeleteRange API 等。
-- [TiDB 2.0 RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.4.md): TiDB 2.0 RC4 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持了一些新的语法和修复了一些问题。PD 支持手动 split Region 和优化了 metrics 及代码结构。TiKV 限制了接收 snapshot 时的内存使用，支持导数据模式和改善了在被隔离的情况下的输出问题。
-- [TiDB 2.0 RC5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.5.md): TiDB 2.0 RC5 版本发布，对 MySQL 兼容性、系统稳定性和优化器做了很多改进。TiDB 修复了多个问题，并优化了性能。PD 添加了 Raft Learner 支持，优化了 Balance Region Scheduler，并修复了多个问题。TiKV 支持了更多功能，并解决了多个问题。
-- [TiDB 2.0 release notes](https://docs.pingcap.com/tidb/stable/release-2.0-ga.md): TiDB 2.0 GA 版本发布，对 MySQL 兼容性、系统稳定性、优化器和执行器做了很多改进。包括 SQL 优化器、SQL 执行引擎、Server、兼容性、DDL、PD、TiKV 和 TiSpark 的功能、性能和稳定性优化。
-- [TiDB 2.0.1 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.1.md): TiDB 2.0.1 版本对 MySQL 兼容性和系统稳定性做出了改进。TiDB 新增了实时更新 `Add Index` 进度到 DDL 任务信息中的功能，添加了 Session 变量 `tidb_auto_analyze_ratio` 控制统计信息自动更新阈值的功能。修复了事务提交失败时可能未清理所有残留状态的问题，以及其他 Bug 和兼容性问题。PD 新增了 `Scatter Range` 调度和 learner 相关的 metrics，修复了多个问题。TiKV 修复了多个问题，优化了慢查询的日志，减少了 `thread_yield` 的调用次数。
-- [TiDB 2.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.10.md): TiDB 2.0.10 版本发布，修复了系统兼容性和稳定性问题。包括取消 DDL 任务可能导致的问题，ORDER BY 和 UNION 语句无法引用带表名的列的问题，UNCOMPRESS 函数错误输入长度的问题等。PD 修复了 RaftCluster 退出时可能的死锁问题，TiKV 修复了迁移 Leader 到新节点时造成请求延时问题和多余的 Region 心跳问题。
-- [TiDB 2.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.11.md): TiDB 2.0.11 版本发布，对系统兼容性和稳定性做出改进。修复了多个问题，包括 PD 异常处理问题、Rename 行为问题、ADMIN CHECK TABLE 误报问题、前缀索引错误问题和添加列导致 UPDATE 语句 panic 问题。TiKV 修复了两个 Region merge 相关问题。
-- [TiDB 2.0.2 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.2.md): TiDB 2.0.2 版本发布，改进了系统稳定性。TiDB 修复了 Decimal 除法内置函数下推的问题，支持 `Delete` 语句中使用 `USE INDEX` 的语法，禁止在带有 `Auto-Increment` 的列中使用 `shard_row_id_bits` 特性，并增加了写入 Binlog 的超时机制。PD 使 balance leader scheduler 过滤失连节点，更改 transfer leader operator 的超时时间为 10 秒，修复 label scheduler 在集群 Regions 不健康状态下不调度的问题，修复 evict leader scheduler 调度不当的问题。TiKV 修复了 Raft 日志没有打出来的问题，支持配置更多 gRPC 相关参数，支持配置选举超时的取值范围，修复过期 learner 没有删掉的问题，修复 snapshot 中间文件被误删的问题。
-- [TiDB 2.0.3 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.3.md): TiDB 2.0.3 版本在 2.0.2 版的基础上做出了改进，包括系统兼容性和稳定性的改进。TiDB 支持在线更改日志级别和 `COM_CHANGE_USER` 命令，优化查询条件代价估算和修复多个问题。PD 修复了特定条件下的问题，TiKV 修复了错误上报和除数为 0 的问题。
-- [TiDB 2.0.4 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.4.md): TiDB 2.0.4 版本发布，改进了系统兼容性和稳定性。TiDB 支持了新的语法和变量设置，优化了监控项和查询代价估计精度。PD 改进了调度参数行为，TiKV 新增了调试接口和命令，优化了问题和修复了崩溃。
-- [TiDB 2.0.5 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.5.md): TiDB 2.0.5 版本发布，改进了系统兼容性和稳定性。新增系统变量 `tidb_disable_txn_auto_retry`，调整计算 `Selection` 代价的方式，优化查询条件匹配唯一索引或主键，修复多个 bug。PD 修复副本迁移导致 TiKV 磁盘空间耗尽和 `AdjacentRegionScheduler` 导致的崩溃问题。TiKV 修复 decimal 运算中的溢出和 merge 过程中的脏读问题。
-- [TiDB 2.0.6 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.6.md): TiDB 2.0.6 版本在系统兼容性和稳定性方面有所改进。包括日志长度精简、记录 ADD INDEX 执行过程中的慢操作、减少更新统计信息操作中的事务冲突等。此外，修复了多个 bug，包括 DROP USER 语句和 MySQL 行为不兼容、tidb_batch_insert 打开后 INSERT/LOAD DATA 语句在某些场景下 OOM 的问题等。TiKV 方面扩大了默认 scheduler slots 值以减少假冲突现象，修复了字符串转 Decimal 时出现的 crash。
-- [TiDB 2.0.7 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.7.md): TiDB 2.0.7 版本在系统兼容性和稳定性方面有改进。TiDB 新增了在 `information_schema` 中添加 `PROCESSLIST` 表的功能。还对语句执行细节进行了改进，并在 `SLOW QUERY` 日志中输出更多信息。修复了多个 bug，包括 `PRIMARY KEY` 为整数的表无法使用 `USE INDEX(PRIMARY)` 的问题，以及 `Merge Join` 和 `Index Join` 在 inner row 为 `NULL` 时输出多余结果的问题。TiKV 方面，空集群默认打开 `dynamic-level-bytes` 参数减少空间放大，并在 Region merge 之后更新 Region 的 `approximate size` 和 keys。
-- [TiDB 2.0.8 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.8.md): TiDB 2.0.8 版本在 2.0.7 版的基础上做出了改进，包括功能改进和 Bug 修复。TiKV 也修复了节点宕机时内存持续上升的问题。
-- [TiDB 2.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.9.md): TiDB 2.0.9 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括统计信息、DDL JOB、Commit 操作、Limit 值、字符集支持、内建函数、主键选择率估算、Session 变量、Union 语句、统计信息清除、事务运行时间、表创建语句、取消 DDL 任务、全局环境变量等。PD 修复了 etcd 启动失败和 pd-ctl 读取 Region key 的问题。TiKV 增加了 kv_scan 接口扫描上界的限制，废弃了 max-tasks-xxx 配置，并修复了 RocksDB CompactFiles 的问题。
-- [TiDB 2.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-beta.md): TiDB 2.1 Beta 版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。SQL 优化器优化了 Index Join 选择范围和关联子查询，下推 Filter 和扩大索引选择范围。SQL 执行引擎实现了并行 Hash Aggregate 和 Project 算子，提高了执行性能。Server 添加了 HTTP API 控制功能和支持 Server side cursor。兼容性方面支持更多 MySQL 语法和 SHOW PRIVILEGES 语句。PD 优化了 Balance Scheduler 和热点调度器，TiKV 升级了 Rust 版本和优化了性能。
-- [TiDB 2.1 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-ga.md): TiDB 2.1 GA 版本发布，对系统稳定性、性能、兼容性、易用性做了大量改进。包括 SQL 优化器、SQL 执行引擎、统计信息、表达式、Server、DDL、兼容性等方面的优化。PD (Placement Driver) 进行了可用性优化、调度器优化、API 及运维工具优化、监控和性能优化。TiKV 进行了 Coprocessor、Transaction、Raftstore、存储引擎和 tikv-ctl 方面的优化。同时支持全量数据快速导入工具 TiDB Lightning。升级兼容性说明包括存储引擎更新不支持回退至 2.0.x 或更旧版本，以及升级前需要确认集群中是否存在正在运行中的 DDL 操作。
-- [TiDB 2.1 RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.1.md): TiDB 2.1 RC1 版本于 2018 年 8 月 24 日发布。该版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、DML、DDL 等方面的改进。PD 方面新增了版本控制机制，支持集群滚动兼容升级等功能。TiKV 方面新增了支持 batch split 等新特性，以及对性能和功能进行了优化和改进。
-- [TiDB 2.1 RC2 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.2.md): TiDB 2.1 RC2 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。具体包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、表达式、DML、DDL、TiKV 和 PD 的新特性、功能改进和 Bug 修复。
-- [TiDB 2.1 RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.3.md): TiDB 2.1 RC3 版本对系统稳定性、兼容性、优化器和执行引擎做了很多改进。包括修复了多个 SQL 优化器和执行引擎的问题，增强了部分执行器的性能，修复了配置文件内存配额选项不生效的问题，支持使用 `admin show slow` 语句来获取 SLOW QUERY LOG，修复了一些兼容性问题，增加了一些内建函数的支持，修复了一些 DML 和 DDL 的问题。PD 新增了获取按大小逆序排序的 Region 列表 API，Region API 返回更详细的信息，修复了 PD 切换 leader 后可能导致 crash 的问题。TiKV 进行了性能优化，并新增了一些函数的支持，同时修复了一些 Bug。
-- [TiDB 2.1 RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.4.md): TiDB 2.1 RC4 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个 SQL 优化器和执行引擎的问题，重构了 Latch，提升了并发事务的执行性能。PD 修复了多个 TiKV 下线后的问题。TiKV 优化了 apply snapshot 导致的 RocksDB Write stall 的问题，并增加了 raftstore tick 相关 metrics。
-- [TiDB 2.1 RC5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.5.md): TiDB 2.1 RC5 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括修复了多个问题，提升了性能，增加了环境变量设置功能。PD 修复了多个问题，TiKV 优化了报错信息和接口限制。
-- [TiDB 2.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.1.md): TiDB 2.1.1 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括时间四舍五入错误、uncompress 函数未检查数据长度、PD 故障获取错误 TSO、不规范语句导致启动失败等。DDL 改变了表的默认字符集和排序规则，增加了控制添加索引速度的变量。PD 修复了配置项无法设置为 0 的问题，避免了 transfer leader 至新创建的 Peer 产生的延迟增加问题。TiKV 也避免了相同的问题。 Lightning 优化了对导入表的 analyze 机制，提升了导入速度。 TiDB Binlog 修复了 pb files 输出 bug。
-- [TiDB 2.1.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.10.md): TiDB 2.1.10 发布，修复了多个 bug 和兼容性问题，增强了安全性。PD 修复了 Leader 优先级不生效的问题。TiKV 修复了多个问题，包括 transfer leader 中可能发生的脏读问题。TiDB Lightning 新增了发送数据到 importer 失败时进行重试的功能。TiDB Binlog 优化了 Pump storage 组件 log。TiDB Ansible 更新了配置文件，新增了 tidb_lightning_ctl 脚本。
-- [TiDB 2.1.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.11.md): TiDB 2.1.11 发布，修复多表 join 删除错误 schema 问题，更新统计信息合并反馈信息，修复函数返回错误字段类型问题，修复时间计算错误问题，修复与 MySQL 8.0 不兼容问题，支持 SHOW OPEN TABLES 语句，修复 goroutine 泄露问题，修复设置 tidb_snapshot 变量时间格式解析出错问题。PD 修复热点 Region 调度问题，新增热点调度优先级配置项。TiKV 修复 leader, learner 读到空 index 问题，处理锁命令放在高优先级线程池中。TiDB Binlog 新增 GC 删数据限速功能。TiDB Ansible 新增 Drainer 参数。
-- [TiDB 2.1.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.12.md): TiDB 2.1.12 发布，修复了多个 bug，包括类型不匹配导致进程 panic、字符集改变导致类型变化、事务中的 GRANT 误报错误等问题。同时提升了与 MySQL 的兼容性，修复了 TiDB 跟 TiKV 在 gRPC 最大封包设置不一致导致的超大封包报错问题。PD 修复了极端情况下 etcd Leader 选举阻塞的问题，TiKV 修复了 Leader 迁移过程中 Region 不可用的问题和异常掉电导致丢数据的问题。
-- [TiDB 2.1.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.13.md): TiDB 2.1.13 发布，新增了列属性包含 `AUTO_INCREMENT` 时利用 `SHARD_ROW_ID_BITS` 打散行 ID 功能，优化无效 DDL 元信息存活时间，修复了在大并发场景下 OOM 的问题，新增了 `update-stats` 配置项，新增了 3 个 TiDB 特有语法，修复了某些情况下 `KILL` 语句导致的 panic 问题，增强了 `ADD_DATE` 在某些情况下跟 MySQL 的兼容性，修复了 index join 中内表过滤条件在某些情况下的选择率估计错误的问题。TiKV 修复了因迭代器未检查状态导致系统生成残缺 snapshot 的问题，新增了检查 `block-size` 配置的有效性功能。TiDB Binlog 修复了 Pump 因写入失败时未检查返回值导致偏移量错误问题，Drainer 新增了 `advertise-addr` 配置，支持容器环境中使用桥接模式。
-- [TiDB 2.1.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.14.md): TiDB 2.1.14 发布说明：修复查询结果不正确的问题，支持自动调整 Auto ID 分配的步长，新增全局系统变量 `max_execution_time`，修复内存配额超出时返回结果不正确的问题，禁用 `TRACE` 语句，新增系统表控制函数下推，优化 Raftstore 消息处理，调整无效配置项日志级别，新增 Binlog 配置项，修复 Binlog 更新失败问题，新增 Ansible 命令预检查功能。
-- [TiDB 2.1.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.15.md): TiDB 2.1.15 发布，修复了多个函数处理微秒、空值比较、插入参数、索引建立等问题，并新增了多个 SQL 语句和监控项。TiKV 统一日志格式，提高了调度准确度。PD 也统一了日志格式。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修复了导入错误问题。TiDB Ansible 新增监控项用于监测 SQL 语句解析耗时和执行计划编译耗时。
-- [TiDB 2.1.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.16.md): TiDB 2.1.16 发布，修复了 SQL 优化器和执行引擎的多个问题。TiKV 支持逆向 raw_scan 和 raw_batch_scan 接口。TiDB Binlog 和 TiDB Lightning 做了一些功能增强和 bug 修复。TiDB Ansible 也有多个 bug 修复和功能优化。
-- [TiDB 2.1.17 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.17.md): TiDB 2.1.17 发布，新增了 `SHOW TABLE REGIONS` 语法的 `WHERE` 条件子句，以及 TiKV、PD 的 `config-check` 功能。PD 优化调度流程，TiKV 优化启动流程。TiDB 慢日志中的 `start ts` 和 `Index_ids` 字段有改动。SQL 优化器和执行引擎修复了多个问题。DDL 改进了 `SPLIT TABLE` 语法的行为。TiKV 解决了一些问题并新增了 `config-check` 选项。PD 新增了 `config-check` 选项和 `remove-tombstone` 命令。Reparo 新增了配置项，用于控制恢复速率。TiDB Ansible 更新了 Spark 版本和修复了连接等待问题。
-- [TiDB 2.1.18 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.18.md): TiDB 2.1.18 发布，修复了多项 SQL 优化器和执行引擎的问题，改进了 Server、DDL 和 Monitor 功能，同时 TiDB Ansible 也有多项更新。
-- [TiDB 2.1.19 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.19.md): TiDB 2.1.19 发布，包含了对 SQL 优化器、SQL 执行引擎、Server、DDL、TiKV、PD 和 TiDB Ansible 的多项修复和优化。修复了多个查询和更新语句中可能出现的错误，提升了系统稳定性和性能。
-- [TiDB 2.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.2.md): TiDB 2.1.2 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括索引 panic、优化器执行计划、字符集检查和时间类型字段错误。PD 修复了 Region Merge 相关问题，TiKV 支持日为时间单位的配置格式，并解决了配置兼容性问题，修复了 Approximate Size Split 和两个 Region merge 相关问题。TiDB Lightning 支持最小 TiDB 集群版本为 2.1.0，修复了解析 JSON 类型数据文件内容出错和使用 checkpoint 重启后的错误。TiDB Binlog 消除了往 Kafka 写数据的瓶颈点，支持写 Kafka 版本的 TiDB Binlog。
-- [TiDB 2.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.3.md): TiDB 2.1.3 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个问题，包括 Prepared Plan Cache panic、Range 计算错误、统计信息溢出、Generated Column 在 Update 中 Panic 等。还支持了一些新特性，如对 `_tidb_rowid` 构造查询的 Range、`CASE` 子句返回 JSON 类型等。PD 修复了 Leader 选举相关的 Watch 问题，TiKV 支持了使用 HTTP 方式获取监控信息，并修复了一些问题。TiDB Binlog 也修复了一些启动或重启时的问题。
-- [TiDB 2.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.4.md): TiDB 2.1.4 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个函数处理结果不正确的问题，优化了服务器日志和 DDL 操作。TiKV 修复了关闭时可能发生重复写的问题和事件监听器处理异常的问题。工具方面优化了内存使用，减少了对 dump 文件的解析，提高了导入稳定性。数据同步对比统计支持使用 TiDB 统计信息来划分 chunk。
-- [TiDB 2.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.5.md): TiDB 2.1.5 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括优化器 / 执行器、Server、DDL、PD、TiKV 和 Tools 的改进和修复。
-- [TiDB 2.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.6.md): TiDB 2.1.6 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括索引扫描选择问题、聚合函数兼容性问题、变量设置导致的 Panic 问题等。TiKV 修复了解析 protobuf 失败导致的错误。Lightning 修复了多个导入相关的问题，并支持 CSV 格式。
-- [TiDB 2.1.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.7.md): TiDB 2.1.7 发布，修复了 DDL 取消导致升级程序启动时间变长的问题，提升了内置函数的兼容性，新增了系统表管理 Table 与 Index 之间的关系，支持在 DO 语句中使用子查询，修复了对 JSON 数据的聚合函数在计算过程中 Panic 的问题。PD 修改副本数为 1 时 balance-region 无法迁移 leader 的问题。Tools 支持 binlog 同步 generated column。TiDB Ansible 将 Prometheus 监控数据默认保留时间改成 30d。
-- [TiDB 2.1.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.8.md): TiDB 2.1.8 发布，修复了多个函数和语句的兼容性问题，优化了日志格式规范和统计信息估算准确性。PD 和 TiKV 也有多项修复和优化。工具方面，Lightning 和 Binlog Pump 等新增了多项配置和性能优化。TiDB Ansible 修改了操作系统版本限制和滚动升级版本限制。
-- [TiDB 2.1.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.9.md): TiDB 2.1.9 发布，修复了多个函数和权限检查问题，支持指定 collation 为 utf8mb4_0900_ai_ci，改进了慢日志输出和 PD 服务支持。 TiKV 修复了在 transfer leader 时的问题。 TiDB Binlog 和 TiDB Lightning 也有多个修复和改进。 TiDB Ansible 更新了文档链接和移除了一个参数。
-- [TiDB 3.0 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0-beta.md): TiDB 3.0 Beta 版本发布，新增支持 View、窗口函数、Range 分区、Hash 分区等特性。SQL 优化器做了很多改进，包括重新支持聚合消除、优化 `NOT EXISTS` 子查询、支持 Index Join 等。SQL 执行引擎优化了 Merge Join 算子、日志打印等功能。权限管理增加了对 `ANALYZE`、`USE`、`SET GLOBAL`、`SHOW PROCESSLIST` 语句的权限检查。Server 支持了 `Trace` 功能、插件框架、`unix_socket` 和 TCP 连接等功能。兼容性方面支持了 `ALLOW_INVALID_DATES` SQL mode、load data 对 CSV 文件的容错能力等。DDL 支持了快速恢复误删除的表、动态调整 ADD INDEX 的并发数等功能。Tools 方面 TiDB Lightning 大幅优化了 SQL 转 KV 的处理速度。PD 和 TiKV 也做了很多功能增加和优化。
-- [TiDB 3.0 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0-ga.md): TiDB 3.0 GA 版本于 2019 年 6 月 28 日发布，对应的 TiDB Ansible 版本为 3.0.0。V3.0.0 版本相比 V2.1 在稳定性、易用性、性能和新功能方面有重要改进。新增功能包括窗口函数、视图、分区表、插件系统、悲观锁、SQL Plan Management 等。SQL 优化器和执行引擎也有多项优化，包括对 `NOT EXISTS` 子查询、`Outer Join`、`IN` 子查询、Index Join 等的性能提升。PD 新增了从单个节点重建集群的功能，将 Region 元信息从 etcd 移至 go-leveldb 存储引擎。TiKV 新增了分布式 GC、并行 Resolve Lock、多线程 Raftstore 和 Apply 等功能，以及对 Engine、Server、RaftStore 和 Coprocessor 的优化。Tools 方面 TiDB Lightning 新增了多项功能，TiDB Binlog 新增了多项功能，sync-diff-inspector 也新增了多项功能。TiDB Ansible 升级了监控组件版本，新增了多项监控面板和功能。
-- [TiDB 3.0.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-beta.1.md): TiDB 3.0.0 Beta.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、权限管理、Server、DDL、PD、TiKV 和 Tools 的更新。
-- [TiDB 3.0.0-rc.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.1.md): TiDB 3.0.0-rc.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Tools 和 TiDB Ansible 的更新和修复。
-- [TiDB 3.0.0-rc.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.2.md): TiDB 3.0.0-rc.2 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL 和 PD 的更新。TiKV 的更新包括 Engine、Server、Raftstore 和 Coprocessor 的改进。工具方面，TiDB Binlog 增加下游同步延迟监控项，TiDB Lightning 支持数据库合并和新增 KV 写入失败重试机制。
-- [TiDB 3.0.0-rc.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.3.md): TiDB 3.0.0-rc.3 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Transaction、tikv-ctl、Misc 等方面的修复和新增功能。TiDB Ansible 新增预测集群最大 QPS 的监控项。
-- [TiDB 3.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.1.md): TiDB 3.0.1 发布，新增多项功能和修复了多个问题。TiKV 新增了对 Blob 文件大小的统计和死锁检测性能的提升。PD 优化了热点 Region 调度策略和 Region Merge 处理逻辑。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修正了导入错误的问题。TiDB Ansible 新增了预检查功能和更新了监控信息。
-- [TiDB 3.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.10.md): TiDB 3.0.10 发布，修复了多个 bug 和性能问题。TiKV 修复了 Region merge 失败导致系统 Panic 的问题。PD 自动更新 Region 缓存信息，解决缓存失效问题。TiDB Binlog 支持 relay log。TiDB Lightning 优化配置项和修复 web 界面无法打开的问题。TiDB Ansible 修复获取不到 PD Leader 导致命令执行失败的问题，并新增多个监控项。
-- [TiDB 3.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.11.md): TiDB 3.0.11 发布，包含兼容性变化、新功能和 Bug 修复。新增配置项 `max-index-length` 控制索引最大长度，显示分区表的分区元信息，以及 TiDB 集群之间数据双向复制功能。Bug 修复包括查询结果不正确、Goroutine 泄露等问题。TiKV 也进行了日志输出优化和问题修复。TiDB Ansible 修复了失效文档链接和未定义变量问题。
-- [TiDB 3.0.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.12.md): TiDB 3.0.12 发布日期为 2020 年 3 月 16 日。该版本存在一些已知问题，建议使用最新版本。兼容性变化包括修复慢日志中记录 prewrite binlog 时间计时不准确的问题。新功能包括动态加载已被替换的证书文件，添加配置项，限流功能，以及在 binlog 写入失败时 TiDB 退出。Bug 修复包括保证原子性，悲观锁加锁问题修复，建索引长度超过限制时的报错信息显示，FROM_UNIXTIME 函数小数点位数不正确的问题修复，以及其他问题的修复。
-- [TiDB 3.0.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.13.md): TiDB 3.0.13 发布日期为 2020 年 04 月 22 日。此版本修复了 TiDB 和 TiKV 中的一些 bug。其中 TiDB 修复了由于未检查 `MemBuffer`，事务内执行 `INSERT ... ON DUPLICATE KEY UPDATE` 语句插入多行重复数据可能出错的问题。TiKV 修复了重复多次执行 `Region Merge` 导致系统被阻塞的问题，阻塞期间服务不可用。
-- [TiDB 3.0.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.14.md): TiDB 3.0.14 发布日期为 2020 年 5 月 9 日。该版本兼容性变化包括 `performance_schema` 和 `metrics_schema` 由读写改为只读。重点修复的 Bug 包括 join 条件在 handle 列上存在多个等值条件时，index join 查询结果错误等问题。新功能包括 `admin show ddl jobs` 查询结果中添加库名和表名列等功能。Bug 修复包括 `WEEKEND` 函数在 SQL mode 为 `ALLOW_INVALID_DATES` 时结果与 MySQL 不兼容等问题。TiKV 也有相关 Bug 修复，如节点隔离恢复之后无法被正确删掉等问题。
-- [TiDB 3.0.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.15.md): TiDB 3.0.15 发布，新增禁止分区表查询使用 plan cache 功能、支持 admin recover index、admin check index 语句、优化统计信息 CMSketch 的内存分配机制等功能。PD 新增按照 Leader 个数调度的策略。修复了多处 Bug，包括 Hash 聚合函数中的深拷贝方式、点查整数溢出处理逻辑、CHAR() 函数查询条件处理逻辑等问题。TiKV 修复了长时间运行后碎片整理不再有效、系统意外重启后删除 snapshot 文件导致系统 panic、消息包过大导致 gRPC 连接断开的问题。
-- [TiDB 3.0.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.16.md): TiDB 3.0.16 发布，优化了 hash partition pruning 和 Region 设置，修复了多个 Bug，包括锁住的 primary key 造成的结果不一致问题和 JSON 数据中 int 和 float 类型比较的问题。TiKV 也进行了稳定性优化和 Bug 修复。PD 修复了查询 Region 报 404 错误的问题。
-- [TiDB 3.0.17 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.17.md): TiDB 3.0.17 发布，修复了多个 bug，包括查询返回错误和函数处理问题。优化了配置项和 HTTP API 访问速度。TiKV 修复了数据读取和调度问题，新增了配置支持。TiDB Lightning 解决了参数不生效的问题，并新增了更简单易用的过滤规则。
-- [TiDB 3.0.18 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.18.md): TiDB 3.0.18 发布，提升了 TiDB Binlog 工具的细粒度 Pump GC 时间支持。修复了 TiDB 中 Hash 函数对 Decimal 类型的错误处理问题，以及对 Set 和 Enum 类型的错误处理问题。还修复了 Duplicate Key 检测在悲观事务下失效的问题，以及其他执行结果错误的问题。TiKV 将 GC 的失败日志级别改为 Warning。TiDB Lightning 修复了多个命令行参数和使用 TiDB backend 时的问题。
-- [TiDB 3.0.19 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.19.md): TiDB 3.0.19 发布，兼容性变化包括更改 PD 的导入路径和版权信息。提升改进方面，缓解故障恢复对 QPS 的影响，支持调整 `union` 运算符的并发数。Bug 修复包括解决 `slow-log` 文件不存在导致查询出错的问题，添加权限检查命令，修复类型转换问题等。TiKV 修复了 status server 解析响应出错导致 panic 的问题。TiDB Lightning 修复了严格模式下 CSV 中遇到不合法 UTF 字符集没有及时退出进程的问题。
-- [TiDB 3.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.2.md): TiDB 3.0.2 发布日期为 2019 年 8 月 7 日。该版本修复了多个 SQL 优化器和执行引擎的问题，包括修复了查询结果列名称不正确、LIKE 表达式被隐式转换为 0、SHOW 语句中使用子查询等问题。此外，还修复了 TiKV panic、悲观事务下 Insert 行为不正确等问题。PD 也修复了 Scatter Region 调度器不能工作等 bug。TiDB Ansible 也有多个修复和更新，包括修复了 Disk Performance 监控单位错误、新增了 TiDB Summary Dashboard 等。
-- [TiDB 3.0.20 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.20.md): TiDB 3.0.20 发布，兼容性更改包括废弃 `enable-streaming` 配置项。改进提升包括优化 `LOAD DATA` 语句执行报错信息。Bug 修复包括缓存悲观事务提交状态问题、查询统计信息不准确问题等。TiKV 修复事务删除 key 报错问题，PD 修复启动时打印过量日志问题。
-- [TiDB 3.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.3.md): TiDB 3.0.3 发布，包含了多项 SQL 优化器和执行引擎的修复，以及 Server、DDL、Monitor、TiKV、PD、Tools 和 TiDB Ansible 的更新和修复。
-- [TiDB 3.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.4.md): TiDB 3.0.4 发布日期为 2019 年 10 月 8 日。此版本新增了系统表 `performance_schema.events_statements_summary_by_digest` 用于排查 SQL 性能问题。同时，TiDB 的 `SHOW TABLE REGIONS` 语法新增了 `WHERE` 条件子句。此外，Reparo 新增了 `worker-count` 和 `txn-batch` 配置项，用于控制恢复速率。还修复了一些问题，如特殊语法 `PRE_SPLIT_REGIONS` 没有使用注释的方式向下游同步的问题。
-- [TiDB 3.0.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.5.md): TiDB 3.0.5 发布，包含 SQL 优化器和执行引擎的多项修复和改进，支持事务 TTL 修改接口函数，以及对 Region Cache TTL 的配置修改。TiKV 新特性包括悲观事务 Cleanup 接口支持和 Raftstore 性能优化。PD 提高了 Region 占用空间的精度和 label 监控可读性。TiDB Binlog 和 TiDB Lightning 也有多项修复和功能增强。TiDB Ansible 更新了监控表达式和配置文件内容。
-- [TiDB 3.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.6.md): TiDB 3.0.6 发布，包含多项 SQL 优化器和执行引擎的修复和优化，以及 Server、DDL、TiKV、PD 和 Tools 的更新和修复。TiKV 修复了悲观锁支持和 GC worker 写入量限制等问题。PD 添加了新维度和降低日志级别。Tools 中 TiDB Binlog 和 TiDB Lightning 也有多项修复和新增配置。
-- [TiDB 3.0.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.7.md): TiDB 3.0.7 发布，修复了多个问题，包括本地时间落后导致锁的 TTL 过大、解析日期时时区不正确、整型数据转换精度丢失等问题。TiKV 也修复了死锁检测和内存泄漏问题。
-- [TiDB 3.0.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.8.md): TiDB 3.0.8 发布，修复了 SQL 优化器、SQL 执行引擎、DDL、Server、Transaction、Monitor 等方面的多个问题。TiKV 也进行了多项修复和优化。PD 新增了一些功能，并升级了 etcd 版本。TiDB Ansible 进行了配置项回滚和优化，TiSpark 版本升级到 2.1.8。
-- [TiDB 3.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.9.md): TiDB 3.0.9 发布日期为 2020 年 1 月 14 日。该版本修复了一些已知问题，并提升了性能。包括 Executor 修复了聚合函数作用于枚举和集合列时结果不正确的问题，Server 支持了系统变量 `auto_increment_increment` 和 `auto_increment_offset`，新增了监控项等。TiKV 提升了 Raft 成员变更的速度，新增了监控项用于监控 `waiter` 的生命周期等。PD 新增了一些功能和修复了一些问题。Tools 方面也有一些新增和优化。TiDB Ansible 优化了 Lightning 部署。
-- [TiDB 3.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.md): TiDB 3.1 Beta 发布说明：发版日期为 2019 年 12 月 20 日，TiDB 版本为 3.1.0-beta，TiDB Ansible 版本为 3.1.0-beta。TiDB 新增 SQL 优化器和丰富的 SQL hint 功能。另外，TiDB 还支持 Follower Read 功能。TiKV 新增支持分布式备份恢复功能和 Follower Read 功能。PD 也新增支持分布式备份恢复功能。
-- [TiDB 3.1 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.1.md): TiDB 3.1 Beta.1 发布日期为 2020 年 1 月 10 日。TiDB 版本为 3.1.0-beta.1，TiDB Ansible 版本也为 3.1.0-beta.1。TiKV 新增了备份功能和 SST 文件恢复修复。Tools 中 BR 组件修复了备份进度信息不准确的问题，并新增了自动调度 PD schedulers 功能。TiDB Ansible 新增了初始化阶段自动关闭操作系统 THP 的功能和 BR 组件的 Grafana 监控。
-- [TiDB 3.1 Beta.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.2.md): TiDB 3.1 Beta.2 发布日期为 2020 年 3 月 9 日。该版本存在已知问题，建议使用最新版本。兼容性变化包括 TiDB Lightning 配置项优化和新增命令行参数。新功能包括支持在列属性上添加 `AutoRandom` 关键字，新增通过 DDL 语句为表创建、删除列存储副本的功能等。Bug 修复包括修复静默 Region 读数据处理不当导致无法处理读请求的问题等。
-- [TiDB 3.1 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-ga.md): TiDB 3.1 GA 发布说明：兼容性变化包括支持报告状态配置项和 BR 不支持旧版 TiKV 集群恢复。新功能包括展示 coprocessor 任务信息和减少日志冗余信息。PD 优化热点 Region 调度，TiFlash 添加读写负载信息和支持函数下推。TiDB Ansible 新增 TiFlash 监控和优化配置参数。Bug 修复包括修复 merge join 和计算选择率问题。TiKV 修复 replica read 和 restore 问题，TiFlash 修复同步 schema 和数据丢失问题。TiDB Binlog 修复因 TiFlash 相关 DDL job 导致同步中断问题，BR 修复 checksum 和增量备份失败问题。
-- [TiDB 3.1 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-rc.md): TiDB 3.1 RC 发布日期为 2020 年 4 月 2 日。该版本存在已知问题，建议使用最新版本 3.1.x。新功能包括性能提升、数据恢复、TLS 证书动态更新等。Bug 修复包括信息 schema 错误、DDL 卡住、冲突检测失效等。PD 修复了数据竞争、规则未遵守等问题。工具方面优化了性能、修复了数据错误和无法恢复的问题。
-- [TiDB 3.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.1.md): TiDB 3.1.1 发布，新增了 auto_rand_base 表选项和 Feature ID 注释。TiFlash 优化了读写负载相关图表和 chunk encode decimal 数据的流程。修复了隔离读设置不生效、hash 分区表上的分区选择语法报错、update sql 中包含 view 仍然报错等问题。TiFlash 修复了非 normal 状态时读取数据错误、表名映射方式支持 recover table/flashback table、数据存储路径问题、读模型优化和特殊字符导致无法启动的问题。BR 修复了恢复带有 auto_random 属性的表后插入数据触发 duplicate entry 错误的问题。
-- [TiDB 3.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.2.md): TiDB 3.1.2 发布日期为 2020 年 6 月 4 日。此版本修复了 TiKV 和 Tools 中的一些错误，包括 S3 和 GCS 备份恢复时的错误处理问题，备份过程中的 DefaultNotFound 错误，以及 BR 在备份恢复到 S3 和 GCS 存储时的稳定性提升等问题。同时还修复了 BR 在恢复数据时出现的一些错误，并增加了备份恢复 S3 时的 AWS KMS 服务端加密支持。
-- [TiDB 4.0 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.md): TiDB 4.0 Beta 发布说明：TiDB 版本 4.0.0-beta 和 TiDB Ansible 版本 4.0.0-beta 已发布。更新内容包括性能优化、新功能支持、bug 修复等。详细信息请查阅官方发布说明。
-- [TiDB 4.0 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0-ga.md): TiDB 4.0 GA 发布日期为 2020 年 5 月 28 日。该版本包含兼容性变化、重点修复的 Bug、新功能、Bug 修复等内容。其中 TiDB 新增了多项配置项和语法支持，TiFlash 修复了多项功能不一致的问题，TiKV 修复了多个备份和系统 panic 相关的问题，PD 修复了删除调度器和 presplit 功能无法正常使用的问题，Tools 中 BR 修复了从云存储恢复数据失败的问题，TiCDC 修复了多个系统 panic 和资源泄露的问题。
-- [TiDB 4.0 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.md): TiDB 4.0 RC 发布日期为 2020 年 4 月 8 日，版本为 4.0.0-rc，TiUP 版本为 0.0.3。该版本存在已知问题，建议使用最新版本 4.0.x。兼容性变化包括 TiDB、TiKV 和 Tools 的更新。重点修复了 TiDB 的 Bug，并新增了一些功能。TiKV 修复了启用 Follower Read 功能导致系统 Panic 的问题。Tools 中 TiDB Lightning 修复了字符转换错误导致数据错误的问题，TiCDC 新增了一些功能。
-- [TiDB 4.0 RC.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.1.md): TiDB 4.0 RC.1 发布说明：TiDB 4.0.0-rc.1 版本兼容性变化包括 TiKV 默认关闭 hibernate region，TiDB Binlog 增加对 Sequence DDL 的支持。重点修复了多个 Bug，包括 TiDB 事务内执行 INSERT ... ON DUPLICATE KEY UPDATE 语句插入多行重复数据可能出错的问题等。新增功能包括 TiDB 支持发送 batch coprocessor 请求给 TiFlash 等。Bug 修复包括 TiDB 系统表由于 unsigned 列定义导致无法正确显示负数的问题等。
-- [TiDB 4.0 RC.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.2.md): TiDB 4.0 RC.2 发布说明：兼容性变化包括事务容量上限统一为 10GB，查询 CLUSTER_LOG 表需指定时间范围，CREATE TABLE 创建分区表时指定未支持的选项将创建非分区普通表。重点修复了多个 Bug。新增了备份和恢复语句，支持预检查单个 Region 提交数据量。TiKV 新增了加密存储适配和配置 gRPC 消息大小上限。PD 修复了 pd-ctl 命令错误和缺失监控的问题。TiFlash 优化了系统负载和新增了容量配置参数。Tools 方面修复了多个问题和优化了功能。
-- [TiDB 4.0.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.1.md): TiDB 4.0.0 Beta.1 发布，包含兼容性变化、新功能和 Bug 修复。兼容性变化包括配置项类型修改和默认值调整。新增慢日志系统表支持查询任意时间段的日志，SQL 性能诊断功能和 Sequence 功能。Bug 修复包括视图创建、时区修改和函数表达式问题。TiKV 和 PD 也有新增功能和 Bug 修复。TiDB Ansible 新增部署多个 Grafana/Prometheus/Alertmanager 的功能和 TiFlash 监控 Dashboard。
-- [TiDB 4.0.0 Beta.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.2.md): TiDB 4.0.0 Beta.2 发布日期为 2020 年 3 月 18 日。该版本修复了 TiDB Binlog 在配置 `disable-dispatch`、`disable-causality` 时系统直接报错并退出的问题。新增了 TiKV 和 PD 支持将动态修改配置的结果持久化存储到硬盘的功能。另外，TiDB Binlog 新增了 TiDB 集群之间数据双向复制功能，TiDB Lightning 新增了配置 TLS 功能，新增了 TiCDC 工具，提供了进程级别的高可用能力。此外，BR 开启了增量备份、支持将备份文件存储在 AWS S3 等实验性功能。TiDB Ansible 新增了将节点信息注册到 etcd 的功能，新增支持在 ARM 平台上部署 TiDB 服务的功能。修复了 TiKV、PD 和 Tools 中的多个 bug。
-- [TiDB 4.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.1.md): TiDB 4.0.1 发布日期为 2020 年 6 月 12 日。新功能包括 TiKV 添加 `--advertise-status-addr` 启动参数，PD 支持内部代理和客户端自定义超时设置，TiFlash 支持新的排序规则框架和函数下推，以及 BR 增加集群版本检查。Bug 修复方面，TiKV 修复了多个问题，PD 修复了错误配置和 panic 问题，TiFlash 修复了默认值解析和时区计算错误的问题。
-- [TiDB 4.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.10.md): TiDB 4.0.10 发布日期为 2021 年 1 月 15 日。新功能包括 PD 添加了配置项 `enable-redact-log` 和 TiFlash 添加了配置项 `security.redact_info_log`。改进提升方面，TiDB 添加了 `txn-entry-size-limit` 配置项，PD 优化了 `store-state-filter` 监控，Tools 中 TiCDC 默认开启了 old value 特性。Bug 修复方面，TiDB 修复了多个并发导致的问题，TiKV 修复了 peer 和 ready 之间的错误映射，PD 修复了 ID 分配不是单调递增的问题，TiFlash 修复了多个启动和函数调用的问题，Tools 中 TiCDC 修复了多个协议和内存问题，Dumpling 修改了默认设置的行为。 Backup & Restore (BR) 修复了多个备份和恢复问题，TiDB Binlog 修复了启用 `AMEND TRANSACTION` 特性时的问题，TiDB Lightning 修复了多个备份和使用问题。
-- [TiDB 4.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.11.md): TiDB 4.0.11 发布，新增支持 `uft8_unicode_ci` 和 `utf8mb4_unicode_ci` 排序规则。TiKV 支持 `utf8mb4_unicode_ci` 和 `cast_year_as_time` 排序规则。TiFlash 增加排队处理 Coprocessor 任务的线程池。改进包括重排由 `outer join` 简化的 `inner join` 顺序，Grafana 面板支持多集群，Bug 修复包括修复异常的 `unicode_ci` 常数传递等。PD 修复成员健康的监控显示不正确的问题。TiFlash 修复 Decimal 类型的 `min`/`max` 计算结果错误等。Tools 修复 TiCDC 服务在同时发生 `ErrTaskStatusNotExists` 和 `capture` 会话关闭的情况下的非预期的退出等。
-- [TiDB 4.0.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.12.md): TiDB 4.0.12 发布，新增 TiFlash 工具用于检测状态。优化了 EXPLAIN 语句输出信息，在 metrics 监控中记录了 PREPARE 执行失败的问题。TiKV 修复了多个问题，包括处理 JSON 向字符串转换时空格缺失的问题。PD 修复了 store 缺失 label 的隔离级别错误问题。TiFlash 修复了多个查询结果错误的问题。TiCDC 修复了多个数据丢失和资源释放问题。BR 修复了多个备份和恢复问题。TiDB Lightning 修复了多个数据错误和文件损坏问题。
-- [TiDB 4.0.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.13.md): TiDB 4.0.13 发布，新增 `AUTO_INCREMENT` 变更为 `AUTO_RANDOM` 功能，引入 `infoschema.client_errors_summary` 表。提升内存中统计信息缓存，减少 CPU 使用率。TiKV 提高 `store used size` 计算准确性，返回更多的 Region 以降低 Region miss。PD 优化 TSO 处理时间统计指标，更新 Dashboard 版本。TiFlash 自动清除过期历史数据。BR 支持备份恢复系统库，检查集群版本和备份数据版本。TiCDC 增加流程控制，清理陈旧临时文件，增加 HTTP 接口调用。修复多个 Bug。
-- [TiDB 4.0.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.14.md): TiDB 4.0.14 发布，包含兼容性更改、功能增强、改进提升和 Bug 修复。兼容性更改包括默认值修改和配置项更新。功能增强包括监控项添加和新功能支持。改进提升包括算子优化和系统变量支持。Bug 修复包括查询结果错误和函数参数错误修复。PD、TiDB Dashboard、TiFlash 和 Tools 也有相关更新和修复。
-- [TiDB 4.0.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.15.md): TiDB 4.0.15 发布，修复了执行 `SHOW VARIABLES` 速度慢的问题，以及多个 Bug 和兼容性变化。TiKV 支持动态修改 TiCDC 配置。TiDB 基于直方图的 row count 来触发 auto-analyze。TiKV 分离处理读写的 ready 状态以减少读延迟。PD 提升了同步 Region 信息的性能。BR 支持并发执行分裂和打散 Region 的操作。Dumpling 提升了 `SHOW TABLE STATUS` 的过滤效率。TiCDC 支持导入数据到带有表达式索引或带有基于虚拟生成列的索引的表中。修复了多个 Bug 和问题。
-- [TiDB 4.0.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.16.md): TiDB 4.0.16 发布，包含兼容性更改、提升改进和 Bug 修复。TiKV 改进了对非法 UTF-8 字符串的处理，Tools 中 TiCDC 改变了 Kafka Sink 默认值。TiDB 升级了 Grafana，TiKV 使用 zstd 算法压缩 SST 文件。Bug 修复包括统计信息模块的查询崩溃、`ENUM` 类型控制函数返回结果不正确等问题。TiKV 修复了多个问题，包括 Decimal 除法计算结果为负、监控项中 gRPC 平均延迟时间不准确等问题。PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了无法启动的问题。Tools 中 TiDB Binlog 修复了 Drainer 传输事务超过 1 GB 时退出的问题，TiCDC 修复了多个问题。
-- [TiDB 4.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.2.md): TiDB 4.0.2 发布，兼容性改进和新功能增加。TiDB 默认收集使用情况信息，并分享给 PingCAP 用于改善产品。新增功能包括支持 INSERT 语句中使用 MEMORY_QUOTA() hint，基于 TLS 证书 SAN 属性的登录认证，以及其他函数和表的新增配置项。Bug 修复包括执行计划不正确、运行时错误、内存统计过大等问题。PD、TiKV、TiFlash 和 TiCDC 也有相关改进和修复。Tools 中 Backup & Restore (BR) 提升了多表场景下的恢复数据性能。
-- [TiDB 4.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.3.md): TiDB 4.0.3 发布了新版本，包括 TiDB Dashboard、TiFlash、Tools 和改进提升等多个方面的更新和修复。新增功能包括 TiDB Dashboard 显示详细信息、TiFlash 支持文件加密、Tools 支持多种算法压缩备份文件等。改进提升方面包括增加全局变量控制日志记录、加速执行速度、默认打开执行信息收集等。此外，还修复了多个 Bug，包括 gRPC transportReader 异常、数据不完整、无法正确设置 safepoint 等问题。
-- [TiDB 4.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.4.md): TiDB 4.0.4 发布日期为 2020 年 7 月 31 日。此版本修复了多个 bug，包括查询 `information_schema.columns` 卡死的问题、`PointGet` 和 `BatchPointGet` 在遇到 `in(null)` 条件时出错的问题、`BatchPointGet` 算子结果不正确的问题以及 `HashJoin` 算子在遇到 `set`、`enum` 类型时查询结果不正确的问题。
-- [TiDB 4.0.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.5.md): TiDB 4.0.5 发布，兼容性变化包括修改参数和添加状态检查。新增功能包括为错误定义错误码和支持统一的 log 格式。优化提升包括减少 GC 锁扫描次数和降低统计信息对性能的影响。Bug 修复包括函数错误处理和查询结果错误等。PD 修复了 TSO 不可用和 Region 调度问题。TiFlash 修复了进程启动和升级问题。Tools 修复了恢复缓慢和同步任务问题。
-- [TiDB 4.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.6.md): TiDB 4.0.6 发布日期为 2020 年 9 月 15 日。新功能包括 TiFlash 中支持在广播 Join 中使用外连接，TiDB Dashboard 添加了多个页面和功能。TiCDC 从 v4.0.6 起成为正式功能。优化提升方面，TiDB 提升了分区表的写性能，支持调整 Union 执行算子的并发度等。Bug 修复方面，TiDB 修复了多个查询结果不正确的问题。TiKV 修复了统计信息估算错误的问题等。PD 修复了 store limit 的单位问题等。TiFlash 修复了多个启动失败和异常问题。Tools 方面也有多个问题得到解决。
-- [TiDB 4.0.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.7.md): TiDB 4.0.7 发布，新增 PD 客户端函数 `GetAllMembers` 和 TiDB Dashboard 统计指标关系图支持。TiDB 优化了 `join` 算子执行信息和协处理器缓存命中率信息，支持将 `ROUND` 函数下推至 TiFlash，并修复了多个 bug。TiKV 支持日志输出为 JSON 格式，修复了 TLS 握手失败导致 Status API 不可用的问题。PD 修复了多个问题，TiFlash 修正了 right outer join 结果错误。Backup & Restore (BR) 修复了恢复数据后导致 TiDB 配置变更的错误，Dumpling 修复了 metadata 解析失败的问题。
-- [TiDB 4.0.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.8.md): TiDB 4.0.8 发布，新增聚合函数 `APPROX_PERCENTILE` 和 `CAST` 函数下推支持。优化了索引组合计算表达式选择率的贪心算法，记录更多的 RPC 信息，提升慢查询性能。修复了多个 BUG，如分区表可能遇到非预期 Panic、外连接时 Index Merge Join 结果不正确等。 PD 修复了 TiDB Dashboard 引起 PD panic 的错误。TiFlash 修复了多个问题，如日志信息中时间戳错误、重启后可能提示数据文件损坏等。Backup & Restore (BR) 修复了 Restore 期间可能发生的 `send on closed channel` panic 问题。
-- [TiDB 4.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.9.md): TiDB 4.0.9 发布日期为 2020 年 12 月 21 日。该版本包含兼容性更改、新功能、优化提升、Bug 修复等内容。兼容性更改包括废弃配置文件中的某些配置项。新功能包括 TiFlash 支持存储引擎的新数据分布在多个硬盘上等。优化提升方面包括避免生成 (index) merge join 以得到更好的执行计划等。Bug 修复方面包括修复了前缀索引和 `OR` 条件一起使用时结果不正确的问题等。
-- [TiDB 5.0 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.0-rc.md): TiDB 5.0.0-rc 版本是 5.0 版本的前序版本。在 5.0 版本中，我们专注于帮助企业基于 TiDB 数据库快速构建应用程序，提升数据库性能、降低写入数据延迟、稳定性、可用性、容灾、SQL 语句效率等问题。新增聚簇索引、异步提交事务、Raft Joint Consensus 算法、不可见索引、`EXCEPT`/`INTERSECT` 操作符、悲观事务执行成功概率、字符集和排序规则优化、错误信息和日志信息脱敏、优化器选择索引稳定性、调度功能优化、备份与恢复、数据导入导出、`EXPLAIN` 功能优化、TiUP 增强功能等特性。
-- [TiDB 5.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.1.md): TiDB 5.0.1 发布日期为 2021 年 4 月 24 日。此版本包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括 TiDB 配置文件的默认值改变。改进提升方面，TiDB 支持 `VITESS_HASH()` 函数，TiKV 使用 `zstd` 压缩 Region Snapshot，PD 调整 Region 分数公式等。Bug 修复方面，TiDB 修复了多个查询结果可能错误的问题，TiKV 修复了多个导致问题的 Bug。Tools 方面也有多个 Bug 修复。
-- [TiDB 5.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.2.md): TiDB 5.0.2 发布日期为 2021 年 6 月 10 日。此版本包含兼容性更改、新功能、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具中的参数废弃和 TiKV 默认开启 Hibernate Region 特性。新功能包括 BR 支持 S3 兼容的存储和 TiFlash 优化锁操作。提升改进方面，TiDB 避免后台作业频繁读取表造成高 CPU 使用率，TiKV 添加背压功能和减少扫描的内存使用量。Bug 修复方面，修复了多个问题，包括索引导致的 panic、事务中的语句不正确使用、排序规则写入错误值等。
-- [TiDB 5.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.3.md): TiDB 5.0.3 发布日期为 2021 年 7 月 2 日。此版本包含兼容性更改、功能增强、提升改进和 Bug 修复。兼容性更改包括 `tidb_multi_statement_mode` 变量默认值变更和兼容 MySQL 5.7 的 noop 变量配置。功能增强方面，TiCDC 增加了 HTTP API 获取 changefeed 信息和节点健康信息。TiDB 提升了多个内置函数的支持和优化了聚合算子的代价常数。Bug 修复方面，修复了多个查询和函数使用时可能出现的问题。PD 升级了 TiDB Dashboard。TiFlash 支持了多个新功能和修复了多个问题。TiCDC、BR 和 TiDB Lightning 也进行了多项修复和优化。
-- [TiDB 5.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.4.md): TiDB 5.0.4 发布日期为 2021 年 9 月 27 日。此版本包含兼容性更改、功能增强、提升改进、Bug 修复等内容。兼容性更改包括修复了 `SHOW VARIABLES` 速度慢的问题，系统变量 `tidb_stmt_summary_max_stmt_count` 默认值修改为 `3000` 等。功能增强包括支持将系统变量 `tidb_enforce_mpp` 的值设为 `1` 以忽略优化器代价估算，强制使用 MPP 模式。提升改进包括基于直方图的 row count 来触发 auto-analyze、支持 MPP 查询的重试等。Bug 修复包括修复了查询分区表且分区键带有 `IS NULL` 条件时 TiDB 可能 panic 的问题等。
-- [TiDB 5.0.5 Release Note](https://docs.pingcap.com/tidb/stable/release-5.0.5.md): TiDB 5.0.5 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。详细信息请查看 issue
-- [TiDB 5.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.6.md): TiDB 5.0.6 发布日期为 2021 年 12 月 31 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具的错误输出改为标准错误，以及 Kafka sink 模块的默认值设置。提升改进方面，TiDB 改进了 coprocessor 遇到锁时的调试日志显示，TiKV 提高了插入 SST 文件的速度，PD 优化了调度器退出的速度。Bug 修复方面，TiDB 修复了多个问题，包括乐观事务冲突、MPP 查询相关日志、DML 和 DDL 语句并发执行等。TiKV 修复了多个节点停机导致的问题，PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了多个数据不一致的问题。TiCDC 修复了多个同步任务推进停滞的问题。Backup & Restore (BR) 修复了平均速度不准确的问题。Dumpling 修复了导出速度过慢的问题。
-- [TiDB 5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.0.md): TiDB 5.1 版本新增了许多关键特性，包括对 MySQL 8 中的公共表表达式和动态权限的支持，以及对数据表列类型的在线变更。此外，还引入了新的统计信息类型和锁视图功能，以提升查询稳定性和性能。同时，TiDB 5.1 修复了许多 Bug，包括投影消除、列包含 NULL 值时查询结果错误等问题。这些改进和修复将提升 TiDB 的性能和稳定性。
-- [TiDB 5.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.1.md): TiDB 5.1.1 发布，兼容性更改包括默认值修改和权限变更。功能增强方面新增 OIDC SSO 支持和 DAG 请求中的 `HAVING()` 函数。改进提升包括 Stale Read 成为正式功能、加快数据插入速度、稳定结果模式支持等。Bug 修复方面修复了多个问题，包括数据丢失、panic、数据不一致等。 Tools 方面也有多个修复，包括 TiCDC、Backup & Restore、TiDB Lightning。
-- [TiDB 5.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.2.md): TiDB 5.1.2 发布，包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括修复多个 Bug，改进提升包括根据直方图行数触发 auto-analyze、支持动态更改 TiCDC 配置项等。Bug 修复涉及 hash 列为 ENUM 类型时 index hash join 的结果可能出错、TiKV 从 v3.x 升级至较高版本后出现 Panic 等问题。Tools 方面的改进包括 BR 修复备份数据和恢复数据时显示的平均速度数值不准确的问题、Dumpling 修复特定 MySQL 版本下导致 dump 阶段卡死的问题等。
-- [TiDB 5.1.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.1.3.md): TiDB 5.1.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
-- [TiDB 5.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.4.md): TiDB 5.1.4 发布日期为 2022 年 2 月 22 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括系统变量 `tidb_analyze_version` 默认值修改为 `1`，以及 TiKV 在开启 `storage.enable-ttl` 后拒绝 TiDB 请求。提升改进方面，TiDB 支持在 Range 类型分区表中对 `IN` 表达式进行分区裁剪，TiKV 升级了 proc filesystem 版本。Bug 修复方面，修复了多个 TiDB 和 TiKV 的问题，包括内存泄露、配置项不生效、panic 等。Tools 方面也有多个修复和改进，包括 TiCDC、Backup & Restore、TiDB Binlog 和 TiDB Lightning。
-- [TiDB 5.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.5.md): TiDB 5.1.5 发布日期为 2022 年 12 月 28 日。此版本包含 PD 默认关闭编译 swagger server 的兼容性变更以及 TiDB、TiKV、PD、TiFlash 和 Tools 中的多项 Bug 修复。修复内容涵盖了窗口函数执行、动态模式、函数传入值计算、left join 删除数据、SQL 语句计算、连接错误、索引错误、HTTP 服务异常、并发列类型变更、空闲链接、SESSION 变量、Region 合并、KV client 连接、TiDB Binlog 错误、TiKV 运行、Raftstore 线程、Region merge、Follower Read、Async Commit、网络问题、Unified Read Pool CPU 表达式、TLS、并行聚合、查询错误、日期格式、MPP query、数据回收、逻辑运算符、备份系统表、增量扫描、Sorter 组件监控数据和 ddl schema 缓存优化。
-- [TiDB 5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.0.md): TiDB 5.2 版本于 2021 年 8 月 27 日发布。该版本新增了许多功能和改进，包括支持基于部分函数创建表达式索引、提升优化器的估算准确度、锁视图成为 GA 特性等。此外，还修复了多个 bug，提升了稳定性和性能。
-- [TiDB 5.2.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.1.md): TiDB 5.2.1 发布日期为 2021 年 9 月 9 日。此版本修复了 TiDB 在分区中下推聚合算子时的执行计划和执行报错问题。同时，TiKV 修复了 Region 迁移时出现的死锁导致 TiKV 不可用的问题。用户可通过关闭调度并重启出问题的 TiKV 来临时应对。
-- [TiDB 5.2.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.2.md): TiDB 5.2.2 发布日期为 2021 年 10 月 29 日。此版本包含了对 TiDB、TiKV、PD 和 Tools 的多项提升改进和 bug 修复。其中 TiDB 修复了多项问题，如 `plan cache` 无法感知 `unsigned` 标志变化、分区功能出现 `out of range` 时 `partition pruning` 出错等。TiKV 修复了因 Congest 错误而导致的 CDC 频繁增加 scan 重试的问题等。PD 修复了因超过副本配置数量而导致错误删除带有数据且处于 pending 状态的副本的问题等。TiFlash 修复了在部分平台上由于缺失 `nsl` 库而无法启动的问题。Tools 中的 TiCDC 也进行了多项修复，如当上游 TiDB 实例意外退出时，TiCDC 同步任务推进可能停滞的问题等。
-- [TiDB 5.2.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.2.3.md): TiDB 5.2.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
-- [TiDB 5.2.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.4.md): TiDB 5.2.4 发布日期为 2022 年 4 月 26 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB、TiKV 和 Tools 的调整。提升改进主要针对 TiKV 和 Tools 进行了优化。Bug 修复方面涉及 TiDB、TiKV、PD、TiFlash 和 Tools 的修复。
-- [TiDB 5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.0.md): TiDB 5.3.0 版本发布了许多重要的功能和改进，包括临时表、表属性设置、TiDB Dashboard 安全性提升、PD 时间戳处理流程优化、DM 同步性能提升、TiDB Lightning 分布式并行导入等。此外，还修复了许多 bug，提升了稳定性和性能。
-- [TiDB 5.3.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.1.md): TiDB 5.3.1 发布日期为 2022 年 3 月 3 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB Lightning 工具的默认值调整。提升改进包括 TiDB、TiKV 和 PD 的优化。Bug 修复包括 TiDB、TiKV、PD、TiFlash、Backup & Restore (BR)、TiCDC、TiDB Data Migration (DM) 和 TiDB Lightning 工具的问题修复。
-- [TiDB 5.3.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.2.md): TiDB 5.3.2 发布日期为 2022 年 6 月 29 日。该版本存在 bug，建议升级至 v5.3.3。兼容性变更包括修复了 auto ID 超出范围时的问题。TiKV 提升了 Raft 客户端的效率，并修复了多个 bug。TiDB 修复了多个 bug，包括 Amazon S3 数据计算错误和网络连接问题。PD 也修复了多个 bug。TiFlash 修复了存储目录配置错误和数据不一致的问题。BR 和 TiCDC 也有多个 bug 修复。DM 和 TiDB Lightning 也有 bug 修复。
-- [TiDB 5.3.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.3.3.md): TiDB 5.3.3 发布日期为 2022 年 9 月 14 日。此版本修复了 TiKV 存在的 bug，该 bug 导致在执行 SQL 语句时出现持续报错的问题。影响版本为 v5.3.2 和 v5.4.2，已在 v5.3.3 上修复。如果使用 v5.3.2 的 TiDB 集群，可以升级至 v5.3.3。除升级外，还可以重启无法向 PD 发送 Region 心跳的 TiKV 节点，直至不再有待发送的 Region 心跳为止。
-- [TiDB 5.3.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.4.md): TiDB 5.3.4 发布，提升了 TiKV 的自动 TLS 证书重新加载功能。修复了 TiDB、PD 和 TiFlash 的多个 bug，包括 Region 合并、权限清理、连接失败等问题。同时修复了工具 Dumpling 和 TiCDC 的导出数据和同步任务状态不正确的问题。
-- [TiDB 5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.0.md): TiDB 5.4.0 版本发布日期为 2022 年 2 月 15 日。此版本新增了许多功能和改进，包括支持 GBK 字符集、索引合并、有界限过期数据读取、统计信息采集配置持久化等。同时还修复了许多 bug，提升了稳定性和性能。
-- [TiDB 5.4.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.1.md): TiDB 5.4.1 发布日期为 2022 年 5 月 13 日。该版本未引入产品设计上的兼容性变化，但 Bug 修复可能带来兼容性变更。提升改进包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个方面的改进。Bug 修复方面包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个问题的修复。
-- [TiDB 5.4.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.2.md): TiDB 5.4.2 发布日期为 2022 年 7 月 8 日。该版本存在 bug，建议升级至 v5.4.3。此版本提升了 TiDB、TiKV、PD 和 Tools 的稳定性和可用性，并修复了多个 bug。
-- [TiDB 5.4.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.3.md): TiDB 5.4.3 发布，提升了 TiKV 和 Tools 的功能，修复了多个 Bug。包括 TiKV 支持更小的 RocksDB write stall 参数，TiDB 修复了多个查询和执行时可能出现的问题。PD 也修复了一些请求和权限问题。TiFlash 修复了一些函数和并行聚合的错误。Tools 中的 TiDB Lightning 修复了一些数据导入和连接问题，DM 修复了一些数据同步和连接问题，BR 修复了备份恢复和 Region 不均衡的问题，Dumpling 修复了 IPv6 的支持问题。
-- [TiDB 6.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.0.0-dmr.md): 了解 TiDB 6.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.0.md): 了解 TiDB 6.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.1.md): TiDB 6.1.1 发布日期为 2022 年 9 月 1 日。该版本兼容性变更包括大小写敏感语句不再敏感，以及默认关闭持续性能分析特性。其他变更包括新增内容和不同操作系统和 CPU 架构的支持。提升改进方面，引入了新的优化器提示和支持通过 gzip 压缩 metrics 响应减少 HTTP body 大小。Bug 修复方面，修复了多个 TiDB、TiKV、PD 和 TiFlash 的问题。 Tools 方面，TiDB Lightning 修复了多个问题，TiDB Data Migration (DM) 修复了多个问题，TiCDC 修复了多个问题，Backup & Restore (BR) 修复了多个问题，Dumpling 修复了一个问题，TiDB Binlog 修复了一个问题。
-- [TiDB 6.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.2.md): TiDB 6.1.2 发布，包括 TiDB、TiKV、Tools 和 Bug 修复。提升改进包括允许在一张表上同时设置数据放置规则和 TiFlash 副本。Bug 修复包括修复数据库级别的权限清理不正确的问题。
-- [TiDB 6.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.3.md): TiDB 6.1.3 发布日期为 2022 年 12 月 5 日。此版本兼容性变更包括 TiCDC 的默认值修改和事务拆分功能的优化。提升改进方面，PD 优化了锁的粒度，TiCDC 默认关闭 safeMode 并开启大事务拆分功能。此外，为了提升 TiDB 稳定性，Go 编译器版本从 go1.18 升级到了 go1.19。Bug 修复方面，修复了多个 TiDB、PD、TiKV、TiFlash 和 Tools 的问题。
-- [TiDB 6.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.4.md): 了解 TiDB 6.1.4 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.5.md): 了解 TiDB 6.1.5 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.6.md): 了解 TiDB 6.1.6 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.7.md): 了解 TiDB 6.1.7 版本的改进提升与错误修复。
-- [TiDB 6.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.2.0.md): 了解 TiDB 6.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.3.0.md): 了解 TiDB 6.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.4.0.md): 了解 TiDB 6.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.0.md): 了解 TiDB 6.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.1.md): 了解 TiDB 6.5.1 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.10.md): 了解 TiDB 6.5.10 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.11.md): 了解 TiDB 6.5.11 版本的改进提升和错误修复。
-- [TiDB 6.5.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.12.md): 了解 TiDB 6.5.12 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.2.md): 了解 TiDB 6.5.2 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.3.md): 了解 TiDB 6.5.3 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.4.md): 了解 TiDB 6.5.4 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.5.md): 了解 TiDB 6.5.5 版本的改进提升与错误修复。
-- [TiDB 6.5.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.6.md): 了解 TiDB 6.5.6 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.7.md): 了解 TiDB 6.5.7 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.8.md): 了解 TiDB 6.5.8 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.9.md): 了解 TiDB 6.5.9 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.6.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.6.0.md): 了解 TiDB 6.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.0.0.md): 了解 TiDB 7.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.0.md): 了解 TiDB 7.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.1.md): 了解 TiDB 7.1.1 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.2.md): 了解 TiDB 7.1.2 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.3.md): 了解 TiDB 7.1.3 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.4.md): 了解 TiDB 7.1.4 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.5.md): 了解 TiDB 7.1.5 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.6.md): 了解 TiDB 7.1.6 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.2.0.md): 了解 TiDB 7.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.3.0.md): 了解 TiDB 7.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.4.0.md): 了解 TiDB 7.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.0.md): 了解 TiDB 7.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.1.md): 了解 TiDB 7.5.1 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.2.md): 了解 TiDB 7.5.2 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.3.md): 了解 TiDB 7.5.3 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.4.md): 了解 TiDB 7.5.4 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.5.md): 了解 TiDB 7.5.5 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.6.md): 了解 TiDB 7.5.6 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.6.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.6.0.md): 了解 TiDB 7.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.0.0.md): 了解 TiDB 8.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.0.md): 了解 TiDB 8.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.1.md): 了解 TiDB 8.1.1 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.2.md): 了解 TiDB 8.1.2 版本的改进提升和错误修复。
-- [TiDB 8.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.2.0.md): 了解 TiDB 8.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.3.0.md): 了解 TiDB 8.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.4.0.md): 了解 TiDB 8.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.5.0.md): 了解 TiDB 8.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.5.1.md): 了解 TiDB 8.5.1 版本的操作系统支持变更、改进提升，以及错误修复。
-- [TiDB Control 使用说明](https://docs.pingcap.com/tidb/stable/tidb-control.md): TiDB Control 是 TiDB 的命令行工具，用于获取 TiDB 状态信息和调试。可通过 TiUP 安装或从源代码编译安装。使用介绍包括命令、选项和参数组成，以及全局参数和各子命令的功能。其中包括获取帮助信息、解码 base64 数据、解码 row key 和 value、操作 etcd、格式化日志文件，以及查询关键 key range 信息。注意：TiDB Control 主要用于诊断调试，不保证和 TiDB 未来引入的新特性完全兼容。
-- [TiDB Dashboard SQL 语句分析列表页面](https://docs.pingcap.com/tidb/stable/dashboard-statement-list.md): 查看所有 SQL 语句在集群上执行情况
-- [TiDB Dashboard SQL 语句分析执行详情页面](https://docs.pingcap.com/tidb/stable/dashboard-statement-details.md): 查看单个 SQL 语句执行的详细情况
-- [TiDB Dashboard Top SQL 页面](https://docs.pingcap.com/tidb/stable/top-sql.md): 使用 Top SQL 找到 CPU 开销较大的 SQL 语句
-- [TiDB Dashboard 介绍](https://docs.pingcap.com/tidb/stable/dashboard-intro.md): TiDB Dashboard 是 TiDB 4.0 版本后提供的图形化界面，用于监控和诊断集群。它内置于 TiDB 的 PD 组件中，无需独立部署。可以查看集群整体运行概况、组件及主机运行状态、集群读写流量分布、SQL 查询的执行信息、耗时较长的 SQL 语句执行信息、诊断集群问题并生成报告、查询所有组件日志、预估资源管控容量、收集分析各个组件的性能数据。
-- [TiDB Dashboard 实例性能分析 - 手动分析页面](https://docs.pingcap.com/tidb/stable/dashboard-profiling.md): 了解如何收集集群各个实例当前性能数据，从而分析复杂问题
-- [TiDB Dashboard 实例性能分析 - 持续分析页面](https://docs.pingcap.com/tidb/stable/continuous-profiling.md): 了解如何持续地收集 TiDB、TiKV、PD 各个实例的性能数据，缩短平均故障恢复时间
-- [TiDB Dashboard 常见问题](https://docs.pingcap.com/tidb/stable/dashboard-faq.md): TiDB Dashboard 常见问题汇总，包括访问、界面功能方面的常见问题与解决办法。若无法解决，请获取官方或社区支持。
-- [TiDB Dashboard 慢查询页面](https://docs.pingcap.com/tidb/stable/dashboard-slow-query.md): 了解如何在 TiDB Dashboard 中查看慢查询。
-- [TiDB Dashboard 日志搜索页面](https://docs.pingcap.com/tidb/stable/dashboard-log-search.md): 在集群中搜索所有节点上的日志
-- [TiDB Dashboard 概况页面](https://docs.pingcap.com/tidb/stable/dashboard-overview.md): TiDB Dashboard 概况页面显示整个集群的 QPS、查询延迟、Top SQL 语句、最近的慢查询、实例状态和监控及告警信息。登录后默认进入该页面，也可通过左侧导航条点击概况进入。包含最近一小时整个集群的 QPS 和查询延迟，以及最近一段时间内累计耗时最多的 SQL 语句和运行时间超过一定阈值的慢查询。还显示各个实例的节点数和状态，以及提供了便捷的链接方便用户查看详细监控或告警。
-- [TiDB Dashboard 流量可视化页面](https://docs.pingcap.com/tidb/stable/dashboard-key-visualizer.md): TiDB Dashboard 的流量可视化页面可用于分析 TiDB 集群的使用模式和排查流量热点。通过登录 TiDB Dashboard 或在浏览器中访问指定链接，可以查看流量可视化页面。页面展示了流量热力图，可观察到整体访问流量随时间的变化情况，以及热力图某个坐标的详细信息。流量可视化页面涉及的基本概念包括 Region、热点、热力图和 Region 压缩。使用介绍包括设置、观察时间段或 Region 范围、调整亮度、选择指标、刷新与自动刷新以及查看详情。常见热力图解读包括均衡结果、X 轴明暗交替、Y 轴明暗交替和明亮斜线。解决热点问题可参考 TiDB 高并发写入场景最佳实践。
-- [TiDB Dashboard 用户管理](https://docs.pingcap.com/tidb/stable/dashboard-user.md): 了解如何创建 SQL 用户用于访问 TiDB Dashboard
-- [TiDB Dashboard 监控关系图](https://docs.pingcap.com/tidb/stable/dashboard-metrics-relation.md): 了解 TiDB Dashboard 监控关系图
-- [TiDB Dashboard 监控页面](https://docs.pingcap.com/tidb/stable/dashboard-monitoring.md): 介绍如何通过 TiDB Dashboard 监控页面查看 Performance Overview 面板，以及如何理解面板上的关键指标项。
-- [TiDB Dashboard 诊断报告](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-report.md): TiDB Dashboard 诊断报告介绍了诊断报告的内容和查看技巧。报告包括基本信息、诊断信息、负载信息、概览信息、TiDB/PD/TiKV 监控信息和配置信息。对比报告显示两个时间段的差异，通过 DIFF_RATIO 和 Maximum Different Item 报表可以快速发现监控项的差异。
-- [TiDB Dashboard 资源管控页面](https://docs.pingcap.com/tidb/stable/dashboard-resource-manager.md): 介绍如何使用 TiDB Dashboard 的资源管控页面查看资源管控相关信息，以便预估集群容量，更好地进行资源配置。
-- [TiDB Dashboard 集群信息页面](https://docs.pingcap.com/tidb/stable/dashboard-cluster-info.md): 查看整个集群中 TiDB、TiKV、PD、TiFlash 组件的运行状态及其所在主机的运行状态
-- [TiDB Dashboard 集群诊断页面](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-access.md): TiDB Dashboard 集群诊断页面是用于诊断集群问题并生成诊断报告的工具。可以通过 TiDB Dashboard 或浏览器访问诊断页面。生成诊断报告的步骤包括设置时间范围和长度，然后点击开始。还可以生成对比报告来比较异常时间段和正常时间段的情况。已生成的报告会显示在主页列表中，可随时查看。
-- [TiDB Data Migration 1.0.x 到 2.0+ 手动升级](https://docs.pingcap.com/tidb/stable/manually-upgrade-dm-1.0-to-2.0.md): 了解如何从 TiDB Data Migration 1.0.x 手动升级到 2.0+。
-- [TiDB Data Migration Binlog 事件过滤](https://docs.pingcap.com/tidb/stable/dm-binlog-event-filter.md): 了解 DM 的关键特性 binlog 事件过滤 (Binlog event filter) 的使用方法和注意事项。
-- [TiDB Data Migration 上游数据库配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-source-configuration-file.md): TiDB Data Migration (DM) 上游数据库配置文件包括示例与配置项说明。示例配置文件包括上游数据库的配置项，如是否开启 GTID、是否开启 relay log、拉取上游 binlog 的起始文件名等。配置项说明包括全局配置、relay log 清理策略配置、任务状态检查配置和 Binlog event filter。配置项包括标识一个 MySQL 实例、是否使用 GTID 方式、是否开启 relay log、存储 relay log 的目录等。从 DM v2.0.2 开始，Binlog event filter 也可以在上游数据库配置文件中进行配置。
-- [TiDB Data Migration 任务前置检查](https://docs.pingcap.com/tidb/stable/dm-precheck.md): 了解 DM 执行数据迁移任务时将进行的前置检查。
-- [TiDB Data Migration 兼容性目录](https://docs.pingcap.com/tidb/stable/dm-compatibility-catalog.md): 了解 DM 各版本与上下游各类型数据库的兼容关系
-- [TiDB Data Migration 分库分表合并](https://docs.pingcap.com/tidb/stable/dm-shard-merge.md): 了解 DM 的分库分表合并功能。
-- [TiDB Data Migration 命令行参数](https://docs.pingcap.com/tidb/stable/dm-command-line-flags.md): 介绍 DM 各组件的主要命令行参数。
-- [TiDB Data Migration 处理告警](https://docs.pingcap.com/tidb/stable/dm-handle-alerts.md): 了解 DM 中各主要告警信息的处理方法。
-- [TiDB Data Migration 对 online DDL 工具的支持](https://docs.pingcap.com/tidb/stable/dm-online-ddl-tool-support.md): 了解 DM 对常见 online DDL 工具的支持情况，使用方法和注意事项。
-- [TiDB Data Migration 导出和导入集群的数据源和任务配置](https://docs.pingcap.com/tidb/stable/dm-export-import-config.md): 了解 TiDB Data Migration 导出和导入集群的数据源和任务配置。
-- [TiDB Data Migration 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-dm.md): 了解如何使用 TiUP Playground 快速部署试用 TiDB Data Migration 数据迁移工具。
-- [TiDB Data Migration 性能问题及处理方法](https://docs.pingcap.com/tidb/stable/dm-handle-performance-issues.md): 了解 DM 可能存在的常见性能问题及其处理方法。
-- [TiDB Data Migration 故障及处理方法](https://docs.pingcap.com/tidb/stable/dm-error-handling.md): 了解 DM 的错误系统及常见故障的处理方法。
-- [TiDB Data Migration 数据迁移任务配置向导](https://docs.pingcap.com/tidb/stable/dm-task-configuration-guide.md): 本文介绍了如何配置 TiDB Data Migration (DM) 的数据迁移任务。包括配置数据源、目标 TiDB 集群、需要迁移的表、需要过滤的操作、数据源表到目标 TiDB 表的映射以及分库分表合并等配置。详细配置规则可参考相关链接。
-- [TiDB Data Migration 日常巡检](https://docs.pingcap.com/tidb/stable/dm-daily-check.md): 了解 DM 工具的日常巡检。
-- [TiDB Data Migration 术语表](https://docs.pingcap.com/tidb/stable/dm-glossary.md): 学习 TiDB Data Migration 相关术语
-- [TiDB Data Migration 查询任务状态](https://docs.pingcap.com/tidb/stable/dm-query-status.md): 深入了解 TiDB Data Migration 如何查询数据迁移任务状态
-- [TiDB Data Migration 版本发布历史](https://docs.pingcap.com/tidb/stable/dm-release-notes.md): TiDB Data Migration 版本发布历史从 DM v5.4.0 起，TiDB Data Migration 的 Release Notes 合并入相同版本号的 TiDB Release Notes。如需阅读 v5.4.0 及之后版本的 DM Release Notes，请查看对应版本的 TiDB Release Notes 中 DM 相关的内容。如需阅读 v5.3.0 及更早版本的 DM Release Notes，请参考以下链接：5.3.0, 2.0.7, 2.0.6, 2.0.5, 2.0.4, 2.0.3, 2.0.2, 2.0.1, 2.0 GA, 2.0.0-rc.2, 2.0.0-rc, 1.0.7, 1.0.6, 1.0.5, 1.0.4, 1.0.3, 1.0.2.
-- [TiDB Data Migration 生成自签名证书](https://docs.pingcap.com/tidb/stable/dm-generate-self-signed-certificates.md): 了解如何生成自签名证书。
-- [TiDB Data Migration 简介](https://docs.pingcap.com/tidb/stable/dm-overview.md): 了解 TiDB Data Migration
-- [TiDB Data Migration 表路由](https://docs.pingcap.com/tidb/stable/dm-table-routing.md): 了解 DM 的关键特性表路由 (Table Routing) 的使用方法和注意事项。
-- [TiDB Data Migration 集群软硬件环境需求](https://docs.pingcap.com/tidb/stable/dm-hardware-and-software-requirements.md): 了解部署 DM 集群的软件和硬件要求。
-- [TiDB Data Migration 黑白名单过滤](https://docs.pingcap.com/tidb/stable/dm-block-allow-table-lists.md): 了解 DM 的关键特性黑白名单过滤 (Block & Allow List) 的使用方法和注意事项。
-- [TiDB Lightning Web 界面](https://docs.pingcap.com/tidb/stable/tidb-lightning-web-interface.md): 了解 TiDB Lightning 的服务器模式——通过 Web 界面来控制 TiDB Lightning。
-- [TiDB Lightning 前置检查](https://docs.pingcap.com/tidb/stable/tidb-lightning-prechecks.md): 本文档介绍了 TiDB Lightning 前置检查功能，确保 TiDB Lightning 能够顺利执行任务。
-- [TiDB Lightning 命令行参数](https://docs.pingcap.com/tidb/stable/tidb-lightning-command-line-full.md): 使用命令行配置 TiDB Lightning。
-- [TiDB Lightning 常见问题](https://docs.pingcap.com/tidb/stable/tidb-lightning-faq.md): TiDB Lightning 常见问题的摘要：TiDB Lightning 对TiDB/TiKV/PD 的最低版本要求，支持导入多个库，对下游数据库的账号权限要求，导数据过程中某个表报错不会影响其他表，正确重启 TiDB Lightning 的步骤，校验导入数据的正确性方法，支持的数据源格式，禁止导入不合规数据的方法，结束 tidb-lightning 进程的操作，使用千兆网卡的建议，TiDB Lightning 预留空间的原因，清除与 TiDB Lightning 相关的中间数据的步骤，获取 TiDB Lightning 运行时的 goroutine 信息的方法，TiDB Lightning 不兼容 Placement Rules in SQL 的原因，使用 TiDB Lightning 和 Dumpling 复制 schema 的步骤。
-- [TiDB Lightning 并行导入](https://docs.pingcap.com/tidb/stable/tidb-lightning-distributed-import.md): 本文档介绍了 TiDB Lightning 并行导入的概念、使用场景和使用方法。
-- [TiDB Lightning 快速上手](https://docs.pingcap.com/tidb/stable/get-started-with-tidb-lightning.md): TiDB Lightning 可快速将 MySQL 数据导入到 TiDB 集群中。首先使用 Dumpling 导出数据，然后部署 TiDB 集群。安装最新版本的 TiDB Lightning 并启动，最后检查数据导入情况。详细功能和使用请参考 TiDB Lightning 简介。
-- [TiDB Lightning 故障处理](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-lightning.md): 本文档总结了使用 TiDB Lightning 过程中常见的运行故障及解决方案。
-- [TiDB Lightning 数据源](https://docs.pingcap.com/tidb/stable/tidb-lightning-data-source.md): 了解 TiDB Lightning 支持的各类型数据源。
-- [TiDB Lightning 断点续传](https://docs.pingcap.com/tidb/stable/tidb-lightning-checkpoints.md): TiDB Lightning 提供了“断点续传”的功能，即使 `tidb-lightning` 崩溃，在重启时仍然接着之前的进度继续工作。断点续传可通过配置启用，存储方式包括本地文件和 MySQL 数据库。在出现不可恢复的错误时，可以使用 `tidb-lightning-ctl` 工具来控制断点的处理，包括重置断点状态、清除出错状态和移除断点。
-- [TiDB Lightning 术语表](https://docs.pingcap.com/tidb/stable/tidb-lightning-glossary.md): 了解 TiDB Lightning 相关的术语及定义。
-- [TiDB Lightning 监控告警](https://docs.pingcap.com/tidb/stable/monitor-tidb-lightning.md): TiDB Lightning 支持使用Prometheus采集监控指标。监控配置需手动部署，配置方法在 tidb-lightning.toml 中。Grafana 面板可用于监控速度、进度、资源使用和存储空间。监控指标包括计数器和直方图，用于计算引擎文件数量、闲置 worker、KV 编码器、处理过的表、引擎文件和 Chunks的状态，以及导入每个表所需时间等。
-- [TiDB Lightning 目标数据库要求](https://docs.pingcap.com/tidb/stable/tidb-lightning-requirements.md): 了解 TiDB Lightning 运行时对目标数据库的必需条件。
-- [TiDB Lightning 简介](https://docs.pingcap.com/tidb/stable/tidb-lightning-overview.md): TiDB Lightning 是用于导入 TB 级数据到 TiDB 的工具。了解 TiDB Lightning 的基本原理和使用方法。
-- [TiDB Lightning 配置参数](https://docs.pingcap.com/tidb/stable/tidb-lightning-configuration.md): 使用配置文件或命令行配置 TiDB Lightning。
-- [TiDB Lightning 错误处理功能](https://docs.pingcap.com/tidb/stable/tidb-lightning-error-resolution.md): 介绍了如何解决导入数据过程中的类型转换和冲突错误。
-- [TiDB OOM 故障排查](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-oom.md): TiDB OOM 故障排查总结了 OOM 常见问题的解决思路、故障现象、原因、解决方法和需要收集的诊断信息。排查思路包括确认是否属于 OOM 问题和进一步排查触发 OOM 的原因。常见故障原因包括部署问题、数据库问题和客户端问题。处理 OOM 问题需要收集操作系统内存配置、数据库版本和内存配置、Grafana TiDB 内存使用情况等信息。详细排查方法请参考相关章节。
-- [TiDB Operator](https://docs.pingcap.com/tidb/stable/tidb-operator-overview.md): 了解 Kubernetes 上的 TiDB 集群自动部署运维工具 TiDB Operator。
-- [TiDB Pre-GA Release Notes](https://docs.pingcap.com/tidb/stable/release-pre-ga.md): TiDB Pre-GA 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 改进了 SQL 查询优化器、大量 MySQL 兼容性相关功能、支持 Natural Join、JSON 类型支持、裁剪无用数据、支持在 SQL 语句中设置优先级、完成表达式重构。PD 支持手动切换 PD 集群 Leader。TiKV 改进了 Raft Log 使用独立的 RocksDB 实例、使用 DeleteRange 加快删除副本速度、Coprocessor 支持更多运算符下推、提升性能和稳定性。TiSpark Beta Release 支持谓词下推、支持聚合下推、支持范围裁剪。
-- [TiDB RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.1.md): TiDB RC1 于 2016 年 12 月 23 日发布，TiKV 提升了写入速度和稳定性，支持百 TB 级别数据，集群规模支持 200 个节点。PD 优化了调度策略框架，添加了 label 支持，提供了 PD Control。TiDB 新增了 SQL 查询优化器和更多 MySQL 内建函数，重构了 time 相关类型的实现，提升了和 MySQL 的兼容性。工具方面，Loader 兼容 Percona 的 Mydumper 数据格式，提供了多线程导入、出错重试、断点续传等功能，并且针对 TiDB 有优化。完成了一键部署工具。
-- [TiDB RC2 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.2.md): TiDB RC2 版本发布，提升了 MySQL 兼容性、SQL 优化器、系统稳定性和性能。对于 OLTP 场景，读取性能提升 60%，写入性能提升 30%。新增权限管理功能，支持基本权限管理和大量 MySQL 内建函数。完善监控，修复 Bug 和内存泄漏问题。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，支持更多下推功能，加入更多统计，修复 Bug。
-- [TiDB RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.3.md): TiDB RC3 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了负载均衡调度策略和流程，完善权限管理功能，DDL 速度显著提升。开源了 TiDB Ansible 项目，可以一键部署 / 升级 / 启停 TiDB 集群。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，修复 Bug。
-- [TiDB RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.4.md): TiDB RC4 版本对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了写入速度，计算任务调度支持优先级，避免分析型大事务影响在线事务。SQL 优化器全新改版，查询代价估算更准确，且能自动选择 Join 物理算子。功能方面进一步 MySQL 兼容性。同时开源了 TiSpark 项目，可以通过 Spark 读取和分析 TiKV 中的数据。PD 支持通过 PD 设置 TiKV location labels，调度优化，优化数据加载，加快 failover 速度。 TiKV 支持查询优先级设置，支持 RC 隔离级别，完善 Jepsen，支持 Document Store，提升性能，提升稳定性。TiSpark Beta Release 支持谓词下推，支持聚合下推，支持范围裁剪。
+- [Scheduling 配置参数](https://docs.pingcap.com/zh/tidb/stable/command-line-flags-for-scheduling-configuration.md): Scheduling 配置参数可以通过命令行参数或环境变量配置。
+- [Scheduling 配置文件描述](https://docs.pingcap.com/zh/tidb/stable/scheduling-configuration-file.md): Scheduling 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
+- [Schema 对象名](https://docs.pingcap.com/zh/tidb/stable/schema-object-names.md): 本文介绍 TiDB SQL 语句中的模式对象名。
+- [Schema 缓存](https://docs.pingcap.com/zh/tidb/stable/schema-cache.md): TiDB 对于 schema 信息采用基于 LRU 的缓存机制，在大量数据库和表的场景下能够显著减少 schema 信息的内存占用以及提高性能。
+- [schema_unused_indexes](https://docs.pingcap.com/zh/tidb/stable/sys-schema-unused-indexes.md): 了解 TiDB `sys` 系统数据库中的 `schema_unused_indexes` 表。
+- [SCHEMATA](https://docs.pingcap.com/zh/tidb/stable/information-schema-schemata.md): 了解 information_schema 表 `SCHEMATA`。
+- [SELECT](https://docs.pingcap.com/zh/tidb/stable/sql-statement-select.md): TiDB 数据库中 SELECT 的使用概况。
+- [SEQUENCES](https://docs.pingcap.com/zh/tidb/stable/information-schema-sequences.md): 了解 INFORMATION_SCHEMA 表 `SEQUENCES`。
+- [SESSION_CONNECT_ATTRS](https://docs.pingcap.com/zh/tidb/stable/performance-schema-session-connect-attrs.md): 了解 performance_schema 表 `SESSION_CONNECT_ATTRS`。
+- [SESSION_VARIABLES](https://docs.pingcap.com/zh/tidb/stable/information-schema-session-variables.md): 了解 INFORMATION_SCHEMA 表 `SESSION_VARIABLES`。
+- [SET [GLOBAL|SESSION] <variable>](https://docs.pingcap.com/zh/tidb/stable/sql-statement-set-variable.md): TiDB 数据库中 SET [GLOBAL|SESSION] <variable> 的使用概况。
+- [SET [NAMES|CHARACTER SET]](https://docs.pingcap.com/zh/tidb/stable/sql-statement-set-names.md): TiDB 数据库中 SET [NAMES|CHARACTER SET] 的使用概况。
+- [SET DEFAULT ROLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-set-default-role.md): TiDB 数据库中 SET DEFAULT ROLE 的使用概况。
+- [SET PASSWORD](https://docs.pingcap.com/zh/tidb/stable/sql-statement-set-password.md): TiDB 数据库中 SET PASSWORD 的使用概况。
+- [SET RESOURCE GROUP](https://docs.pingcap.com/zh/tidb/stable/sql-statement-set-resource-group.md): TiDB 数据库中 SET RESOURCE GROUP 的使用概况。
+- [SET ROLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-set-role.md): TiDB 数据库中 SET ROLE 的使用概况。
+- [SET TRANSACTION](https://docs.pingcap.com/zh/tidb/stable/sql-statement-set-transaction.md): TiDB 数据库中 SET TRANSACTION 的使用概况。
+- [SHARD_ROW_ID_BITS](https://docs.pingcap.com/zh/tidb/stable/shard-row-id-bits.md): 介绍 TiDB 的 `SHARD_ROW_ID_BITS` 表属性。
+- [SHOW [BACKUPS|RESTORES]](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-backups.md): TiDB 数据库中 SHOW [BACKUPS|RESTORES] 的使用概况。
+- [SHOW [FULL] COLUMNS FROM](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-columns-from.md): TiDB 数据库中 SHOW [FULL] COLUMNS FROM 的使用概况。
+- [SHOW [FULL] FIELDS FROM](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-fields-from.md): TiDB 数据库中 SHOW [FULL] FIELDS FROM 的使用概况。
+- [SHOW [FULL] PROCESSLIST](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-processlist.md): TiDB 数据库中 SHOW [FULL] PROCESSLIST 的使用概况。
+- [SHOW [FULL] TABLES](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-tables.md): TiDB 数据库中 SHOW [FULL] TABLES 的使用概况。
+- [SHOW [GLOBAL|SESSION] BINDINGS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-bindings.md): TiDB 数据库中 SHOW [GLOBAL|SESSION] BINDINGS 的使用概况。
+- [SHOW [GLOBAL|SESSION] STATUS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-status.md): TiDB 数据库中 SHOW [GLOBAL|SESSION] STATUS 的使用概况。
+- [SHOW [GLOBAL|SESSION] VARIABLES](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-variables.md): TiDB 数据库中 SHOW [GLOBAL|SESSION] VARIABLES 的使用概况。
+- [SHOW ANALYZE STATUS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-analyze-status.md): TiDB 数据库中 SHOW ANALYZE STATUS 的使用概况。
+- [SHOW BUILTINS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-builtins.md): TiDB 数据库中 SHOW BUILTINS 的使用概况。
+- [SHOW CHARACTER SET](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-character-set.md): TiDB 数据库中 SHOW CHARACTER SET 的使用概况。
+- [SHOW COLLATION](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-collation.md): TiDB 数据库中 SHOW COLLATION 的使用概况。
+- [SHOW COLUMN_STATS_USAGE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-column-stats-usage.md): TiDB 数据库中 SHOW COLUMN_STATS_USAGE 的使用概况。
+- [SHOW CONFIG](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-config.md): TiDB 数据库中 SHOW CONFIG 的使用概况。
+- [SHOW CREATE DATABASE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-create-database.md): TiDB 数据库中 SHOW CREATE DATABASE 的使用概况。
+- [SHOW CREATE PLACEMENT POLICY](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-create-placement-policy.md): TiDB 数据库中 SHOW CREATE PLACEMENT POLICY 的使用概况。
+- [SHOW CREATE RESOURCE GROUP](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-create-resource-group.md): TiDB 数据库中 SHOW CREATE RESOURCE GROUP 的使用概况。
+- [SHOW CREATE SEQUENCE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-create-sequence.md): TiDB 数据库中 SHOW CREATE SEQUENCE 的使用概况。
+- [SHOW CREATE TABLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-create-table.md): TiDB 数据库中 SHOW CREATE TABLE 的使用概况。
+- [SHOW CREATE USER](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-create-user.md): TiDB 数据库中 SHOW CREATE USER 的使用概况。
+- [SHOW DATABASES](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-databases.md): TiDB 数据库中 SHOW DATABASES 的使用概况。
+- [SHOW ENGINES](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-engines.md): TiDB 数据库中 SHOW ENGINES 的使用概况。
+- [SHOW ERRORS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-errors.md): TiDB 数据库中 SHOW ERRORS 的使用概况。
+- [SHOW GRANTS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-grants.md): TiDB 数据库中 SHOW GRANTS 的使用概况。
+- [SHOW IMPORT](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-import-job.md): TiDB 数据库中 SHOW IMPORT 的使用概况。
+- [SHOW INDEXES [FROM|IN]](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-indexes.md): TiDB 数据库中 SHOW INDEXES [FROM|IN] 的使用概况。
+- [SHOW MASTER STATUS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-master-status.md): TiDB 数据库中 SHOW MASTER STATUS 的使用概况。
+- [SHOW PLACEMENT](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-placement.md): TiDB 数据库中 SHOW PLACEMENT 的使用概况。
+- [SHOW PLACEMENT FOR](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-placement-for.md): TiDB 数据库中 SHOW PLACEMENT FOR 的使用概况。
+- [SHOW PLACEMENT LABELS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-placement-labels.md): TiDB 数据库中 SHOW PLACEMENT LABELS 的使用概况。
+- [SHOW PLUGINS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-plugins.md): TiDB 数据库中 SHOW PLUGINS 的使用概况。
+- [SHOW PRIVILEGES](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-privileges.md): TiDB 数据库中 SHOW PRIVILEGES 的使用概况。
+- [SHOW PROFILES](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-profiles.md): TiDB 数据库中 SHOW PROFILES 的使用概况。
+- [SHOW SCHEMAS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-schemas.md): TiDB 数据库中 SHOW SCHEMAS 的使用概况。
+- [SHOW STATS_BUCKETS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-stats-buckets.md): TiDB 数据库中 SHOW STATS_BUCKETS 的使用概况。
+- [SHOW STATS_HEALTHY](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-stats-healthy.md): TiDB 数据库中 SHOW STATS_HEALTHY 的使用概况。
+- [SHOW STATS_HISTOGRAMS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-stats-histograms.md): TiDB 数据库中 SHOW STATS_HISTOGRAMS 语句的简单说明。
+- [SHOW STATS_LOCKED](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-stats-locked.md): TiDB 数据库中 SHOW STATS_LOCKED 的使用概况。
+- [SHOW STATS_META](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-stats-meta.md): TiDB 数据库中 SHOW STATS_META 语句的简单说明。
+- [SHOW STATS_TOPN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-stats-topn.md): TiDB 数据库中 SHOW STATS_TOPN 的使用概况。
+- [SHOW TABLE NEXT_ROW_ID](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-table-next-rowid.md): TiDB 数据库中 SHOW TABLE NEXT_ROW_ID 的使用概况。
+- [SHOW TABLE REGIONS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-table-regions.md): 了解如何使用 TiDB 数据库中的 SHOW TABLE REGIONS。
+- [SHOW TABLE STATUS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-table-status.md): TiDB 数据库中 SHOW TABLE STATUS 的使用概况。
+- [SHOW WARNINGS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-show-warnings.md): TiDB 数据库中 SHOW WARNINGS 的使用概况。
+- [SHUTDOWN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-shutdown.md): TiDB 数据库中 SHUTDOWN 的使用概况。
+- [SLOW_QUERY](https://docs.pingcap.com/zh/tidb/stable/information-schema-slow-query.md): 了解 INFORMATION_SCHEMA 表 `SLOW_QUERY`。
+- [Split Region 使用文档](https://docs.pingcap.com/zh/tidb/stable/sql-statement-split-region.md): TiDB 中的 Split Region 功能可以解决表数据超过默认 Region 大小限制后的热点问题。预切分 Region 可以根据指定的参数，预先为某个表切分出多个 Region，并打散到各个 TiKV 上去。使用 `SPLIT` 语句可以实现均匀切分和不均匀切分，返回结果包括新增预切分的 Region 数量和打散完成的比率。需要注意 `tidb_wait_split_region_finish` 和 `tidb_wait_split_region_timeout` 会影响 `SPLIT` 语句的行为。
+- [SQL 优化流程简介](https://docs.pingcap.com/zh/tidb/stable/sql-optimization-concepts.md): TiDB 中的 SQL 优化流程包括查询文本解析、逻辑等价变化和最终执行计划生成。经过 parser 解析和合法性验证后，TiDB 会对查询进行逻辑上的等价变化，使得查询在逻辑执行计划上更易处理。之后根据数据分布和执行开销生成最终执行计划。同时，TiDB 在执行 PREPARE 语句时可以选择开启缓存来降低执行计划生成的开销。
+- [SQL 基本操作](https://docs.pingcap.com/zh/tidb/stable/basic-sql-operations.md): TiDB 是一个兼容 MySQL 的数据库，可以执行 DDL、DML、DQL 和 DCL 操作。可以使用 SHOW DATABASES 查看数据库列表，使用 CREATE DATABASE 创建数据库，使用 DROP DATABASE 删除数据库。使用 CREATE TABLE 创建表，使用 SHOW CREATE TABLE 查看建表语句，使用 DROP TABLE 删除表。使用 CREATE INDEX 创建索引，使用 SHOW INDEX 查看表内所有索引，使用 DROP INDEX 删除索引。使用 INSERT 向表内插入记录，使用 UPDATE 修改记录，使用 DELETE 删除记录。使用 SELECT 检索表内数据，使用 WHERE 子句进行筛选。使用 CREATE USER 创建用户，使用 GRANT 授权用户，使用 DROP USER 删除用户。
+- [SQL 开发规范](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sql-development-specification.md): TiDB 的 SQL 开发规范。
+- [SQL 性能调优](https://docs.pingcap.com/zh/tidb/stable/dev-guide-optimize-sql.md): 介绍 TiDB 的 SQL 性能调优方案和分析办法。
+- [SQL 性能调优](https://docs.pingcap.com/zh/tidb/stable/sql-tuning-overview.md): SQL 性能调优是重要的，TiDB 会优化 SQL 语句的执行，以最省时的方式返回结果。这个过程类似于 GPS 导航，利用统计信息和实时交通信息规划最佳路线。了解 TiDB 执行计划、SQL 优化流程和控制执行计划可以帮助提高查询性能。
+- [SQL 或事务问题](https://docs.pingcap.com/zh/tidb/stable/dev-guide-troubleshoot-overview.md): 学习诊断在应用开发过程中可能产生的 SQL 或事务问题的方法。
+- [SQL 操作常见问题](https://docs.pingcap.com/zh/tidb/stable/sql-faq.md): 介绍 SQL 操作相关的常见问题。
+- [SQL 模式](https://docs.pingcap.com/zh/tidb/stable/sql-mode.md): TiDB 服务器采用不同 SQL 模式来操作，可以使用 `SET [SESSION | GLOBAL] sql_mode='modes'` 语句设置 SQL 模式。`GLOBAL` 级别的 SQL 模式需要 `SUPER` 权限，影响新连接；`SESSION` 级别的 SQL 模式只影响当前客户端。重要的 sql_mode 值包括 `ANSI`、`STRICT_TRANS_TABLES` 和 `TRADITIONAL`。SQL mode 列表包括 `PIPES_AS_CONCAT`、`ANSI_QUOTES`、`IGNORE_SPACE`、`ONLY_FULL_GROUP_BY` 等。
+- [SQL 诊断](https://docs.pingcap.com/zh/tidb/stable/information-schema-sql-diagnostics.md): 了解 SQL 诊断功能。
+- [SQL 语句概述](https://docs.pingcap.com/zh/tidb/stable/sql-statement-overview.md): 介绍 TiDB 支持的 SQL 语句。
+- [Stale Read](https://docs.pingcap.com/zh/tidb/stable/dev-guide-use-stale-read.md): 使用 Stale Read 在特定情况下加速查询。
+- [Stale Read 功能的使用场景](https://docs.pingcap.com/zh/tidb/stable/stale-read.md): 介绍 Stale Read 功能和使用场景。
+- [START TRANSACTION](https://docs.pingcap.com/zh/tidb/stable/sql-statement-start-transaction.md): TiDB 数据库中 START TRANSACTION 的使用概况。
+- [Statement Summary Tables](https://docs.pingcap.com/zh/tidb/stable/statement-summary-tables.md): MySQL 的 `performance_schema` 提供了 `statement summary tables`，用于监控和统计 SQL 性能。TiDB 在 `information_schema` 中提供了类似功能的系统表，包括 `statements_summary`、`statements_summary_history`、`cluster_statements_summary` 和 `cluster_statements_summary_history`。这些表用于保存 SQL 监控指标聚合后的结果，帮助用户定位 SQL 问题。同时，还提供了参数配置来控制 statement summary 的功能，如清空周期、保存历史的数量等。
+- [STATISTICS](https://docs.pingcap.com/zh/tidb/stable/information-schema-statistics.md): 了解 information_schema 表 `STATISTICS`。
+- [Storage sink 消费程序开发指引](https://docs.pingcap.com/zh/tidb/stable/ticdc-storage-consumer-dev-guide.md): 了解如何设计与实现一个消费程序来消费 storage sink 中的变更数据。
+- [Store Limit](https://docs.pingcap.com/zh/tidb/stable/configure-store-limit.md): 介绍 Store Limit 功能。
+- [sync-diff-inspector 用户文档](https://docs.pingcap.com/zh/tidb/stable/sync-diff-inspector-overview.md): sync-diff-inspector 是一个用于校验 MySQL/TiDB 中数据一致性的工具，提供修复数据的功能。它支持对比表结构和数据，生成用于修复数据的 SQL 语句。需要注意的是，在校验数据时会消耗一定的服务器资源，需要避免在业务高峰期间校验。生成的 SQL 文件仅作为修复数据的参考，需要确认后再执行这些 SQL 修复数据。
+- [sys Schema](https://docs.pingcap.com/zh/tidb/stable/sys-schema.md): 了解 TiDB `sys` 系统数据库。
+- [TABLE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-table.md): TiDB 数据库中 TABLE 语句的使用概况。
+- [TABLE_CONSTRAINTS](https://docs.pingcap.com/zh/tidb/stable/information-schema-table-constraints.md): 了解 information_schema 表 `TABLE_CONSTRAINTS`。
+- [TABLE_STORAGE_STATS](https://docs.pingcap.com/zh/tidb/stable/information-schema-table-storage-stats.md): 了解 INFORMATION_SCHEMA 表 `TABLE_STORAGE_STATS`。
+- [TABLES](https://docs.pingcap.com/zh/tidb/stable/information-schema-tables.md): 了解 information_schema 表 `TABLES`。
+- [TiCDC Avro Protocol](https://docs.pingcap.com/zh/tidb/stable/ticdc-avro-protocol.md): 了解 TiCDC Avro Protocol 的概念和使用方法。
+- [TiCDC Canal-JSON Protocol](https://docs.pingcap.com/zh/tidb/stable/ticdc-canal-json.md): 了解 TiCDC Canal-JSON Protocol 的概念和使用方法。
+- [TiCDC Changefeed 命令行参数和配置参数](https://docs.pingcap.com/zh/tidb/stable/ticdc-changefeed-config.md): 了解 TiCDC Changefeed 详细的命令行参数和配置文件定义。
+- [TiCDC CSV Protocol](https://docs.pingcap.com/zh/tidb/stable/ticdc-csv.md): 了解 TiCDC CSV Protocol 的概念和使用方法。
+- [TiCDC Debezium Protocol](https://docs.pingcap.com/zh/tidb/stable/ticdc-debezium.md): 了解 TiCDC Debezium Protocol 的概念和使用方法。
+- [TiCDC Open Protocol](https://docs.pingcap.com/zh/tidb/stable/ticdc-open-protocol.md): 了解 TiCDC Open Protocol 的概念和使用方法。
+- [TiCDC OpenAPI v1](https://docs.pingcap.com/zh/tidb/stable/ticdc-open-api.md): 了解如何使用 OpenAPI 接口来管理集群状态和数据同步。
+- [TiCDC OpenAPI v2](https://docs.pingcap.com/zh/tidb/stable/ticdc-open-api-v2.md): 了解如何使用 OpenAPI v2 接口来管理集群状态和数据同步。
+- [TiCDC Server 配置](https://docs.pingcap.com/zh/tidb/stable/ticdc-server-config.md): 了解 TiCDC 详细的命令行参数和配置文件定义。
+- [TiCDC Simple Protocol](https://docs.pingcap.com/zh/tidb/stable/ticdc-simple-protocol.md): 本文介绍了 TiCDC Simple Protocol 的使用方法和数据格式实现。
+- [TiCDC 兼容性](https://docs.pingcap.com/zh/tidb/stable/ticdc-compatibility.md): 了解 TiCDC 兼容性相关限制和问题处理。
+- [TiCDC 单行数据正确性校验](https://docs.pingcap.com/zh/tidb/stable/ticdc-integrity-check.md): 介绍 TiCDC 数据正确性校验功能的实现原理和使用方法。
+- [TiCDC 双向复制](https://docs.pingcap.com/zh/tidb/stable/ticdc-bidirectional-replication.md): 了解 TiCDC 双向复制的使用方法。
+- [TiCDC 基本监控指标](https://docs.pingcap.com/zh/tidb/stable/ticdc-summary-monitor.md): 了解 TiCDC 基本的监控指标。
+- [TiCDC 安装部署与集群运维](https://docs.pingcap.com/zh/tidb/stable/deploy-ticdc.md): 了解 TiCDC 软硬件环境要求以及如何安装部署和运维 TiCDC 集群。
+- [TiCDC 客户端鉴权](https://docs.pingcap.com/zh/tidb/stable/ticdc-client-authentication.md): 介绍使用 TiCDC 命令行工具或通过 OpenAPI 访问 TiCDC 时，如何进行客户端鉴权。
+- [TiCDC 常见问题解答](https://docs.pingcap.com/zh/tidb/stable/ticdc-faq.md): 了解 TiCDC 相关的常见问题。
+- [TiCDC 性能分析和优化方法](https://docs.pingcap.com/zh/tidb/stable/ticdc-performance-tuning-methods.md): 本文介绍了 Performance Overview 面板中的 TiCDC 部分，帮助你了解和监控 TiCDC 工作负载。
+- [TiCDC 拆分 UPDATE 事件行为说明](https://docs.pingcap.com/zh/tidb/stable/ticdc-split-update-behavior.md): 介绍 TiCDC changefeed 拆分 UPDATE 事件的行为变更，说明变更原因以及影响范围。
+- [TiCDC 故障处理](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-ticdc.md): 了解如何解决使用 TiCDC 时经常遇到的问题。
+- [TiCDC 术语表](https://docs.pingcap.com/zh/tidb/stable/ticdc-glossary.md): 了解 TiCDC 相关的术语及定义。
+- [TiCDC 架构设计与原理](https://docs.pingcap.com/zh/tidb/stable/ticdc-architecture.md): 了解 TiCDC 软件的架构设计和运行原理。
+- [TiCDC 简介](https://docs.pingcap.com/zh/tidb/stable/ticdc-overview.md): TiCDC 是一款 TiDB 增量数据同步工具，适用于多 TiDB 集群的高可用和容灾方案，以及实时同步变更数据到异构系统。其主要特性包括数据容灾复制、双向复制、低延迟的增量数据同步能力等。TiCDC 架构包括 TiKV Server、TiCDC 和 PD，支持将数据同步到 TiDB、MySQL 数据库、Kafka 以及存储服务。目前暂不支持单独使用 RawKV 的 TiKV 集群，创建 SEQUENCE 的 DDL 操作和在同步过程中对 TiCDC 正在同步的表和库进行 BR 数据恢复和 TiDB Lightning 导入。
+- [TiCDC 详细监控指标](https://docs.pingcap.com/zh/tidb/stable/monitor-ticdc.md): 了解 TiCDC 详细的监控指标。
+- [TiCDC 部署拓扑](https://docs.pingcap.com/zh/tidb/stable/ticdc-deployment-topology.md): 介绍 TiCDC 部署 TiDB 集群的拓扑结构。
+- [TiCDC 集群监控报警规则](https://docs.pingcap.com/zh/tidb/stable/ticdc-alert-rules.md): 了解 TiCDC 集群监控报警规则以及处理方法。
+- [TiDB 1.0 release notes](https://docs.pingcap.com/zh/tidb/stable/release-1.0-ga.md): TiDB 1.0 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 优化了 SQL 查询优化器、内部数据格式、MySQL 兼容性，并支持 `NO_SQL_CACHE` 语法。PD 支持基于读流量的热点调度和设置 Store 权重。TiKV 支持更多下推函数和手动触发数据 Compact。TiSpark Beta 版本支持可配置框架和 ThriftSever/JDBC 和 Spark SQL 脚本入口。感谢参与项目的企业和团队，以及提供出色开源软件/服务的组织/个人。
+- [TiDB 1.1 Alpha Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-1.1-alpha.md): TiDB 1.1 Alpha 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。包括 SQL parser 兼容更多语法，SQL 查询优化器优化统计信息、代价估算，使用 `Count-Min Sketch` 更精确地估算点查的代价，SQL 执行器重构执行器算子，优化 `INSERT IGNORE` 语句性能，下推更多类型和函数，支持更多 `SQL_MODE`，优化 `Load Data` 性能，支持对物理算子内存使用进行统计。PD 增加更多 API，支持 TLS，调度适应不同的 Region size，修复调度 bug。TiKV 支持 Raft learner，优化 Raft Snapshot，支持 TLS，优化 RocksDB 配置，优化 Coprocessor 性能，增加 Failpoint 和稳定性测试 case，解决 PD 和 TiKV 重连问题，增强数据恢复工具功能，Region 支持按 table 分裂，支持 `Delete Range` 功能，支持设置 snapshot 导致的 I/O 上限，完善流控机制。
+- [TiDB 1.1 Beta Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-1.1-beta.md): TiDB 1.1 Beta 版本在 MySQL 兼容性和系统稳定性方面有多项改进。TiDB 新增监控项和优化日志，兼容更多 MySQL 语法，支持显示建表时间，加快查询速度，控制 Join 产生的中间结果集大小，修复多项问题，优化 SQL 引擎查询性能。PD 新增调试接口和 metrics，提高 TiKV 宕机时数据恢复优先级和恢复速度，优化 Region heartbeat 性能，修复热点调度问题。TiKV 消除潜在的 GC 问题，支持批量 resolve lock 和并行 GC，使用 RocksDB compaction listener 更新 Region Size，设置 Raft snapshot max size，支持更多修复操作，优化有序流式聚合操作，完善 metrics，修复 bug。
+- [TiDB 2.0 RC1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0-rc.1.md): TiDB 2.0 RC1 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持限制单条 SQL 语句内存使用，下推流式聚合算子到 TiKV，配置文件合法性检测，HTTP API 获取参数信息。Parser 兼容更多 MySQL 语法，提升对 Navicat 的兼容性。优化器提升，提取多个 OR 条件的公共表达式，选取更优执行计划。PD 优化检查 Region 状态的代码逻辑，异常情况下日志信息输出，修复监控中 TiKV 节点磁盘空间不足统计。TiKV 修复 PD leader 切换 gRPC call 问题，增加获取 metrics 的 gRPC API，启动时检查是否使用 SSD，使用 ReadPool 优化读性能。
+- [TiDB 2.0 RC3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0-rc.3.md): TiDB 2.0 RC3 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 修复了 MAX/MIN 结果错误、Sort Merge Join 排序问题、uint 和 int 比较错误等。PD 支持 Region Merge 和忽略有大量 pending peer 的节点。TiKV 支持 Region Merge、Raft snapshot 通知 PD 加速调度、增加 Raw DeleteRange API 等。
+- [TiDB 2.0 RC4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0-rc.4.md): TiDB 2.0 RC4 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持了一些新的语法和修复了一些问题。PD 支持手动 split Region 和优化了 metrics 及代码结构。TiKV 限制了接收 snapshot 时的内存使用，支持导数据模式和改善了在被隔离的情况下的输出问题。
+- [TiDB 2.0 RC5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0-rc.5.md): TiDB 2.0 RC5 版本发布，对 MySQL 兼容性、系统稳定性和优化器做了很多改进。TiDB 修复了多个问题，并优化了性能。PD 添加了 Raft Learner 支持，优化了 Balance Region Scheduler，并修复了多个问题。TiKV 支持了更多功能，并解决了多个问题。
+- [TiDB 2.0 release notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0-ga.md): TiDB 2.0 GA 版本发布，对 MySQL 兼容性、系统稳定性、优化器和执行器做了很多改进。包括 SQL 优化器、SQL 执行引擎、Server、兼容性、DDL、PD、TiKV 和 TiSpark 的功能、性能和稳定性优化。
+- [TiDB 2.0.1 release notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.1.md): TiDB 2.0.1 版本对 MySQL 兼容性和系统稳定性做出了改进。TiDB 新增了实时更新 `Add Index` 进度到 DDL 任务信息中的功能，添加了 Session 变量 `tidb_auto_analyze_ratio` 控制统计信息自动更新阈值的功能。修复了事务提交失败时可能未清理所有残留状态的问题，以及其他 Bug 和兼容性问题。PD 新增了 `Scatter Range` 调度和 learner 相关的 metrics，修复了多个问题。TiKV 修复了多个问题，优化了慢查询的日志，减少了 `thread_yield` 的调用次数。
+- [TiDB 2.0.10 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.10.md): TiDB 2.0.10 版本发布，修复了系统兼容性和稳定性问题。包括取消 DDL 任务可能导致的问题，ORDER BY 和 UNION 语句无法引用带表名的列的问题，UNCOMPRESS 函数错误输入长度的问题等。PD 修复了 RaftCluster 退出时可能的死锁问题，TiKV 修复了迁移 Leader 到新节点时造成请求延时问题和多余的 Region 心跳问题。
+- [TiDB 2.0.11 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.11.md): TiDB 2.0.11 版本发布，对系统兼容性和稳定性做出改进。修复了多个问题，包括 PD 异常处理问题、Rename 行为问题、ADMIN CHECK TABLE 误报问题、前缀索引错误问题和添加列导致 UPDATE 语句 panic 问题。TiKV 修复了两个 Region merge 相关问题。
+- [TiDB 2.0.2 release notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.2.md): TiDB 2.0.2 版本发布，改进了系统稳定性。TiDB 修复了 Decimal 除法内置函数下推的问题，支持 `Delete` 语句中使用 `USE INDEX` 的语法，禁止在带有 `Auto-Increment` 的列中使用 `shard_row_id_bits` 特性，并增加了写入 Binlog 的超时机制。PD 使 balance leader scheduler 过滤失连节点，更改 transfer leader operator 的超时时间为 10 秒，修复 label scheduler 在集群 Regions 不健康状态下不调度的问题，修复 evict leader scheduler 调度不当的问题。TiKV 修复了 Raft 日志没有打出来的问题，支持配置更多 gRPC 相关参数，支持配置选举超时的取值范围，修复过期 learner 没有删掉的问题，修复 snapshot 中间文件被误删的问题。
+- [TiDB 2.0.3 release notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.3.md): TiDB 2.0.3 版本在 2.0.2 版的基础上做出了改进，包括系统兼容性和稳定性的改进。TiDB 支持在线更改日志级别和 `COM_CHANGE_USER` 命令，优化查询条件代价估算和修复多个问题。PD 修复了特定条件下的问题，TiKV 修复了错误上报和除数为 0 的问题。
+- [TiDB 2.0.4 release notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.4.md): TiDB 2.0.4 版本发布，改进了系统兼容性和稳定性。TiDB 支持了新的语法和变量设置，优化了监控项和查询代价估计精度。PD 改进了调度参数行为，TiKV 新增了调试接口和命令，优化了问题和修复了崩溃。
+- [TiDB 2.0.5 release notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.5.md): TiDB 2.0.5 版本发布，改进了系统兼容性和稳定性。新增系统变量 `tidb_disable_txn_auto_retry`，调整计算 `Selection` 代价的方式，优化查询条件匹配唯一索引或主键，修复多个 bug。PD 修复副本迁移导致 TiKV 磁盘空间耗尽和 `AdjacentRegionScheduler` 导致的崩溃问题。TiKV 修复 decimal 运算中的溢出和 merge 过程中的脏读问题。
+- [TiDB 2.0.6 release notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.6.md): TiDB 2.0.6 版本在系统兼容性和稳定性方面有所改进。包括日志长度精简、记录 ADD INDEX 执行过程中的慢操作、减少更新统计信息操作中的事务冲突等。此外，修复了多个 bug，包括 DROP USER 语句和 MySQL 行为不兼容、tidb_batch_insert 打开后 INSERT/LOAD DATA 语句在某些场景下 OOM 的问题等。TiKV 方面扩大了默认 scheduler slots 值以减少假冲突现象，修复了字符串转 Decimal 时出现的 crash。
+- [TiDB 2.0.7 release notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.7.md): TiDB 2.0.7 版本在系统兼容性和稳定性方面有改进。TiDB 新增了在 `information_schema` 中添加 `PROCESSLIST` 表的功能。还对语句执行细节进行了改进，并在 `SLOW QUERY` 日志中输出更多信息。修复了多个 bug，包括 `PRIMARY KEY` 为整数的表无法使用 `USE INDEX(PRIMARY)` 的问题，以及 `Merge Join` 和 `Index Join` 在 inner row 为 `NULL` 时输出多余结果的问题。TiKV 方面，空集群默认打开 `dynamic-level-bytes` 参数减少空间放大，并在 Region merge 之后更新 Region 的 `approximate size` 和 keys。
+- [TiDB 2.0.8 release notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.8.md): TiDB 2.0.8 版本在 2.0.7 版的基础上做出了改进，包括功能改进和 Bug 修复。TiKV 也修复了节点宕机时内存持续上升的问题。
+- [TiDB 2.0.9 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.0.9.md): TiDB 2.0.9 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括统计信息、DDL JOB、Commit 操作、Limit 值、字符集支持、内建函数、主键选择率估算、Session 变量、Union 语句、统计信息清除、事务运行时间、表创建语句、取消 DDL 任务、全局环境变量等。PD 修复了 etcd 启动失败和 pd-ctl 读取 Region key 的问题。TiKV 增加了 kv_scan 接口扫描上界的限制，废弃了 max-tasks-xxx 配置，并修复了 RocksDB CompactFiles 的问题。
+- [TiDB 2.1 Beta Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1-beta.md): TiDB 2.1 Beta 版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。SQL 优化器优化了 Index Join 选择范围和关联子查询，下推 Filter 和扩大索引选择范围。SQL 执行引擎实现了并行 Hash Aggregate 和 Project 算子，提高了执行性能。Server 添加了 HTTP API 控制功能和支持 Server side cursor。兼容性方面支持更多 MySQL 语法和 SHOW PRIVILEGES 语句。PD 优化了 Balance Scheduler 和热点调度器，TiKV 升级了 Rust 版本和优化了性能。
+- [TiDB 2.1 GA Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1-ga.md): TiDB 2.1 GA 版本发布，对系统稳定性、性能、兼容性、易用性做了大量改进。包括 SQL 优化器、SQL 执行引擎、统计信息、表达式、Server、DDL、兼容性等方面的优化。PD (Placement Driver) 进行了可用性优化、调度器优化、API 及运维工具优化、监控和性能优化。TiKV 进行了 Coprocessor、Transaction、Raftstore、存储引擎和 tikv-ctl 方面的优化。同时支持全量数据快速导入工具 TiDB Lightning。升级兼容性说明包括存储引擎更新不支持回退至 2.0.x 或更旧版本，以及升级前需要确认集群中是否存在正在运行中的 DDL 操作。
+- [TiDB 2.1 RC1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1-rc.1.md): TiDB 2.1 RC1 版本于 2018 年 8 月 24 日发布。该版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、DML、DDL 等方面的改进。PD 方面新增了版本控制机制，支持集群滚动兼容升级等功能。TiKV 方面新增了支持 batch split 等新特性，以及对性能和功能进行了优化和改进。
+- [TiDB 2.1 RC2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1-rc.2.md): TiDB 2.1 RC2 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。具体包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、表达式、DML、DDL、TiKV 和 PD 的新特性、功能改进和 Bug 修复。
+- [TiDB 2.1 RC3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1-rc.3.md): TiDB 2.1 RC3 版本对系统稳定性、兼容性、优化器和执行引擎做了很多改进。包括修复了多个 SQL 优化器和执行引擎的问题，增强了部分执行器的性能，修复了配置文件内存配额选项不生效的问题，支持使用 `admin show slow` 语句来获取 SLOW QUERY LOG，修复了一些兼容性问题，增加了一些内建函数的支持，修复了一些 DML 和 DDL 的问题。PD 新增了获取按大小逆序排序的 Region 列表 API，Region API 返回更详细的信息，修复了 PD 切换 leader 后可能导致 crash 的问题。TiKV 进行了性能优化，并新增了一些函数的支持，同时修复了一些 Bug。
+- [TiDB 2.1 RC4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1-rc.4.md): TiDB 2.1 RC4 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个 SQL 优化器和执行引擎的问题，重构了 Latch，提升了并发事务的执行性能。PD 修复了多个 TiKV 下线后的问题。TiKV 优化了 apply snapshot 导致的 RocksDB Write stall 的问题，并增加了 raftstore tick 相关 metrics。
+- [TiDB 2.1 RC5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1-rc.5.md): TiDB 2.1 RC5 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括修复了多个问题，提升了性能，增加了环境变量设置功能。PD 修复了多个问题，TiKV 优化了报错信息和接口限制。
+- [TiDB 2.1.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.1.md): TiDB 2.1.1 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括时间四舍五入错误、uncompress 函数未检查数据长度、PD 故障获取错误 TSO、不规范语句导致启动失败等。DDL 改变了表的默认字符集和排序规则，增加了控制添加索引速度的变量。PD 修复了配置项无法设置为 0 的问题，避免了 transfer leader 至新创建的 Peer 产生的延迟增加问题。TiKV 也避免了相同的问题。 Lightning 优化了对导入表的 analyze 机制，提升了导入速度。 TiDB Binlog 修复了 pb files 输出 bug。
+- [TiDB 2.1.10 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.10.md): TiDB 2.1.10 发布，修复了多个 bug 和兼容性问题，增强了安全性。PD 修复了 Leader 优先级不生效的问题。TiKV 修复了多个问题，包括 transfer leader 中可能发生的脏读问题。TiDB Lightning 新增了发送数据到 importer 失败时进行重试的功能。TiDB Binlog 优化了 Pump storage 组件 log。TiDB Ansible 更新了配置文件，新增了 tidb_lightning_ctl 脚本。
+- [TiDB 2.1.11 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.11.md): TiDB 2.1.11 发布，修复多表 join 删除错误 schema 问题，更新统计信息合并反馈信息，修复函数返回错误字段类型问题，修复时间计算错误问题，修复与 MySQL 8.0 不兼容问题，支持 SHOW OPEN TABLES 语句，修复 goroutine 泄露问题，修复设置 tidb_snapshot 变量时间格式解析出错问题。PD 修复热点 Region 调度问题，新增热点调度优先级配置项。TiKV 修复 leader, learner 读到空 index 问题，处理锁命令放在高优先级线程池中。TiDB Binlog 新增 GC 删数据限速功能。TiDB Ansible 新增 Drainer 参数。
+- [TiDB 2.1.12 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.12.md): TiDB 2.1.12 发布，修复了多个 bug，包括类型不匹配导致进程 panic、字符集改变导致类型变化、事务中的 GRANT 误报错误等问题。同时提升了与 MySQL 的兼容性，修复了 TiDB 跟 TiKV 在 gRPC 最大封包设置不一致导致的超大封包报错问题。PD 修复了极端情况下 etcd Leader 选举阻塞的问题，TiKV 修复了 Leader 迁移过程中 Region 不可用的问题和异常掉电导致丢数据的问题。
+- [TiDB 2.1.13 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.13.md): TiDB 2.1.13 发布，新增了列属性包含 `AUTO_INCREMENT` 时利用 `SHARD_ROW_ID_BITS` 打散行 ID 功能，优化无效 DDL 元信息存活时间，修复了在大并发场景下 OOM 的问题，新增了 `update-stats` 配置项，新增了 3 个 TiDB 特有语法，修复了某些情况下 `KILL` 语句导致的 panic 问题，增强了 `ADD_DATE` 在某些情况下跟 MySQL 的兼容性，修复了 index join 中内表过滤条件在某些情况下的选择率估计错误的问题。TiKV 修复了因迭代器未检查状态导致系统生成残缺 snapshot 的问题，新增了检查 `block-size` 配置的有效性功能。TiDB Binlog 修复了 Pump 因写入失败时未检查返回值导致偏移量错误问题，Drainer 新增了 `advertise-addr` 配置，支持容器环境中使用桥接模式。
+- [TiDB 2.1.14 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.14.md): TiDB 2.1.14 发布说明：修复查询结果不正确的问题，支持自动调整 Auto ID 分配的步长，新增全局系统变量 `max_execution_time`，修复内存配额超出时返回结果不正确的问题，禁用 `TRACE` 语句，新增系统表控制函数下推，优化 Raftstore 消息处理，调整无效配置项日志级别，新增 Binlog 配置项，修复 Binlog 更新失败问题，新增 Ansible 命令预检查功能。
+- [TiDB 2.1.15 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.15.md): TiDB 2.1.15 发布，修复了多个函数处理微秒、空值比较、插入参数、索引建立等问题，并新增了多个 SQL 语句和监控项。TiKV 统一日志格式，提高了调度准确度。PD 也统一了日志格式。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修复了导入错误问题。TiDB Ansible 新增监控项用于监测 SQL 语句解析耗时和执行计划编译耗时。
+- [TiDB 2.1.16 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.16.md): TiDB 2.1.16 发布，修复了 SQL 优化器和执行引擎的多个问题。TiKV 支持逆向 raw_scan 和 raw_batch_scan 接口。TiDB Binlog 和 TiDB Lightning 做了一些功能增强和 bug 修复。TiDB Ansible 也有多个 bug 修复和功能优化。
+- [TiDB 2.1.17 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.17.md): TiDB 2.1.17 发布，新增了 `SHOW TABLE REGIONS` 语法的 `WHERE` 条件子句，以及 TiKV、PD 的 `config-check` 功能。PD 优化调度流程，TiKV 优化启动流程。TiDB 慢日志中的 `start ts` 和 `Index_ids` 字段有改动。SQL 优化器和执行引擎修复了多个问题。DDL 改进了 `SPLIT TABLE` 语法的行为。TiKV 解决了一些问题并新增了 `config-check` 选项。PD 新增了 `config-check` 选项和 `remove-tombstone` 命令。Reparo 新增了配置项，用于控制恢复速率。TiDB Ansible 更新了 Spark 版本和修复了连接等待问题。
+- [TiDB 2.1.18 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.18.md): TiDB 2.1.18 发布，修复了多项 SQL 优化器和执行引擎的问题，改进了 Server、DDL 和 Monitor 功能，同时 TiDB Ansible 也有多项更新。
+- [TiDB 2.1.19 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.19.md): TiDB 2.1.19 发布，包含了对 SQL 优化器、SQL 执行引擎、Server、DDL、TiKV、PD 和 TiDB Ansible 的多项修复和优化。修复了多个查询和更新语句中可能出现的错误，提升了系统稳定性和性能。
+- [TiDB 2.1.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.2.md): TiDB 2.1.2 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括索引 panic、优化器执行计划、字符集检查和时间类型字段错误。PD 修复了 Region Merge 相关问题，TiKV 支持日为时间单位的配置格式，并解决了配置兼容性问题，修复了 Approximate Size Split 和两个 Region merge 相关问题。TiDB Lightning 支持最小 TiDB 集群版本为 2.1.0，修复了解析 JSON 类型数据文件内容出错和使用 checkpoint 重启后的错误。TiDB Binlog 消除了往 Kafka 写数据的瓶颈点，支持写 Kafka 版本的 TiDB Binlog。
+- [TiDB 2.1.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.3.md): TiDB 2.1.3 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个问题，包括 Prepared Plan Cache panic、Range 计算错误、统计信息溢出、Generated Column 在 Update 中 Panic 等。还支持了一些新特性，如对 `_tidb_rowid` 构造查询的 Range、`CASE` 子句返回 JSON 类型等。PD 修复了 Leader 选举相关的 Watch 问题，TiKV 支持了使用 HTTP 方式获取监控信息，并修复了一些问题。TiDB Binlog 也修复了一些启动或重启时的问题。
+- [TiDB 2.1.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.4.md): TiDB 2.1.4 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个函数处理结果不正确的问题，优化了服务器日志和 DDL 操作。TiKV 修复了关闭时可能发生重复写的问题和事件监听器处理异常的问题。工具方面优化了内存使用，减少了对 dump 文件的解析，提高了导入稳定性。数据同步对比统计支持使用 TiDB 统计信息来划分 chunk。
+- [TiDB 2.1.5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.5.md): TiDB 2.1.5 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括优化器 / 执行器、Server、DDL、PD、TiKV 和 Tools 的改进和修复。
+- [TiDB 2.1.6 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.6.md): TiDB 2.1.6 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括索引扫描选择问题、聚合函数兼容性问题、变量设置导致的 Panic 问题等。TiKV 修复了解析 protobuf 失败导致的错误。Lightning 修复了多个导入相关的问题，并支持 CSV 格式。
+- [TiDB 2.1.7 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.7.md): TiDB 2.1.7 发布，修复了 DDL 取消导致升级程序启动时间变长的问题，提升了内置函数的兼容性，新增了系统表管理 Table 与 Index 之间的关系，支持在 DO 语句中使用子查询，修复了对 JSON 数据的聚合函数在计算过程中 Panic 的问题。PD 修改副本数为 1 时 balance-region 无法迁移 leader 的问题。Tools 支持 binlog 同步 generated column。TiDB Ansible 将 Prometheus 监控数据默认保留时间改成 30d。
+- [TiDB 2.1.8 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.8.md): TiDB 2.1.8 发布，修复了多个函数和语句的兼容性问题，优化了日志格式规范和统计信息估算准确性。PD 和 TiKV 也有多项修复和优化。工具方面，Lightning 和 Binlog Pump 等新增了多项配置和性能优化。TiDB Ansible 修改了操作系统版本限制和滚动升级版本限制。
+- [TiDB 2.1.9 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-2.1.9.md): TiDB 2.1.9 发布，修复了多个函数和权限检查问题，支持指定 collation 为 utf8mb4_0900_ai_ci，改进了慢日志输出和 PD 服务支持。 TiKV 修复了在 transfer leader 时的问题。 TiDB Binlog 和 TiDB Lightning 也有多个修复和改进。 TiDB Ansible 更新了文档链接和移除了一个参数。
+- [TiDB 3.0 Beta Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0-beta.md): TiDB 3.0 Beta 版本发布，新增支持 View、窗口函数、Range 分区、Hash 分区等特性。SQL 优化器做了很多改进，包括重新支持聚合消除、优化 `NOT EXISTS` 子查询、支持 Index Join 等。SQL 执行引擎优化了 Merge Join 算子、日志打印等功能。权限管理增加了对 `ANALYZE`、`USE`、`SET GLOBAL`、`SHOW PROCESSLIST` 语句的权限检查。Server 支持了 `Trace` 功能、插件框架、`unix_socket` 和 TCP 连接等功能。兼容性方面支持了 `ALLOW_INVALID_DATES` SQL mode、load data 对 CSV 文件的容错能力等。DDL 支持了快速恢复误删除的表、动态调整 ADD INDEX 的并发数等功能。Tools 方面 TiDB Lightning 大幅优化了 SQL 转 KV 的处理速度。PD 和 TiKV 也做了很多功能增加和优化。
+- [TiDB 3.0 GA Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0-ga.md): TiDB 3.0 GA 版本于 2019 年 6 月 28 日发布，对应的 TiDB Ansible 版本为 3.0.0。V3.0.0 版本相比 V2.1 在稳定性、易用性、性能和新功能方面有重要改进。新增功能包括窗口函数、视图、分区表、插件系统、悲观锁、SQL Plan Management 等。SQL 优化器和执行引擎也有多项优化，包括对 `NOT EXISTS` 子查询、`Outer Join`、`IN` 子查询、Index Join 等的性能提升。PD 新增了从单个节点重建集群的功能，将 Region 元信息从 etcd 移至 go-leveldb 存储引擎。TiKV 新增了分布式 GC、并行 Resolve Lock、多线程 Raftstore 和 Apply 等功能，以及对 Engine、Server、RaftStore 和 Coprocessor 的优化。Tools 方面 TiDB Lightning 新增了多项功能，TiDB Binlog 新增了多项功能，sync-diff-inspector 也新增了多项功能。TiDB Ansible 升级了监控组件版本，新增了多项监控面板和功能。
+- [TiDB 3.0.0 Beta.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.0-beta.1.md): TiDB 3.0.0 Beta.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、权限管理、Server、DDL、PD、TiKV 和 Tools 的更新。
+- [TiDB 3.0.0-rc.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.0-rc.1.md): TiDB 3.0.0-rc.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Tools 和 TiDB Ansible 的更新和修复。
+- [TiDB 3.0.0-rc.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.0-rc.2.md): TiDB 3.0.0-rc.2 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL 和 PD 的更新。TiKV 的更新包括 Engine、Server、Raftstore 和 Coprocessor 的改进。工具方面，TiDB Binlog 增加下游同步延迟监控项，TiDB Lightning 支持数据库合并和新增 KV 写入失败重试机制。
+- [TiDB 3.0.0-rc.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.0-rc.3.md): TiDB 3.0.0-rc.3 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Transaction、tikv-ctl、Misc 等方面的修复和新增功能。TiDB Ansible 新增预测集群最大 QPS 的监控项。
+- [TiDB 3.0.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.1.md): TiDB 3.0.1 发布，新增多项功能和修复了多个问题。TiKV 新增了对 Blob 文件大小的统计和死锁检测性能的提升。PD 优化了热点 Region 调度策略和 Region Merge 处理逻辑。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修正了导入错误的问题。TiDB Ansible 新增了预检查功能和更新了监控信息。
+- [TiDB 3.0.10 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.10.md): TiDB 3.0.10 发布，修复了多个 bug 和性能问题。TiKV 修复了 Region merge 失败导致系统 Panic 的问题。PD 自动更新 Region 缓存信息，解决缓存失效问题。TiDB Binlog 支持 relay log。TiDB Lightning 优化配置项和修复 web 界面无法打开的问题。TiDB Ansible 修复获取不到 PD Leader 导致命令执行失败的问题，并新增多个监控项。
+- [TiDB 3.0.11 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.11.md): TiDB 3.0.11 发布，包含兼容性变化、新功能和 Bug 修复。新增配置项 `max-index-length` 控制索引最大长度，显示分区表的分区元信息，以及 TiDB 集群之间数据双向复制功能。Bug 修复包括查询结果不正确、Goroutine 泄露等问题。TiKV 也进行了日志输出优化和问题修复。TiDB Ansible 修复了失效文档链接和未定义变量问题。
+- [TiDB 3.0.12 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.12.md): TiDB 3.0.12 发布日期为 2020 年 3 月 16 日。该版本存在一些已知问题，建议使用最新版本。兼容性变化包括修复慢日志中记录 prewrite binlog 时间计时不准确的问题。新功能包括动态加载已被替换的证书文件，添加配置项，限流功能，以及在 binlog 写入失败时 TiDB 退出。Bug 修复包括保证原子性，悲观锁加锁问题修复，建索引长度超过限制时的报错信息显示，FROM_UNIXTIME 函数小数点位数不正确的问题修复，以及其他问题的修复。
+- [TiDB 3.0.13 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.13.md): TiDB 3.0.13 发布日期为 2020 年 04 月 22 日。此版本修复了 TiDB 和 TiKV 中的一些 bug。其中 TiDB 修复了由于未检查 `MemBuffer`，事务内执行 `INSERT ... ON DUPLICATE KEY UPDATE` 语句插入多行重复数据可能出错的问题。TiKV 修复了重复多次执行 `Region Merge` 导致系统被阻塞的问题，阻塞期间服务不可用。
+- [TiDB 3.0.14 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.14.md): TiDB 3.0.14 发布日期为 2020 年 5 月 9 日。该版本兼容性变化包括 `performance_schema` 和 `metrics_schema` 由读写改为只读。重点修复的 Bug 包括 join 条件在 handle 列上存在多个等值条件时，index join 查询结果错误等问题。新功能包括 `admin show ddl jobs` 查询结果中添加库名和表名列等功能。Bug 修复包括 `WEEKEND` 函数在 SQL mode 为 `ALLOW_INVALID_DATES` 时结果与 MySQL 不兼容等问题。TiKV 也有相关 Bug 修复，如节点隔离恢复之后无法被正确删掉等问题。
+- [TiDB 3.0.15 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.15.md): TiDB 3.0.15 发布，新增禁止分区表查询使用 plan cache 功能、支持 admin recover index、admin check index 语句、优化统计信息 CMSketch 的内存分配机制等功能。PD 新增按照 Leader 个数调度的策略。修复了多处 Bug，包括 Hash 聚合函数中的深拷贝方式、点查整数溢出处理逻辑、CHAR() 函数查询条件处理逻辑等问题。TiKV 修复了长时间运行后碎片整理不再有效、系统意外重启后删除 snapshot 文件导致系统 panic、消息包过大导致 gRPC 连接断开的问题。
+- [TiDB 3.0.16 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.16.md): TiDB 3.0.16 发布，优化了 hash partition pruning 和 Region 设置，修复了多个 Bug，包括锁住的 primary key 造成的结果不一致问题和 JSON 数据中 int 和 float 类型比较的问题。TiKV 也进行了稳定性优化和 Bug 修复。PD 修复了查询 Region 报 404 错误的问题。
+- [TiDB 3.0.17 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.17.md): TiDB 3.0.17 发布，修复了多个 bug，包括查询返回错误和函数处理问题。优化了配置项和 HTTP API 访问速度。TiKV 修复了数据读取和调度问题，新增了配置支持。TiDB Lightning 解决了参数不生效的问题，并新增了更简单易用的过滤规则。
+- [TiDB 3.0.18 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.18.md): TiDB 3.0.18 发布，提升了 TiDB Binlog 工具的细粒度 Pump GC 时间支持。修复了 TiDB 中 Hash 函数对 Decimal 类型的错误处理问题，以及对 Set 和 Enum 类型的错误处理问题。还修复了 Duplicate Key 检测在悲观事务下失效的问题，以及其他执行结果错误的问题。TiKV 将 GC 的失败日志级别改为 Warning。TiDB Lightning 修复了多个命令行参数和使用 TiDB backend 时的问题。
+- [TiDB 3.0.19 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.19.md): TiDB 3.0.19 发布，兼容性变化包括更改 PD 的导入路径和版权信息。提升改进方面，缓解故障恢复对 QPS 的影响，支持调整 `union` 运算符的并发数。Bug 修复包括解决 `slow-log` 文件不存在导致查询出错的问题，添加权限检查命令，修复类型转换问题等。TiKV 修复了 status server 解析响应出错导致 panic 的问题。TiDB Lightning 修复了严格模式下 CSV 中遇到不合法 UTF 字符集没有及时退出进程的问题。
+- [TiDB 3.0.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.2.md): TiDB 3.0.2 发布日期为 2019 年 8 月 7 日。该版本修复了多个 SQL 优化器和执行引擎的问题，包括修复了查询结果列名称不正确、LIKE 表达式被隐式转换为 0、SHOW 语句中使用子查询等问题。此外，还修复了 TiKV panic、悲观事务下 Insert 行为不正确等问题。PD 也修复了 Scatter Region 调度器不能工作等 bug。TiDB Ansible 也有多个修复和更新，包括修复了 Disk Performance 监控单位错误、新增了 TiDB Summary Dashboard 等。
+- [TiDB 3.0.20 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.20.md): TiDB 3.0.20 发布，兼容性更改包括废弃 `enable-streaming` 配置项。改进提升包括优化 `LOAD DATA` 语句执行报错信息。Bug 修复包括缓存悲观事务提交状态问题、查询统计信息不准确问题等。TiKV 修复事务删除 key 报错问题，PD 修复启动时打印过量日志问题。
+- [TiDB 3.0.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.3.md): TiDB 3.0.3 发布，包含了多项 SQL 优化器和执行引擎的修复，以及 Server、DDL、Monitor、TiKV、PD、Tools 和 TiDB Ansible 的更新和修复。
+- [TiDB 3.0.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.4.md): TiDB 3.0.4 发布日期为 2019 年 10 月 8 日。此版本新增了系统表 `performance_schema.events_statements_summary_by_digest` 用于排查 SQL 性能问题。同时，TiDB 的 `SHOW TABLE REGIONS` 语法新增了 `WHERE` 条件子句。此外，Reparo 新增了 `worker-count` 和 `txn-batch` 配置项，用于控制恢复速率。还修复了一些问题，如特殊语法 `PRE_SPLIT_REGIONS` 没有使用注释的方式向下游同步的问题。
+- [TiDB 3.0.5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.5.md): TiDB 3.0.5 发布，包含 SQL 优化器和执行引擎的多项修复和改进，支持事务 TTL 修改接口函数，以及对 Region Cache TTL 的配置修改。TiKV 新特性包括悲观事务 Cleanup 接口支持和 Raftstore 性能优化。PD 提高了 Region 占用空间的精度和 label 监控可读性。TiDB Binlog 和 TiDB Lightning 也有多项修复和功能增强。TiDB Ansible 更新了监控表达式和配置文件内容。
+- [TiDB 3.0.6 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.6.md): TiDB 3.0.6 发布，包含多项 SQL 优化器和执行引擎的修复和优化，以及 Server、DDL、TiKV、PD 和 Tools 的更新和修复。TiKV 修复了悲观锁支持和 GC worker 写入量限制等问题。PD 添加了新维度和降低日志级别。Tools 中 TiDB Binlog 和 TiDB Lightning 也有多项修复和新增配置。
+- [TiDB 3.0.7 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.7.md): TiDB 3.0.7 发布，修复了多个问题，包括本地时间落后导致锁的 TTL 过大、解析日期时时区不正确、整型数据转换精度丢失等问题。TiKV 也修复了死锁检测和内存泄漏问题。
+- [TiDB 3.0.8 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.8.md): TiDB 3.0.8 发布，修复了 SQL 优化器、SQL 执行引擎、DDL、Server、Transaction、Monitor 等方面的多个问题。TiKV 也进行了多项修复和优化。PD 新增了一些功能，并升级了 etcd 版本。TiDB Ansible 进行了配置项回滚和优化，TiSpark 版本升级到 2.1.8。
+- [TiDB 3.0.9 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.0.9.md): TiDB 3.0.9 发布日期为 2020 年 1 月 14 日。该版本修复了一些已知问题，并提升了性能。包括 Executor 修复了聚合函数作用于枚举和集合列时结果不正确的问题，Server 支持了系统变量 `auto_increment_increment` 和 `auto_increment_offset`，新增了监控项等。TiKV 提升了 Raft 成员变更的速度，新增了监控项用于监控 `waiter` 的生命周期等。PD 新增了一些功能和修复了一些问题。Tools 方面也有一些新增和优化。TiDB Ansible 优化了 Lightning 部署。
+- [TiDB 3.1 Beta Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.1.0-beta.md): TiDB 3.1 Beta 发布说明：发版日期为 2019 年 12 月 20 日，TiDB 版本为 3.1.0-beta，TiDB Ansible 版本为 3.1.0-beta。TiDB 新增 SQL 优化器和丰富的 SQL hint 功能。另外，TiDB 还支持 Follower Read 功能。TiKV 新增支持分布式备份恢复功能和 Follower Read 功能。PD 也新增支持分布式备份恢复功能。
+- [TiDB 3.1 Beta.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.1.0-beta.1.md): TiDB 3.1 Beta.1 发布日期为 2020 年 1 月 10 日。TiDB 版本为 3.1.0-beta.1，TiDB Ansible 版本也为 3.1.0-beta.1。TiKV 新增了备份功能和 SST 文件恢复修复。Tools 中 BR 组件修复了备份进度信息不准确的问题，并新增了自动调度 PD schedulers 功能。TiDB Ansible 新增了初始化阶段自动关闭操作系统 THP 的功能和 BR 组件的 Grafana 监控。
+- [TiDB 3.1 Beta.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.1.0-beta.2.md): TiDB 3.1 Beta.2 发布日期为 2020 年 3 月 9 日。该版本存在已知问题，建议使用最新版本。兼容性变化包括 TiDB Lightning 配置项优化和新增命令行参数。新功能包括支持在列属性上添加 `AutoRandom` 关键字，新增通过 DDL 语句为表创建、删除列存储副本的功能等。Bug 修复包括修复静默 Region 读数据处理不当导致无法处理读请求的问题等。
+- [TiDB 3.1 GA Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.1.0-ga.md): TiDB 3.1 GA 发布说明：兼容性变化包括支持报告状态配置项和 BR 不支持旧版 TiKV 集群恢复。新功能包括展示 coprocessor 任务信息和减少日志冗余信息。PD 优化热点 Region 调度，TiFlash 添加读写负载信息和支持函数下推。TiDB Ansible 新增 TiFlash 监控和优化配置参数。Bug 修复包括修复 merge join 和计算选择率问题。TiKV 修复 replica read 和 restore 问题，TiFlash 修复同步 schema 和数据丢失问题。TiDB Binlog 修复因 TiFlash 相关 DDL job 导致同步中断问题，BR 修复 checksum 和增量备份失败问题。
+- [TiDB 3.1 RC Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.1.0-rc.md): TiDB 3.1 RC 发布日期为 2020 年 4 月 2 日。该版本存在已知问题，建议使用最新版本 3.1.x。新功能包括性能提升、数据恢复、TLS 证书动态更新等。Bug 修复包括信息 schema 错误、DDL 卡住、冲突检测失效等。PD 修复了数据竞争、规则未遵守等问题。工具方面优化了性能、修复了数据错误和无法恢复的问题。
+- [TiDB 3.1.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.1.1.md): TiDB 3.1.1 发布，新增了 auto_rand_base 表选项和 Feature ID 注释。TiFlash 优化了读写负载相关图表和 chunk encode decimal 数据的流程。修复了隔离读设置不生效、hash 分区表上的分区选择语法报错、update sql 中包含 view 仍然报错等问题。TiFlash 修复了非 normal 状态时读取数据错误、表名映射方式支持 recover table/flashback table、数据存储路径问题、读模型优化和特殊字符导致无法启动的问题。BR 修复了恢复带有 auto_random 属性的表后插入数据触发 duplicate entry 错误的问题。
+- [TiDB 3.1.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-3.1.2.md): TiDB 3.1.2 发布日期为 2020 年 6 月 4 日。此版本修复了 TiKV 和 Tools 中的一些错误，包括 S3 和 GCS 备份恢复时的错误处理问题，备份过程中的 DefaultNotFound 错误，以及 BR 在备份恢复到 S3 和 GCS 存储时的稳定性提升等问题。同时还修复了 BR 在恢复数据时出现的一些错误，并增加了备份恢复 S3 时的 AWS KMS 服务端加密支持。
+- [TiDB 4.0 Beta Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.0-beta.md): TiDB 4.0 Beta 发布说明：TiDB 版本 4.0.0-beta 和 TiDB Ansible 版本 4.0.0-beta 已发布。更新内容包括性能优化、新功能支持、bug 修复等。详细信息请查阅官方发布说明。
+- [TiDB 4.0 GA Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0-ga.md): TiDB 4.0 GA 发布日期为 2020 年 5 月 28 日。该版本包含兼容性变化、重点修复的 Bug、新功能、Bug 修复等内容。其中 TiDB 新增了多项配置项和语法支持，TiFlash 修复了多项功能不一致的问题，TiKV 修复了多个备份和系统 panic 相关的问题，PD 修复了删除调度器和 presplit 功能无法正常使用的问题，Tools 中 BR 修复了从云存储恢复数据失败的问题，TiCDC 修复了多个系统 panic 和资源泄露的问题。
+- [TiDB 4.0 RC Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.0-rc.md): TiDB 4.0 RC 发布日期为 2020 年 4 月 8 日，版本为 4.0.0-rc，TiUP 版本为 0.0.3。该版本存在已知问题，建议使用最新版本 4.0.x。兼容性变化包括 TiDB、TiKV 和 Tools 的更新。重点修复了 TiDB 的 Bug，并新增了一些功能。TiKV 修复了启用 Follower Read 功能导致系统 Panic 的问题。Tools 中 TiDB Lightning 修复了字符转换错误导致数据错误的问题，TiCDC 新增了一些功能。
+- [TiDB 4.0 RC.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.0-rc.1.md): TiDB 4.0 RC.1 发布说明：TiDB 4.0.0-rc.1 版本兼容性变化包括 TiKV 默认关闭 hibernate region，TiDB Binlog 增加对 Sequence DDL 的支持。重点修复了多个 Bug，包括 TiDB 事务内执行 INSERT ... ON DUPLICATE KEY UPDATE 语句插入多行重复数据可能出错的问题等。新增功能包括 TiDB 支持发送 batch coprocessor 请求给 TiFlash 等。Bug 修复包括 TiDB 系统表由于 unsigned 列定义导致无法正确显示负数的问题等。
+- [TiDB 4.0 RC.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.0-rc.2.md): TiDB 4.0 RC.2 发布说明：兼容性变化包括事务容量上限统一为 10GB，查询 CLUSTER_LOG 表需指定时间范围，CREATE TABLE 创建分区表时指定未支持的选项将创建非分区普通表。重点修复了多个 Bug。新增了备份和恢复语句，支持预检查单个 Region 提交数据量。TiKV 新增了加密存储适配和配置 gRPC 消息大小上限。PD 修复了 pd-ctl 命令错误和缺失监控的问题。TiFlash 优化了系统负载和新增了容量配置参数。Tools 方面修复了多个问题和优化了功能。
+- [TiDB 4.0.0 Beta.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.0-beta.1.md): TiDB 4.0.0 Beta.1 发布，包含兼容性变化、新功能和 Bug 修复。兼容性变化包括配置项类型修改和默认值调整。新增慢日志系统表支持查询任意时间段的日志，SQL 性能诊断功能和 Sequence 功能。Bug 修复包括视图创建、时区修改和函数表达式问题。TiKV 和 PD 也有新增功能和 Bug 修复。TiDB Ansible 新增部署多个 Grafana/Prometheus/Alertmanager 的功能和 TiFlash 监控 Dashboard。
+- [TiDB 4.0.0 Beta.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.0-beta.2.md): TiDB 4.0.0 Beta.2 发布日期为 2020 年 3 月 18 日。该版本修复了 TiDB Binlog 在配置 `disable-dispatch`、`disable-causality` 时系统直接报错并退出的问题。新增了 TiKV 和 PD 支持将动态修改配置的结果持久化存储到硬盘的功能。另外，TiDB Binlog 新增了 TiDB 集群之间数据双向复制功能，TiDB Lightning 新增了配置 TLS 功能，新增了 TiCDC 工具，提供了进程级别的高可用能力。此外，BR 开启了增量备份、支持将备份文件存储在 AWS S3 等实验性功能。TiDB Ansible 新增了将节点信息注册到 etcd 的功能，新增支持在 ARM 平台上部署 TiDB 服务的功能。修复了 TiKV、PD 和 Tools 中的多个 bug。
+- [TiDB 4.0.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.1.md): TiDB 4.0.1 发布日期为 2020 年 6 月 12 日。新功能包括 TiKV 添加 `--advertise-status-addr` 启动参数，PD 支持内部代理和客户端自定义超时设置，TiFlash 支持新的排序规则框架和函数下推，以及 BR 增加集群版本检查。Bug 修复方面，TiKV 修复了多个问题，PD 修复了错误配置和 panic 问题，TiFlash 修复了默认值解析和时区计算错误的问题。
+- [TiDB 4.0.10 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.10.md): TiDB 4.0.10 发布日期为 2021 年 1 月 15 日。新功能包括 PD 添加了配置项 `enable-redact-log` 和 TiFlash 添加了配置项 `security.redact_info_log`。改进提升方面，TiDB 添加了 `txn-entry-size-limit` 配置项，PD 优化了 `store-state-filter` 监控，Tools 中 TiCDC 默认开启了 old value 特性。Bug 修复方面，TiDB 修复了多个并发导致的问题，TiKV 修复了 peer 和 ready 之间的错误映射，PD 修复了 ID 分配不是单调递增的问题，TiFlash 修复了多个启动和函数调用的问题，Tools 中 TiCDC 修复了多个协议和内存问题，Dumpling 修改了默认设置的行为。 Backup & Restore (BR) 修复了多个备份和恢复问题，TiDB Binlog 修复了启用 `AMEND TRANSACTION` 特性时的问题，TiDB Lightning 修复了多个备份和使用问题。
+- [TiDB 4.0.11 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.11.md): TiDB 4.0.11 发布，新增支持 `uft8_unicode_ci` 和 `utf8mb4_unicode_ci` 排序规则。TiKV 支持 `utf8mb4_unicode_ci` 和 `cast_year_as_time` 排序规则。TiFlash 增加排队处理 Coprocessor 任务的线程池。改进包括重排由 `outer join` 简化的 `inner join` 顺序，Grafana 面板支持多集群，Bug 修复包括修复异常的 `unicode_ci` 常数传递等。PD 修复成员健康的监控显示不正确的问题。TiFlash 修复 Decimal 类型的 `min`/`max` 计算结果错误等。Tools 修复 TiCDC 服务在同时发生 `ErrTaskStatusNotExists` 和 `capture` 会话关闭的情况下的非预期的退出等。
+- [TiDB 4.0.12 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.12.md): TiDB 4.0.12 发布，新增 TiFlash 工具用于检测状态。优化了 EXPLAIN 语句输出信息，在 metrics 监控中记录了 PREPARE 执行失败的问题。TiKV 修复了多个问题，包括处理 JSON 向字符串转换时空格缺失的问题。PD 修复了 store 缺失 label 的隔离级别错误问题。TiFlash 修复了多个查询结果错误的问题。TiCDC 修复了多个数据丢失和资源释放问题。BR 修复了多个备份和恢复问题。TiDB Lightning 修复了多个数据错误和文件损坏问题。
+- [TiDB 4.0.13 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.13.md): TiDB 4.0.13 发布，新增 `AUTO_INCREMENT` 变更为 `AUTO_RANDOM` 功能，引入 `infoschema.client_errors_summary` 表。提升内存中统计信息缓存，减少 CPU 使用率。TiKV 提高 `store used size` 计算准确性，返回更多的 Region 以降低 Region miss。PD 优化 TSO 处理时间统计指标，更新 Dashboard 版本。TiFlash 自动清除过期历史数据。BR 支持备份恢复系统库，检查集群版本和备份数据版本。TiCDC 增加流程控制，清理陈旧临时文件，增加 HTTP 接口调用。修复多个 Bug。
+- [TiDB 4.0.14 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.14.md): TiDB 4.0.14 发布，包含兼容性更改、功能增强、改进提升和 Bug 修复。兼容性更改包括默认值修改和配置项更新。功能增强包括监控项添加和新功能支持。改进提升包括算子优化和系统变量支持。Bug 修复包括查询结果错误和函数参数错误修复。PD、TiDB Dashboard、TiFlash 和 Tools 也有相关更新和修复。
+- [TiDB 4.0.15 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.15.md): TiDB 4.0.15 发布，修复了执行 `SHOW VARIABLES` 速度慢的问题，以及多个 Bug 和兼容性变化。TiKV 支持动态修改 TiCDC 配置。TiDB 基于直方图的 row count 来触发 auto-analyze。TiKV 分离处理读写的 ready 状态以减少读延迟。PD 提升了同步 Region 信息的性能。BR 支持并发执行分裂和打散 Region 的操作。Dumpling 提升了 `SHOW TABLE STATUS` 的过滤效率。TiCDC 支持导入数据到带有表达式索引或带有基于虚拟生成列的索引的表中。修复了多个 Bug 和问题。
+- [TiDB 4.0.16 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.16.md): TiDB 4.0.16 发布，包含兼容性更改、提升改进和 Bug 修复。TiKV 改进了对非法 UTF-8 字符串的处理，Tools 中 TiCDC 改变了 Kafka Sink 默认值。TiDB 升级了 Grafana，TiKV 使用 zstd 算法压缩 SST 文件。Bug 修复包括统计信息模块的查询崩溃、`ENUM` 类型控制函数返回结果不正确等问题。TiKV 修复了多个问题，包括 Decimal 除法计算结果为负、监控项中 gRPC 平均延迟时间不准确等问题。PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了无法启动的问题。Tools 中 TiDB Binlog 修复了 Drainer 传输事务超过 1 GB 时退出的问题，TiCDC 修复了多个问题。
+- [TiDB 4.0.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.2.md): TiDB 4.0.2 发布，兼容性改进和新功能增加。TiDB 默认收集使用情况信息，并分享给 PingCAP 用于改善产品。新增功能包括支持 INSERT 语句中使用 MEMORY_QUOTA() hint，基于 TLS 证书 SAN 属性的登录认证，以及其他函数和表的新增配置项。Bug 修复包括执行计划不正确、运行时错误、内存统计过大等问题。PD、TiKV、TiFlash 和 TiCDC 也有相关改进和修复。Tools 中 Backup & Restore (BR) 提升了多表场景下的恢复数据性能。
+- [TiDB 4.0.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.3.md): TiDB 4.0.3 发布了新版本，包括 TiDB Dashboard、TiFlash、Tools 和改进提升等多个方面的更新和修复。新增功能包括 TiDB Dashboard 显示详细信息、TiFlash 支持文件加密、Tools 支持多种算法压缩备份文件等。改进提升方面包括增加全局变量控制日志记录、加速执行速度、默认打开执行信息收集等。此外，还修复了多个 Bug，包括 gRPC transportReader 异常、数据不完整、无法正确设置 safepoint 等问题。
+- [TiDB 4.0.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.4.md): TiDB 4.0.4 发布日期为 2020 年 7 月 31 日。此版本修复了多个 bug，包括查询 `information_schema.columns` 卡死的问题、`PointGet` 和 `BatchPointGet` 在遇到 `in(null)` 条件时出错的问题、`BatchPointGet` 算子结果不正确的问题以及 `HashJoin` 算子在遇到 `set`、`enum` 类型时查询结果不正确的问题。
+- [TiDB 4.0.5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.5.md): TiDB 4.0.5 发布，兼容性变化包括修改参数和添加状态检查。新增功能包括为错误定义错误码和支持统一的 log 格式。优化提升包括减少 GC 锁扫描次数和降低统计信息对性能的影响。Bug 修复包括函数错误处理和查询结果错误等。PD 修复了 TSO 不可用和 Region 调度问题。TiFlash 修复了进程启动和升级问题。Tools 修复了恢复缓慢和同步任务问题。
+- [TiDB 4.0.6 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.6.md): TiDB 4.0.6 发布日期为 2020 年 9 月 15 日。新功能包括 TiFlash 中支持在广播 Join 中使用外连接，TiDB Dashboard 添加了多个页面和功能。TiCDC 从 v4.0.6 起成为正式功能。优化提升方面，TiDB 提升了分区表的写性能，支持调整 Union 执行算子的并发度等。Bug 修复方面，TiDB 修复了多个查询结果不正确的问题。TiKV 修复了统计信息估算错误的问题等。PD 修复了 store limit 的单位问题等。TiFlash 修复了多个启动失败和异常问题。Tools 方面也有多个问题得到解决。
+- [TiDB 4.0.7 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.7.md): TiDB 4.0.7 发布，新增 PD 客户端函数 `GetAllMembers` 和 TiDB Dashboard 统计指标关系图支持。TiDB 优化了 `join` 算子执行信息和协处理器缓存命中率信息，支持将 `ROUND` 函数下推至 TiFlash，并修复了多个 bug。TiKV 支持日志输出为 JSON 格式，修复了 TLS 握手失败导致 Status API 不可用的问题。PD 修复了多个问题，TiFlash 修正了 right outer join 结果错误。Backup & Restore (BR) 修复了恢复数据后导致 TiDB 配置变更的错误，Dumpling 修复了 metadata 解析失败的问题。
+- [TiDB 4.0.8 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.8.md): TiDB 4.0.8 发布，新增聚合函数 `APPROX_PERCENTILE` 和 `CAST` 函数下推支持。优化了索引组合计算表达式选择率的贪心算法，记录更多的 RPC 信息，提升慢查询性能。修复了多个 BUG，如分区表可能遇到非预期 Panic、外连接时 Index Merge Join 结果不正确等。 PD 修复了 TiDB Dashboard 引起 PD panic 的错误。TiFlash 修复了多个问题，如日志信息中时间戳错误、重启后可能提示数据文件损坏等。Backup & Restore (BR) 修复了 Restore 期间可能发生的 `send on closed channel` panic 问题。
+- [TiDB 4.0.9 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-4.0.9.md): TiDB 4.0.9 发布日期为 2020 年 12 月 21 日。该版本包含兼容性更改、新功能、优化提升、Bug 修复等内容。兼容性更改包括废弃配置文件中的某些配置项。新功能包括 TiFlash 支持存储引擎的新数据分布在多个硬盘上等。优化提升方面包括避免生成 (index) merge join 以得到更好的执行计划等。Bug 修复方面包括修复了前缀索引和 `OR` 条件一起使用时结果不正确的问题等。
+- [TiDB 5.0 RC Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.0.0-rc.md): TiDB 5.0.0-rc 版本是 5.0 版本的前序版本。在 5.0 版本中，我们专注于帮助企业基于 TiDB 数据库快速构建应用程序，提升数据库性能、降低写入数据延迟、稳定性、可用性、容灾、SQL 语句效率等问题。新增聚簇索引、异步提交事务、Raft Joint Consensus 算法、不可见索引、`EXCEPT`/`INTERSECT` 操作符、悲观事务执行成功概率、字符集和排序规则优化、错误信息和日志信息脱敏、优化器选择索引稳定性、调度功能优化、备份与恢复、数据导入导出、`EXPLAIN` 功能优化、TiUP 增强功能等特性。
+- [TiDB 5.0.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.0.1.md): TiDB 5.0.1 发布日期为 2021 年 4 月 24 日。此版本包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括 TiDB 配置文件的默认值改变。改进提升方面，TiDB 支持 `VITESS_HASH()` 函数，TiKV 使用 `zstd` 压缩 Region Snapshot，PD 调整 Region 分数公式等。Bug 修复方面，TiDB 修复了多个查询结果可能错误的问题，TiKV 修复了多个导致问题的 Bug。Tools 方面也有多个 Bug 修复。
+- [TiDB 5.0.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.0.2.md): TiDB 5.0.2 发布日期为 2021 年 6 月 10 日。此版本包含兼容性更改、新功能、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具中的参数废弃和 TiKV 默认开启 Hibernate Region 特性。新功能包括 BR 支持 S3 兼容的存储和 TiFlash 优化锁操作。提升改进方面，TiDB 避免后台作业频繁读取表造成高 CPU 使用率，TiKV 添加背压功能和减少扫描的内存使用量。Bug 修复方面，修复了多个问题，包括索引导致的 panic、事务中的语句不正确使用、排序规则写入错误值等。
+- [TiDB 5.0.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.0.3.md): TiDB 5.0.3 发布日期为 2021 年 7 月 2 日。此版本包含兼容性更改、功能增强、提升改进和 Bug 修复。兼容性更改包括 `tidb_multi_statement_mode` 变量默认值变更和兼容 MySQL 5.7 的 noop 变量配置。功能增强方面，TiCDC 增加了 HTTP API 获取 changefeed 信息和节点健康信息。TiDB 提升了多个内置函数的支持和优化了聚合算子的代价常数。Bug 修复方面，修复了多个查询和函数使用时可能出现的问题。PD 升级了 TiDB Dashboard。TiFlash 支持了多个新功能和修复了多个问题。TiCDC、BR 和 TiDB Lightning 也进行了多项修复和优化。
+- [TiDB 5.0.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.0.4.md): TiDB 5.0.4 发布日期为 2021 年 9 月 27 日。此版本包含兼容性更改、功能增强、提升改进、Bug 修复等内容。兼容性更改包括修复了 `SHOW VARIABLES` 速度慢的问题，系统变量 `tidb_stmt_summary_max_stmt_count` 默认值修改为 `3000` 等。功能增强包括支持将系统变量 `tidb_enforce_mpp` 的值设为 `1` 以忽略优化器代价估算，强制使用 MPP 模式。提升改进包括基于直方图的 row count 来触发 auto-analyze、支持 MPP 查询的重试等。Bug 修复包括修复了查询分区表且分区键带有 `IS NULL` 条件时 TiDB 可能 panic 的问题等。
+- [TiDB 5.0.5 Release Note](https://docs.pingcap.com/zh/tidb/stable/release-5.0.5.md): TiDB 5.0.5 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。详细信息请查看 issue
+- [TiDB 5.0.6 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.0.6.md): TiDB 5.0.6 发布日期为 2021 年 12 月 31 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具的错误输出改为标准错误，以及 Kafka sink 模块的默认值设置。提升改进方面，TiDB 改进了 coprocessor 遇到锁时的调试日志显示，TiKV 提高了插入 SST 文件的速度，PD 优化了调度器退出的速度。Bug 修复方面，TiDB 修复了多个问题，包括乐观事务冲突、MPP 查询相关日志、DML 和 DDL 语句并发执行等。TiKV 修复了多个节点停机导致的问题，PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了多个数据不一致的问题。TiCDC 修复了多个同步任务推进停滞的问题。Backup & Restore (BR) 修复了平均速度不准确的问题。Dumpling 修复了导出速度过慢的问题。
+- [TiDB 5.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.1.0.md): TiDB 5.1 版本新增了许多关键特性，包括对 MySQL 8 中的公共表表达式和动态权限的支持，以及对数据表列类型的在线变更。此外，还引入了新的统计信息类型和锁视图功能，以提升查询稳定性和性能。同时，TiDB 5.1 修复了许多 Bug，包括投影消除、列包含 NULL 值时查询结果错误等问题。这些改进和修复将提升 TiDB 的性能和稳定性。
+- [TiDB 5.1.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.1.1.md): TiDB 5.1.1 发布，兼容性更改包括默认值修改和权限变更。功能增强方面新增 OIDC SSO 支持和 DAG 请求中的 `HAVING()` 函数。改进提升包括 Stale Read 成为正式功能、加快数据插入速度、稳定结果模式支持等。Bug 修复方面修复了多个问题，包括数据丢失、panic、数据不一致等。 Tools 方面也有多个修复，包括 TiCDC、Backup & Restore、TiDB Lightning。
+- [TiDB 5.1.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.1.2.md): TiDB 5.1.2 发布，包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括修复多个 Bug，改进提升包括根据直方图行数触发 auto-analyze、支持动态更改 TiCDC 配置项等。Bug 修复涉及 hash 列为 ENUM 类型时 index hash join 的结果可能出错、TiKV 从 v3.x 升级至较高版本后出现 Panic 等问题。Tools 方面的改进包括 BR 修复备份数据和恢复数据时显示的平均速度数值不准确的问题、Dumpling 修复特定 MySQL 版本下导致 dump 阶段卡死的问题等。
+- [TiDB 5.1.3 Release Note](https://docs.pingcap.com/zh/tidb/stable/release-5.1.3.md): TiDB 5.1.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
+- [TiDB 5.1.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.1.4.md): TiDB 5.1.4 发布日期为 2022 年 2 月 22 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括系统变量 `tidb_analyze_version` 默认值修改为 `1`，以及 TiKV 在开启 `storage.enable-ttl` 后拒绝 TiDB 请求。提升改进方面，TiDB 支持在 Range 类型分区表中对 `IN` 表达式进行分区裁剪，TiKV 升级了 proc filesystem 版本。Bug 修复方面，修复了多个 TiDB 和 TiKV 的问题，包括内存泄露、配置项不生效、panic 等。Tools 方面也有多个修复和改进，包括 TiCDC、Backup & Restore、TiDB Binlog 和 TiDB Lightning。
+- [TiDB 5.1.5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.1.5.md): TiDB 5.1.5 发布日期为 2022 年 12 月 28 日。此版本包含 PD 默认关闭编译 swagger server 的兼容性变更以及 TiDB、TiKV、PD、TiFlash 和 Tools 中的多项 Bug 修复。修复内容涵盖了窗口函数执行、动态模式、函数传入值计算、left join 删除数据、SQL 语句计算、连接错误、索引错误、HTTP 服务异常、并发列类型变更、空闲链接、SESSION 变量、Region 合并、KV client 连接、TiDB Binlog 错误、TiKV 运行、Raftstore 线程、Region merge、Follower Read、Async Commit、网络问题、Unified Read Pool CPU 表达式、TLS、并行聚合、查询错误、日期格式、MPP query、数据回收、逻辑运算符、备份系统表、增量扫描、Sorter 组件监控数据和 ddl schema 缓存优化。
+- [TiDB 5.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.2.0.md): TiDB 5.2 版本于 2021 年 8 月 27 日发布。该版本新增了许多功能和改进，包括支持基于部分函数创建表达式索引、提升优化器的估算准确度、锁视图成为 GA 特性等。此外，还修复了多个 bug，提升了稳定性和性能。
+- [TiDB 5.2.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.2.1.md): TiDB 5.2.1 发布日期为 2021 年 9 月 9 日。此版本修复了 TiDB 在分区中下推聚合算子时的执行计划和执行报错问题。同时，TiKV 修复了 Region 迁移时出现的死锁导致 TiKV 不可用的问题。用户可通过关闭调度并重启出问题的 TiKV 来临时应对。
+- [TiDB 5.2.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.2.2.md): TiDB 5.2.2 发布日期为 2021 年 10 月 29 日。此版本包含了对 TiDB、TiKV、PD 和 Tools 的多项提升改进和 bug 修复。其中 TiDB 修复了多项问题，如 `plan cache` 无法感知 `unsigned` 标志变化、分区功能出现 `out of range` 时 `partition pruning` 出错等。TiKV 修复了因 Congest 错误而导致的 CDC 频繁增加 scan 重试的问题等。PD 修复了因超过副本配置数量而导致错误删除带有数据且处于 pending 状态的副本的问题等。TiFlash 修复了在部分平台上由于缺失 `nsl` 库而无法启动的问题。Tools 中的 TiCDC 也进行了多项修复，如当上游 TiDB 实例意外退出时，TiCDC 同步任务推进可能停滞的问题等。
+- [TiDB 5.2.3 Release Note](https://docs.pingcap.com/zh/tidb/stable/release-5.2.3.md): TiDB 5.2.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
+- [TiDB 5.2.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.2.4.md): TiDB 5.2.4 发布日期为 2022 年 4 月 26 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB、TiKV 和 Tools 的调整。提升改进主要针对 TiKV 和 Tools 进行了优化。Bug 修复方面涉及 TiDB、TiKV、PD、TiFlash 和 Tools 的修复。
+- [TiDB 5.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.3.0.md): TiDB 5.3.0 版本发布了许多重要的功能和改进，包括临时表、表属性设置、TiDB Dashboard 安全性提升、PD 时间戳处理流程优化、DM 同步性能提升、TiDB Lightning 分布式并行导入等。此外，还修复了许多 bug，提升了稳定性和性能。
+- [TiDB 5.3.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.3.1.md): TiDB 5.3.1 发布日期为 2022 年 3 月 3 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB Lightning 工具的默认值调整。提升改进包括 TiDB、TiKV 和 PD 的优化。Bug 修复包括 TiDB、TiKV、PD、TiFlash、Backup & Restore (BR)、TiCDC、TiDB Data Migration (DM) 和 TiDB Lightning 工具的问题修复。
+- [TiDB 5.3.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.3.2.md): TiDB 5.3.2 发布日期为 2022 年 6 月 29 日。该版本存在 bug，建议升级至 v5.3.3。兼容性变更包括修复了 auto ID 超出范围时的问题。TiKV 提升了 Raft 客户端的效率，并修复了多个 bug。TiDB 修复了多个 bug，包括 Amazon S3 数据计算错误和网络连接问题。PD 也修复了多个 bug。TiFlash 修复了存储目录配置错误和数据不一致的问题。BR 和 TiCDC 也有多个 bug 修复。DM 和 TiDB Lightning 也有 bug 修复。
+- [TiDB 5.3.3 Release Note](https://docs.pingcap.com/zh/tidb/stable/release-5.3.3.md): TiDB 5.3.3 发布日期为 2022 年 9 月 14 日。此版本修复了 TiKV 存在的 bug，该 bug 导致在执行 SQL 语句时出现持续报错的问题。影响版本为 v5.3.2 和 v5.4.2，已在 v5.3.3 上修复。如果使用 v5.3.2 的 TiDB 集群，可以升级至 v5.3.3。除升级外，还可以重启无法向 PD 发送 Region 心跳的 TiKV 节点，直至不再有待发送的 Region 心跳为止。
+- [TiDB 5.3.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.3.4.md): TiDB 5.3.4 发布，提升了 TiKV 的自动 TLS 证书重新加载功能。修复了 TiDB、PD 和 TiFlash 的多个 bug，包括 Region 合并、权限清理、连接失败等问题。同时修复了工具 Dumpling 和 TiCDC 的导出数据和同步任务状态不正确的问题。
+- [TiDB 5.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.4.0.md): TiDB 5.4.0 版本发布日期为 2022 年 2 月 15 日。此版本新增了许多功能和改进，包括支持 GBK 字符集、索引合并、有界限过期数据读取、统计信息采集配置持久化等。同时还修复了许多 bug，提升了稳定性和性能。
+- [TiDB 5.4.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.4.1.md): TiDB 5.4.1 发布日期为 2022 年 5 月 13 日。该版本未引入产品设计上的兼容性变化，但 Bug 修复可能带来兼容性变更。提升改进包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个方面的改进。Bug 修复方面包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个问题的修复。
+- [TiDB 5.4.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.4.2.md): TiDB 5.4.2 发布日期为 2022 年 7 月 8 日。该版本存在 bug，建议升级至 v5.4.3。此版本提升了 TiDB、TiKV、PD 和 Tools 的稳定性和可用性，并修复了多个 bug。
+- [TiDB 5.4.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-5.4.3.md): TiDB 5.4.3 发布，提升了 TiKV 和 Tools 的功能，修复了多个 Bug。包括 TiKV 支持更小的 RocksDB write stall 参数，TiDB 修复了多个查询和执行时可能出现的问题。PD 也修复了一些请求和权限问题。TiFlash 修复了一些函数和并行聚合的错误。Tools 中的 TiDB Lightning 修复了一些数据导入和连接问题，DM 修复了一些数据同步和连接问题，BR 修复了备份恢复和 Region 不均衡的问题，Dumpling 修复了 IPv6 的支持问题。
+- [TiDB 6.0.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.0.0-dmr.md): 了解 TiDB 6.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.1.0.md): 了解 TiDB 6.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.1.1.md): TiDB 6.1.1 发布日期为 2022 年 9 月 1 日。该版本兼容性变更包括大小写敏感语句不再敏感，以及默认关闭持续性能分析特性。其他变更包括新增内容和不同操作系统和 CPU 架构的支持。提升改进方面，引入了新的优化器提示和支持通过 gzip 压缩 metrics 响应减少 HTTP body 大小。Bug 修复方面，修复了多个 TiDB、TiKV、PD 和 TiFlash 的问题。 Tools 方面，TiDB Lightning 修复了多个问题，TiDB Data Migration (DM) 修复了多个问题，TiCDC 修复了多个问题，Backup & Restore (BR) 修复了多个问题，Dumpling 修复了一个问题，TiDB Binlog 修复了一个问题。
+- [TiDB 6.1.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.1.2.md): TiDB 6.1.2 发布，包括 TiDB、TiKV、Tools 和 Bug 修复。提升改进包括允许在一张表上同时设置数据放置规则和 TiFlash 副本。Bug 修复包括修复数据库级别的权限清理不正确的问题。
+- [TiDB 6.1.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.1.3.md): TiDB 6.1.3 发布日期为 2022 年 12 月 5 日。此版本兼容性变更包括 TiCDC 的默认值修改和事务拆分功能的优化。提升改进方面，PD 优化了锁的粒度，TiCDC 默认关闭 safeMode 并开启大事务拆分功能。此外，为了提升 TiDB 稳定性，Go 编译器版本从 go1.18 升级到了 go1.19。Bug 修复方面，修复了多个 TiDB、PD、TiKV、TiFlash 和 Tools 的问题。
+- [TiDB 6.1.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.1.4.md): 了解 TiDB 6.1.4 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.1.5.md): 了解 TiDB 6.1.5 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.6 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.1.6.md): 了解 TiDB 6.1.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.7 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.1.7.md): 了解 TiDB 6.1.7 版本的改进提升与错误修复。
+- [TiDB 6.2.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.2.0.md): 了解 TiDB 6.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.3.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.3.0.md): 了解 TiDB 6.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.4.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.4.0.md): 了解 TiDB 6.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.0.md): 了解 TiDB 6.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.1.md): 了解 TiDB 6.5.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.10 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.10.md): 了解 TiDB 6.5.10 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.11 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.11.md): 了解 TiDB 6.5.11 版本的改进提升和错误修复。
+- [TiDB 6.5.12 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.12.md): 了解 TiDB 6.5.12 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.2.md): 了解 TiDB 6.5.2 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.3.md): 了解 TiDB 6.5.3 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.4.md): 了解 TiDB 6.5.4 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.5.md): 了解 TiDB 6.5.5 版本的改进提升与错误修复。
+- [TiDB 6.5.6 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.6.md): 了解 TiDB 6.5.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.7 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.7.md): 了解 TiDB 6.5.7 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.8 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.8.md): 了解 TiDB 6.5.8 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.9 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.5.9.md): 了解 TiDB 6.5.9 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.6.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-6.6.0.md): 了解 TiDB 6.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.0.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.0.0.md): 了解 TiDB 7.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.1.0.md): 了解 TiDB 7.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.1.1.md): 了解 TiDB 7.1.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.1.2.md): 了解 TiDB 7.1.2 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.1.3.md): 了解 TiDB 7.1.3 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.1.4.md): 了解 TiDB 7.1.4 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.1.5.md): 了解 TiDB 7.1.5 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.6 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.1.6.md): 了解 TiDB 7.1.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.2.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.2.0.md): 了解 TiDB 7.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.3.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.3.0.md): 了解 TiDB 7.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.4.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.4.0.md): 了解 TiDB 7.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.5.0.md): 了解 TiDB 7.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.5.1.md): 了解 TiDB 7.5.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.5.2.md): 了解 TiDB 7.5.2 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.5.3.md): 了解 TiDB 7.5.3 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.5.4.md): 了解 TiDB 7.5.4 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.5 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.5.5.md): 了解 TiDB 7.5.5 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.6 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.5.6.md): 了解 TiDB 7.5.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.6.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-7.6.0.md): 了解 TiDB 7.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.0.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-8.0.0.md): 了解 TiDB 8.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.1.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-8.1.0.md): 了解 TiDB 8.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.1.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-8.1.1.md): 了解 TiDB 8.1.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.1.2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-8.1.2.md): 了解 TiDB 8.1.2 版本的改进提升和错误修复。
+- [TiDB 8.2.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-8.2.0.md): 了解 TiDB 8.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.3.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-8.3.0.md): 了解 TiDB 8.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.4.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-8.4.0.md): 了解 TiDB 8.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.5.0 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-8.5.0.md): 了解 TiDB 8.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.5.1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-8.5.1.md): 了解 TiDB 8.5.1 版本的操作系统支持变更、改进提升，以及错误修复。
+- [TiDB Control 使用说明](https://docs.pingcap.com/zh/tidb/stable/tidb-control.md): TiDB Control 是 TiDB 的命令行工具，用于获取 TiDB 状态信息和调试。可通过 TiUP 安装或从源代码编译安装。使用介绍包括命令、选项和参数组成，以及全局参数和各子命令的功能。其中包括获取帮助信息、解码 base64 数据、解码 row key 和 value、操作 etcd、格式化日志文件，以及查询关键 key range 信息。注意：TiDB Control 主要用于诊断调试，不保证和 TiDB 未来引入的新特性完全兼容。
+- [TiDB Dashboard SQL 语句分析列表页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-statement-list.md): 查看所有 SQL 语句在集群上执行情况
+- [TiDB Dashboard SQL 语句分析执行详情页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-statement-details.md): 查看单个 SQL 语句执行的详细情况
+- [TiDB Dashboard Top SQL 页面](https://docs.pingcap.com/zh/tidb/stable/top-sql.md): 使用 Top SQL 找到 CPU 开销较大的 SQL 语句
+- [TiDB Dashboard 介绍](https://docs.pingcap.com/zh/tidb/stable/dashboard-intro.md): TiDB Dashboard 是 TiDB 4.0 版本后提供的图形化界面，用于监控和诊断集群。它内置于 TiDB 的 PD 组件中，无需独立部署。可以查看集群整体运行概况、组件及主机运行状态、集群读写流量分布、SQL 查询的执行信息、耗时较长的 SQL 语句执行信息、诊断集群问题并生成报告、查询所有组件日志、预估资源管控容量、收集分析各个组件的性能数据。
+- [TiDB Dashboard 实例性能分析 - 手动分析页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-profiling.md): 了解如何收集集群各个实例当前性能数据，从而分析复杂问题
+- [TiDB Dashboard 实例性能分析 - 持续分析页面](https://docs.pingcap.com/zh/tidb/stable/continuous-profiling.md): 了解如何持续地收集 TiDB、TiKV、PD 各个实例的性能数据，缩短平均故障恢复时间
+- [TiDB Dashboard 常见问题](https://docs.pingcap.com/zh/tidb/stable/dashboard-faq.md): TiDB Dashboard 常见问题汇总，包括访问、界面功能方面的常见问题与解决办法。若无法解决，请获取官方或社区支持。
+- [TiDB Dashboard 慢查询页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-slow-query.md): 了解如何在 TiDB Dashboard 中查看慢查询。
+- [TiDB Dashboard 日志搜索页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-log-search.md): 在集群中搜索所有节点上的日志
+- [TiDB Dashboard 概况页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-overview.md): TiDB Dashboard 概况页面显示整个集群的 QPS、查询延迟、Top SQL 语句、最近的慢查询、实例状态和监控及告警信息。登录后默认进入该页面，也可通过左侧导航条点击概况进入。包含最近一小时整个集群的 QPS 和查询延迟，以及最近一段时间内累计耗时最多的 SQL 语句和运行时间超过一定阈值的慢查询。还显示各个实例的节点数和状态，以及提供了便捷的链接方便用户查看详细监控或告警。
+- [TiDB Dashboard 流量可视化页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-key-visualizer.md): TiDB Dashboard 的流量可视化页面可用于分析 TiDB 集群的使用模式和排查流量热点。通过登录 TiDB Dashboard 或在浏览器中访问指定链接，可以查看流量可视化页面。页面展示了流量热力图，可观察到整体访问流量随时间的变化情况，以及热力图某个坐标的详细信息。流量可视化页面涉及的基本概念包括 Region、热点、热力图和 Region 压缩。使用介绍包括设置、观察时间段或 Region 范围、调整亮度、选择指标、刷新与自动刷新以及查看详情。常见热力图解读包括均衡结果、X 轴明暗交替、Y 轴明暗交替和明亮斜线。解决热点问题可参考 TiDB 高并发写入场景最佳实践。
+- [TiDB Dashboard 用户管理](https://docs.pingcap.com/zh/tidb/stable/dashboard-user.md): 了解如何创建 SQL 用户用于访问 TiDB Dashboard
+- [TiDB Dashboard 监控关系图](https://docs.pingcap.com/zh/tidb/stable/dashboard-metrics-relation.md): 了解 TiDB Dashboard 监控关系图
+- [TiDB Dashboard 监控页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-monitoring.md): 介绍如何通过 TiDB Dashboard 监控页面查看 Performance Overview 面板，以及如何理解面板上的关键指标项。
+- [TiDB Dashboard 诊断报告](https://docs.pingcap.com/zh/tidb/stable/dashboard-diagnostics-report.md): TiDB Dashboard 诊断报告介绍了诊断报告的内容和查看技巧。报告包括基本信息、诊断信息、负载信息、概览信息、TiDB/PD/TiKV 监控信息和配置信息。对比报告显示两个时间段的差异，通过 DIFF_RATIO 和 Maximum Different Item 报表可以快速发现监控项的差异。
+- [TiDB Dashboard 资源管控页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-resource-manager.md): 介绍如何使用 TiDB Dashboard 的资源管控页面查看资源管控相关信息，以便预估集群容量，更好地进行资源配置。
+- [TiDB Dashboard 集群信息页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-cluster-info.md): 查看整个集群中 TiDB、TiKV、PD、TiFlash 组件的运行状态及其所在主机的运行状态
+- [TiDB Dashboard 集群诊断页面](https://docs.pingcap.com/zh/tidb/stable/dashboard-diagnostics-access.md): TiDB Dashboard 集群诊断页面是用于诊断集群问题并生成诊断报告的工具。可以通过 TiDB Dashboard 或浏览器访问诊断页面。生成诊断报告的步骤包括设置时间范围和长度，然后点击开始。还可以生成对比报告来比较异常时间段和正常时间段的情况。已生成的报告会显示在主页列表中，可随时查看。
+- [TiDB Data Migration 1.0.x 到 2.0+ 手动升级](https://docs.pingcap.com/zh/tidb/stable/manually-upgrade-dm-1.0-to-2.0.md): 了解如何从 TiDB Data Migration 1.0.x 手动升级到 2.0+。
+- [TiDB Data Migration Binlog 事件过滤](https://docs.pingcap.com/zh/tidb/stable/dm-binlog-event-filter.md): 了解 DM 的关键特性 binlog 事件过滤 (Binlog event filter) 的使用方法和注意事项。
+- [TiDB Data Migration 上游数据库配置文件介绍](https://docs.pingcap.com/zh/tidb/stable/dm-source-configuration-file.md): TiDB Data Migration (DM) 上游数据库配置文件包括示例与配置项说明。示例配置文件包括上游数据库的配置项，如是否开启 GTID、是否开启 relay log、拉取上游 binlog 的起始文件名等。配置项说明包括全局配置、relay log 清理策略配置、任务状态检查配置和 Binlog event filter。配置项包括标识一个 MySQL 实例、是否使用 GTID 方式、是否开启 relay log、存储 relay log 的目录等。从 DM v2.0.2 开始，Binlog event filter 也可以在上游数据库配置文件中进行配置。
+- [TiDB Data Migration 任务前置检查](https://docs.pingcap.com/zh/tidb/stable/dm-precheck.md): 了解 DM 执行数据迁移任务时将进行的前置检查。
+- [TiDB Data Migration 兼容性目录](https://docs.pingcap.com/zh/tidb/stable/dm-compatibility-catalog.md): 了解 DM 各版本与上下游各类型数据库的兼容关系
+- [TiDB Data Migration 分库分表合并](https://docs.pingcap.com/zh/tidb/stable/dm-shard-merge.md): 了解 DM 的分库分表合并功能。
+- [TiDB Data Migration 命令行参数](https://docs.pingcap.com/zh/tidb/stable/dm-command-line-flags.md): 介绍 DM 各组件的主要命令行参数。
+- [TiDB Data Migration 处理告警](https://docs.pingcap.com/zh/tidb/stable/dm-handle-alerts.md): 了解 DM 中各主要告警信息的处理方法。
+- [TiDB Data Migration 对 online DDL 工具的支持](https://docs.pingcap.com/zh/tidb/stable/dm-online-ddl-tool-support.md): 了解 DM 对常见 online DDL 工具的支持情况，使用方法和注意事项。
+- [TiDB Data Migration 导出和导入集群的数据源和任务配置](https://docs.pingcap.com/zh/tidb/stable/dm-export-import-config.md): 了解 TiDB Data Migration 导出和导入集群的数据源和任务配置。
+- [TiDB Data Migration 快速上手指南](https://docs.pingcap.com/zh/tidb/stable/quick-start-with-dm.md): 了解如何使用 TiUP Playground 快速部署试用 TiDB Data Migration 数据迁移工具。
+- [TiDB Data Migration 性能问题及处理方法](https://docs.pingcap.com/zh/tidb/stable/dm-handle-performance-issues.md): 了解 DM 可能存在的常见性能问题及其处理方法。
+- [TiDB Data Migration 故障及处理方法](https://docs.pingcap.com/zh/tidb/stable/dm-error-handling.md): 了解 DM 的错误系统及常见故障的处理方法。
+- [TiDB Data Migration 数据迁移任务配置向导](https://docs.pingcap.com/zh/tidb/stable/dm-task-configuration-guide.md): 本文介绍了如何配置 TiDB Data Migration (DM) 的数据迁移任务。包括配置数据源、目标 TiDB 集群、需要迁移的表、需要过滤的操作、数据源表到目标 TiDB 表的映射以及分库分表合并等配置。详细配置规则可参考相关链接。
+- [TiDB Data Migration 日常巡检](https://docs.pingcap.com/zh/tidb/stable/dm-daily-check.md): 了解 DM 工具的日常巡检。
+- [TiDB Data Migration 术语表](https://docs.pingcap.com/zh/tidb/stable/dm-glossary.md): 学习 TiDB Data Migration 相关术语
+- [TiDB Data Migration 查询任务状态](https://docs.pingcap.com/zh/tidb/stable/dm-query-status.md): 深入了解 TiDB Data Migration 如何查询数据迁移任务状态
+- [TiDB Data Migration 版本发布历史](https://docs.pingcap.com/zh/tidb/stable/dm-release-notes.md): TiDB Data Migration 版本发布历史从 DM v5.4.0 起，TiDB Data Migration 的 Release Notes 合并入相同版本号的 TiDB Release Notes。如需阅读 v5.4.0 及之后版本的 DM Release Notes，请查看对应版本的 TiDB Release Notes 中 DM 相关的内容。如需阅读 v5.3.0 及更早版本的 DM Release Notes，请参考以下链接：5.3.0, 2.0.7, 2.0.6, 2.0.5, 2.0.4, 2.0.3, 2.0.2, 2.0.1, 2.0 GA, 2.0.0-rc.2, 2.0.0-rc, 1.0.7, 1.0.6, 1.0.5, 1.0.4, 1.0.3, 1.0.2.
+- [TiDB Data Migration 生成自签名证书](https://docs.pingcap.com/zh/tidb/stable/dm-generate-self-signed-certificates.md): 了解如何生成自签名证书。
+- [TiDB Data Migration 简介](https://docs.pingcap.com/zh/tidb/stable/dm-overview.md): 了解 TiDB Data Migration
+- [TiDB Data Migration 表路由](https://docs.pingcap.com/zh/tidb/stable/dm-table-routing.md): 了解 DM 的关键特性表路由 (Table Routing) 的使用方法和注意事项。
+- [TiDB Data Migration 集群软硬件环境需求](https://docs.pingcap.com/zh/tidb/stable/dm-hardware-and-software-requirements.md): 了解部署 DM 集群的软件和硬件要求。
+- [TiDB Data Migration 黑白名单过滤](https://docs.pingcap.com/zh/tidb/stable/dm-block-allow-table-lists.md): 了解 DM 的关键特性黑白名单过滤 (Block & Allow List) 的使用方法和注意事项。
+- [TiDB Lightning Web 界面](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-web-interface.md): 了解 TiDB Lightning 的服务器模式——通过 Web 界面来控制 TiDB Lightning。
+- [TiDB Lightning 前置检查](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-prechecks.md): 本文档介绍了 TiDB Lightning 前置检查功能，确保 TiDB Lightning 能够顺利执行任务。
+- [TiDB Lightning 命令行参数](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-command-line-full.md): 使用命令行配置 TiDB Lightning。
+- [TiDB Lightning 常见问题](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-faq.md): TiDB Lightning 常见问题的摘要：TiDB Lightning 对TiDB/TiKV/PD 的最低版本要求，支持导入多个库，对下游数据库的账号权限要求，导数据过程中某个表报错不会影响其他表，正确重启 TiDB Lightning 的步骤，校验导入数据的正确性方法，支持的数据源格式，禁止导入不合规数据的方法，结束 tidb-lightning 进程的操作，使用千兆网卡的建议，TiDB Lightning 预留空间的原因，清除与 TiDB Lightning 相关的中间数据的步骤，获取 TiDB Lightning 运行时的 goroutine 信息的方法，TiDB Lightning 不兼容 Placement Rules in SQL 的原因，使用 TiDB Lightning 和 Dumpling 复制 schema 的步骤。
+- [TiDB Lightning 并行导入](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-distributed-import.md): 本文档介绍了 TiDB Lightning 并行导入的概念、使用场景和使用方法。
+- [TiDB Lightning 快速上手](https://docs.pingcap.com/zh/tidb/stable/get-started-with-tidb-lightning.md): TiDB Lightning 可快速将 MySQL 数据导入到 TiDB 集群中。首先使用 Dumpling 导出数据，然后部署 TiDB 集群。安装最新版本的 TiDB Lightning 并启动，最后检查数据导入情况。详细功能和使用请参考 TiDB Lightning 简介。
+- [TiDB Lightning 故障处理](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-tidb-lightning.md): 本文档总结了使用 TiDB Lightning 过程中常见的运行故障及解决方案。
+- [TiDB Lightning 数据源](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-data-source.md): 了解 TiDB Lightning 支持的各类型数据源。
+- [TiDB Lightning 断点续传](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-checkpoints.md): TiDB Lightning 提供了“断点续传”的功能，即使 `tidb-lightning` 崩溃，在重启时仍然接着之前的进度继续工作。断点续传可通过配置启用，存储方式包括本地文件和 MySQL 数据库。在出现不可恢复的错误时，可以使用 `tidb-lightning-ctl` 工具来控制断点的处理，包括重置断点状态、清除出错状态和移除断点。
+- [TiDB Lightning 术语表](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-glossary.md): 了解 TiDB Lightning 相关的术语及定义。
+- [TiDB Lightning 监控告警](https://docs.pingcap.com/zh/tidb/stable/monitor-tidb-lightning.md): TiDB Lightning 支持使用Prometheus采集监控指标。监控配置需手动部署，配置方法在 tidb-lightning.toml 中。Grafana 面板可用于监控速度、进度、资源使用和存储空间。监控指标包括计数器和直方图，用于计算引擎文件数量、闲置 worker、KV 编码器、处理过的表、引擎文件和 Chunks的状态，以及导入每个表所需时间等。
+- [TiDB Lightning 目标数据库要求](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-requirements.md): 了解 TiDB Lightning 运行时对目标数据库的必需条件。
+- [TiDB Lightning 简介](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-overview.md): TiDB Lightning 是用于导入 TB 级数据到 TiDB 的工具。了解 TiDB Lightning 的基本原理和使用方法。
+- [TiDB Lightning 配置参数](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-configuration.md): 使用配置文件或命令行配置 TiDB Lightning。
+- [TiDB Lightning 错误处理功能](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-error-resolution.md): 介绍了如何解决导入数据过程中的类型转换和冲突错误。
+- [TiDB OOM 故障排查](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-tidb-oom.md): TiDB OOM 故障排查总结了 OOM 常见问题的解决思路、故障现象、原因、解决方法和需要收集的诊断信息。排查思路包括确认是否属于 OOM 问题和进一步排查触发 OOM 的原因。常见故障原因包括部署问题、数据库问题和客户端问题。处理 OOM 问题需要收集操作系统内存配置、数据库版本和内存配置、Grafana TiDB 内存使用情况等信息。详细排查方法请参考相关章节。
+- [TiDB Operator](https://docs.pingcap.com/zh/tidb/stable/tidb-operator-overview.md): 了解 Kubernetes 上的 TiDB 集群自动部署运维工具 TiDB Operator。
+- [TiDB Pre-GA Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-pre-ga.md): TiDB Pre-GA 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 改进了 SQL 查询优化器、大量 MySQL 兼容性相关功能、支持 Natural Join、JSON 类型支持、裁剪无用数据、支持在 SQL 语句中设置优先级、完成表达式重构。PD 支持手动切换 PD 集群 Leader。TiKV 改进了 Raft Log 使用独立的 RocksDB 实例、使用 DeleteRange 加快删除副本速度、Coprocessor 支持更多运算符下推、提升性能和稳定性。TiSpark Beta Release 支持谓词下推、支持聚合下推、支持范围裁剪。
+- [TiDB RC1 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-rc.1.md): TiDB RC1 于 2016 年 12 月 23 日发布，TiKV 提升了写入速度和稳定性，支持百 TB 级别数据，集群规模支持 200 个节点。PD 优化了调度策略框架，添加了 label 支持，提供了 PD Control。TiDB 新增了 SQL 查询优化器和更多 MySQL 内建函数，重构了 time 相关类型的实现，提升了和 MySQL 的兼容性。工具方面，Loader 兼容 Percona 的 Mydumper 数据格式，提供了多线程导入、出错重试、断点续传等功能，并且针对 TiDB 有优化。完成了一键部署工具。
+- [TiDB RC2 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-rc.2.md): TiDB RC2 版本发布，提升了 MySQL 兼容性、SQL 优化器、系统稳定性和性能。对于 OLTP 场景，读取性能提升 60%，写入性能提升 30%。新增权限管理功能，支持基本权限管理和大量 MySQL 内建函数。完善监控，修复 Bug 和内存泄漏问题。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，支持更多下推功能，加入更多统计，修复 Bug。
+- [TiDB RC3 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-rc.3.md): TiDB RC3 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了负载均衡调度策略和流程，完善权限管理功能，DDL 速度显著提升。开源了 TiDB Ansible 项目，可以一键部署 / 升级 / 启停 TiDB 集群。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，修复 Bug。
+- [TiDB RC4 Release Notes](https://docs.pingcap.com/zh/tidb/stable/release-rc.4.md): TiDB RC4 版本对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了写入速度，计算任务调度支持优先级，避免分析型大事务影响在线事务。SQL 优化器全新改版，查询代价估算更准确，且能自动选择 Join 物理算子。功能方面进一步 MySQL 兼容性。同时开源了 TiSpark 项目，可以通过 Spark 读取和分析 TiKV 中的数据。PD 支持通过 PD 设置 TiKV location labels，调度优化，优化数据加载，加快 failover 速度。 TiKV 支持查询优先级设置，支持 RC 隔离级别，完善 Jepsen，支持 Document Store，提升性能，提升稳定性。TiSpark Beta Release 支持谓词下推，支持聚合下推，支持范围裁剪。
 - [Tidb Roadmap](https://docs.pingcap.com/zh/tidb/dev/tidb-roadmap): External documentation: https://docs.pingcap.com/zh/tidb/dev/tidb-roadmap
-- [TiDB 中的 TimeStamp Oracle (TSO)](https://docs.pingcap.com/tidb/stable/tso.md): 了解 TiDB 中的 TimeStamp Oracle (TSO)。
-- [TiDB 中的各种超时](https://docs.pingcap.com/tidb/stable/dev-guide-timeouts-in-tidb.md): 简单介绍 TiDB 中的各种超时，为排查错误提供依据。
-- [TiDB 乐观事务模型](https://docs.pingcap.com/tidb/stable/optimistic-transaction.md): 了解 TiDB 的乐观事务模型。
-- [TiDB 事务概览](https://docs.pingcap.com/tidb/stable/transaction-overview.md): 了解 TiDB 中的事务。
-- [TiDB 事务隔离级别](https://docs.pingcap.com/tidb/stable/transaction-isolation-levels.md): 了解 TiDB 事务的隔离级别。
-- [TiDB 产品常见问题](https://docs.pingcap.com/tidb/stable/tidb-faq.md): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理，具备水平扩容、高可用、实时 HTAP、云原生的特性。TiDB 不是基于 MySQL 开发的，而是由 PingCAP 团队完全自主开发的产品。TiDB 易用性很高，支持绝大部分 MySQL 8.0 的语法，但不支持触发器、存储过程、自定义函数等。TiDB 支持分布式事务，兼容 MySQL Client/Driver 的编程语言，支持其他存储引擎，如 TiKV、UniStore 和 MockTiKV。获取 TiDB 知识的途径包括官方文档、官方博客、AskTUG 社区论坛和 PingCAP Education。用户名长度限制为 32 个字符，最大列数为 1017，单行大小不超过 6MB。TiDB 不支持 XA，但支持对列存储引擎的高并发 INSERT 或 UPDATE 操作。
-- [TiDB 产品常见问题解答汇总](https://docs.pingcap.com/tidb/stable/faq-overview.md): 汇总 TiDB 产品的常见问题解答。
-- [TiDB 使用限制](https://docs.pingcap.com/tidb/stable/tidb-limitations.md): TiDB 中的使用限制包括标识符长度限制、数据库、表、视图、连接总个数限制、单个数据库和表的限制、单行限制、数据类型限制、SQL 语句限制和 TiKV 版本限制。
-- [TiDB 全局排序](https://docs.pingcap.com/tidb/stable/tidb-global-sort.md): 了解 TiDB 全局排序功能的使用场景、限制、使用方法和实现原理。
-- [TiDB 内存控制文档](https://docs.pingcap.com/tidb/stable/configure-memory-usage.md): TiDB 内存控制文档介绍了如何追踪和控制 SQL 查询过程中的内存使用情况，以及配置内存使用阈值和 tidb-server 实例的内存使用阈值。还介绍了使用 INFORMATION_SCHEMA 系统表查看内存使用情况，以及降低写入事务内存使用的方法。另外还介绍了流量控制和数据落盘的内存控制策略，以及通过设置环境变量 GOMEMLIMIT 缓解 OOM 问题。
-- [TiDB 分布式执行框架](https://docs.pingcap.com/tidb/stable/tidb-distributed-execution-framework.md): 了解 TiDB 分布式执行框架的使用场景、限制、使用方法和实现原理。
-- [TiDB 功能概览](https://docs.pingcap.com/tidb/stable/basic-features.md): 了解 TiDB 的功能概览。
-- [TiDB 增量备份与恢复使用指南](https://docs.pingcap.com/tidb/stable/br-incremental-guide.md): 了解 TiDB 的增量备份与恢复功能使用。
-- [TiDB 备份与恢复功能使用概述](https://docs.pingcap.com/tidb/stable/br-use-overview.md): 了解如何部署和使用 TiDB 集群的备份与恢复。
-- [TiDB 备份与恢复功能架构概述](https://docs.pingcap.com/tidb/stable/backup-and-restore-design.md): 了解 TiDB 的备份与恢复功能的架构设计。
-- [TiDB 备份与恢复实践示例](https://docs.pingcap.com/tidb/stable/backup-and-restore-use-cases.md): 介绍 TiDB 备份与恢复的具体使用示例，包括推荐环境配置、存储配置、备份策略及如何进行备份与恢复。
-- [TiDB 备份与恢复概述](https://docs.pingcap.com/tidb/stable/backup-and-restore-overview.md): 了解不同场景下如何使用 TiDB 的备份与恢复功能，以及不同功能、版本间的兼容性。
-- [TiDB 安全配置最佳实践](https://docs.pingcap.com/tidb/stable/best-practices-for-security-configuration.md): 介绍 TiDB 安全配置的最佳实践，帮助你降低潜在的安全风险。
-- [TiDB 安装部署常见问题](https://docs.pingcap.com/tidb/stable/deploy-and-maintain-faq.md): 介绍 TiDB 集群安装部署的常见问题、原因及解决方法。
-- [TiDB 容灾方案概述](https://docs.pingcap.com/tidb/stable/dr-solution-introduction.md): 了解 TiDB 提供的几种容灾方案，包括基于主备集群的容灾、基于多副本的单集群容灾和基于备份与恢复的容灾。
-- [TiDB 密码管理](https://docs.pingcap.com/tidb/stable/password-management.md): 了解 TiDB 的用户密码管理机制。
-- [TiDB 工具下载](https://docs.pingcap.com/tidb/stable/download-ecosystem-tools.md): 本文介绍如何下载 TiDB 工具包。TiDB 工具包包含常用工具如 Dumpling、TiDB Lightning、BR 等。如果部署环境能访问互联网，可直接通过 TiUP 命令一键部署所需的 TiDB 工具。操作系统需为 Linux，架构为 amd64 或 arm64。下载步骤包括访问 TiDB 社区版页面，找到 TiDB-community-toolkit 软件包并点击立即下载。注意，点击立即下载后默认下载当前 TiDB 的最新发布版本。根据要使用的工具选择安装对应的离线包。
-- [TiDB 工具功能概览](https://docs.pingcap.com/tidb/stable/ecosystem-tool-user-guide.md): TiDB 提供了丰富的工具，包括部署运维工具 TiUP 和 TiDB Operator，数据管理工具如 TiDB Data Migration（DM）、Dumpling、TiDB Lightning、Backup & Restore（BR）、TiCDC、sync-diff-inspector，以及 OLAP 分析工具 TiSpark。这些工具可用于部署、数据迁移、备份恢复、数据校验等多种操作，满足不同需求。
-- [TiDB 工具的使用场景](https://docs.pingcap.com/tidb/stable/ecosystem-tool-user-case.md): 本文档介绍 TiDB 工具的常见使用场景与工具选择。
-- [TiDB 快照备份与恢复使用指南](https://docs.pingcap.com/tidb/stable/br-snapshot-guide.md): 了解如何使用 br 命令行工具进行 TiDB 快照备份与恢复。
-- [TiDB 快照备份与恢复功能架构](https://docs.pingcap.com/tidb/stable/br-snapshot-architecture.md): 了解 TiDB 快照备份与恢复功能的架构设计。
-- [TiDB 快照备份与恢复命令行手册](https://docs.pingcap.com/tidb/stable/br-snapshot-manual.md): 介绍备份与恢复 TiDB 集群快照的命令行。
-- [TiDB 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/performance-tuning-methods.md): 本文介绍了基于数据库时间的系统优化方法，以及如何利用 TiDB Performance Overview 面板进行性能分析和优化。
-- [TiDB 悲观事务模式](https://docs.pingcap.com/tidb/stable/pessimistic-transaction.md): 了解 TiDB 的悲观事务模式。
-- [TiDB 执行计划概览](https://docs.pingcap.com/tidb/stable/explain-overview.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划。
-- [TiDB 支持的第三方工具](https://docs.pingcap.com/tidb/stable/dev-guide-third-party-support.md): TiDB 支持的第三方工具主要包括驱动、ORM 框架和 GUI。支持等级分为 Full 和 Compatible，其中 Full 表示绝大多数功能兼容性已得到支持，Compatible 表示大部分功能可使用但未经完整验证。对于支持的 Driver 或 ORM 框架并不包括应用端事务重试和错误处理。如果在使用工具连接 TiDB 时出现问题，可在 GitHub 上提交包含详细信息的 issue 以获得进展。
-- [TiDB 数据库快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-tidb.md): 了解如何快速上手使用 TiDB 数据库。
-- [TiDB 数据库的存储](https://docs.pingcap.com/tidb/stable/tidb-storage.md): 了解 TiDB 数据库的存储层。
-- [TiDB 数据库的计算](https://docs.pingcap.com/tidb/stable/tidb-computing.md): 了解 TiDB 数据库的计算层。
-- [TiDB 数据库的调度](https://docs.pingcap.com/tidb/stable/tidb-scheduling.md): TiDB 数据库的调度由 PD（Placement Driver）模块负责管理和实时调度集群数据。PD 需要收集节点和 Region 的状态信息，并根据调度策略制定调度计划，包括增加 / 删除副本、迁移 Leader 角色等基本操作。调度需满足副本数量、位置分布、负载均衡、存储空间利用等需求。PD 通过心跳包收集信息，并根据策略生成调度操作序列，但具体执行由 Region Leader 决定。
-- [TiDB 整体架构](https://docs.pingcap.com/tidb/stable/tidb-architecture.md): 了解 TiDB 的整体架构。
-- [TiDB 日志备份与 PITR 使用指南](https://docs.pingcap.com/tidb/stable/br-pitr-guide.md): 了解 TiDB 的日志备份与 PITR 功能使用。
-- [TiDB 日志备份与 PITR 功能架构](https://docs.pingcap.com/tidb/stable/br-log-architecture.md): 了解 TiDB 的日志备份与 PITR 的架构设计。
-- [TiDB 日志备份与 PITR 命令行手册](https://docs.pingcap.com/tidb/stable/br-pitr-manual.md): 介绍 TiDB 日志备份与 PITR 的命令行。
-- [TiDB 最佳实践](https://docs.pingcap.com/tidb/stable/tidb-best-practices.md): TiDB 最佳实践总结了使用 TiDB 的一些优化技巧，包括 Raft 一致性协议、分布式事务、数据分片、负载均衡、SQL 到 KV 的映射方案、二级索引的实现方法等。建议阅读官方文档和知乎专栏了解更多细节。部署时推荐使用 TiUP，导入数据时可对 TiKV 参数进行调优。在写入和查询时需注意事务大小限制和并发度设置。监控系统和日志查看也是了解系统状态的重要方法。适用场景包括数据量大、不希望做 Sharding、需要事务和强一致性等。
-- [TiDB 热点问题处理](https://docs.pingcap.com/tidb/stable/troubleshoot-hot-spot-issues.md): TiDB 热点问题处理：介绍定位和解决读写热点问题，包括常见热点场景、确定存在热点问题的方法、使用 TiDB Dashboard 定位热点表、使用 SHARD_ROW_ID_BITS 处理热点表、使用 AUTO_RANDOM 处理自增主键热点表、小表热点的优化、打散读热点。
-- [TiDB 版本发布历史](https://docs.pingcap.com/tidb/stable/release-notes.md): 介绍 TiDB 版本发布历史。
-- [TiDB 版本发布时间线](https://docs.pingcap.com/tidb/stable/release-timeline.md): 了解 TiDB 的版本发布时间线。
-- [TiDB 版本规则](https://docs.pingcap.com/tidb/stable/versioning.md): 了解 TiDB 版本发布的规则。
-- [TiDB 特有的函数](https://docs.pingcap.com/tidb/stable/tidb-functions.md): 学习使用 TiDB 特有的函数。
-- [TiDB 环境与系统配置检查](https://docs.pingcap.com/tidb/stable/check-before-deployment.md): 了解部署 TiDB 前的环境检查操作。
-- [TiDB 用户账户管理](https://docs.pingcap.com/tidb/stable/user-account-management.md): TiDB 用户账户管理主要包括用户名和密码设置、添加用户、删除用户、保留用户账户、设置资源限制、设置密码、忘记密码处理和刷新权限。用户可以通过 SQL 语句或图形化界面工具进行用户管理，同时可以使用 `FLUSH PRIVILEGES` 命令立即生效修改。 TiDB 在数据库初始化时会生成一个默认账户。
-- [TiDB 监控常见问题](https://docs.pingcap.com/tidb/stable/monitor-faq.md): 介绍在监控 TiDB 集群时的常见问题、原因及解决方法。
-- [TiDB 监控指标](https://docs.pingcap.com/tidb/stable/grafana-tidb-dashboard.md): 了解 Grafana Dashboard 中展示的关键指标。
-- [TiDB 监控框架概述](https://docs.pingcap.com/tidb/stable/tidb-monitoring-framework.md): TiDB 使用 Prometheus 作为监控和性能指标存储，Grafana 用于可视化展示，以及 TiDB Dashboard 图形化界面用于监控及诊断 TiDB 集群。Prometheus 提供多个组件，包括 Prometheus Server、Client 代码库和 Alertmanager。Grafana 展示 TiDB 集群各组件的相关监控，分组包括备份恢复、Binlog、网络探活、磁盘性能、Kafka、TiDB Lightning 等。每个分组包含多个监控项页签，以及详细的监控指标看板。观看培训视频可快速了解监控与报警系统的体系、数据流转方式、系统管理方法和常用监控指标。
-- [TiDB 磁盘 I/O 过高的处理办法](https://docs.pingcap.com/tidb/stable/troubleshoot-high-disk-io.md): 了解如何定位和处理 TiDB 存储 I/O 过高的问题。
-- [TiDB 社区荣誉列表](https://docs.pingcap.com/tidb/stable/credits.md): 了解 TiDB 社区贡献者列表及角色。
-- [TiDB 离线包](https://docs.pingcap.com/tidb/stable/binary-package.md): 了解 TiDB 离线包及其包含的内容。
-- [TiDB 简介](https://docs.pingcap.com/tidb/stable/overview.md): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理 (HTAP)。具有水平扩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等特性。适用于高可用、强一致性要求高、数据规模大等各种应用场景。具有一键水平扩缩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等五大核心特性，以及金融行业、海量数据及高并发的 OLTP、实时 HTAP、数据汇聚、二次加工处理等四大核心应用场景。
-- [TiDB 证书鉴权使用指南](https://docs.pingcap.com/tidb/stable/certificate-authentication.md): 了解使用 TiDB 的证书鉴权功能。
-- [TiDB 软件和硬件环境需求](https://docs.pingcap.com/tidb/stable/hardware-and-software-requirements.md): TiDB 是一款开源的一站式实时 HTAP 数据库，支持部署在多种硬件环境和操作系统上。软件和硬件环境建议配置包括操作系统要求、编译和运行依赖库、Docker 镜像依赖、软件配置要求、服务器建议配置、网络要求、磁盘空间要求、客户端 Web 浏览器要求以及 TiFlash 存算分离架构的软硬件要求。
-- [TiDB 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tidb-configuration.md): TiDB 配置参数包括启动参数和环境变量。启动参数包括 advertise-address、config、config-check、config-strict、cors 等。其中默认端口为 4000 和 10080。其他参数包括 log-file、metrics-addr、metrics-interval 等。注意配置文件的有效性和安全模式下的启动。
-- [TiDB 配置文件描述](https://docs.pingcap.com/tidb/stable/tidb-configuration-file.md): 介绍未包含在命令行参数中的 TiDB 配置文件选项。
-- [TiDB 锁冲突问题处理](https://docs.pingcap.com/tidb/stable/troubleshoot-lock-conflicts.md): 了解 TiDB 锁冲突问题以及处理方式。
-- [TiDB 集群报警规则](https://docs.pingcap.com/tidb/stable/alert-rules.md): TiDB 集群中各组件的报警规则详解。
-- [TiDB 集群故障诊断](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-cluster.md): TiDB 集群故障诊断包括收集出错信息、组件状态、日志信息、机器配置和 dmesg 中的问题。解决数据库连接问题需要确认服务是否启动，查看 tidb-server 日志并清空数据重新部署服务。解决 tidb-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 tikv-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 pd-server 启动报错需检查参数和端口占用。进程异常退出需检查是否在前台启动，使用 nohup+& 方式运行或写在脚本中。TiKV 进程异常重启需检查 OOM 信息和 panic log。连接被拒绝需确保网络参数正确。解决文件打开过多问题需确保 ulimit -n 足够大。数据库访问超时需检查拓扑结构、硬件配置、其他服务、操作、CPU 线程、网络 /IO 监控数据。
-- [TiDB 集群监控 API](https://docs.pingcap.com/tidb/stable/tidb-monitoring-api.md): TiDB 提供状态接口和 Metrics 接口来监控集群状态。状态接口可获取 TiDB Server 的运行状态和存储信息，PD 的状态接口可查看整个 TiKV 集群的详细信息。Metrics 接口用于监控整个集群的状态和性能。部署 Prometheus 和 Grafana 后，配置 Grafana 即可使用 Metrics 接口。
-- [TiDB 集群管理常见问题](https://docs.pingcap.com/tidb/stable/manage-cluster-faq.md): 介绍 TiDB 集群管理的常见问题、原因及解决方法。
-- [TiDB 集群问题导图](https://docs.pingcap.com/tidb/stable/tidb-troubleshooting-map.md): 了解如何处理 TiDB 集群常见问题。
-- [TiDB 高并发写入场景最佳实践](https://docs.pingcap.com/tidb/stable/high-concurrency-best-practices.md): 了解 TiDB 在高并发写入场景下的最佳实践。
-- [TIDB_CHECK_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-tidb-check-constraints.md): 了解 INFORMATION_SCHEMA 表 `TIDB_CHECK_CONSTRAINTS`。
-- [TIDB_HOT_REGIONS](https://docs.pingcap.com/tidb/stable/information-schema-tidb-hot-regions.md): 了解 information_schema 表 `TIDB_HOT_REGIONS`。
-- [TIDB_HOT_REGIONS_HISTORY](https://docs.pingcap.com/tidb/stable/information-schema-tidb-hot-regions-history.md): 了解 information_schema 表 `TIDB_HOT_REGIONS_HISTORY`。
-- [TIDB_INDEX_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-tidb-index-usage.md): 了解 INFORMATION_SCHEMA 表 `TIDB_INDEX_USAGE`。
-- [TIDB_INDEXES](https://docs.pingcap.com/tidb/stable/information-schema-tidb-indexes.md): 了解 information_schema 表 `TIDB_INDEXES`。
-- [TIDB_SERVERS_INFO](https://docs.pingcap.com/tidb/stable/information-schema-tidb-servers-info.md): 了解 INFORMATION_SCHEMA 表 `TIDB_SERVERS_INFO`。
-- [TIDB_TRX](https://docs.pingcap.com/tidb/stable/information-schema-tidb-trx.md): 了解 INFORMATION_SCHEMA 表 `TIDB_TRX`。
-- [TiFlash MinTSO 调度器](https://docs.pingcap.com/tidb/stable/tiflash-mintso-scheduler.md): 了解 TiFlash MinTSO 调度器的实现原理。
-- [TiFlash Pipeline Model 执行模型](https://docs.pingcap.com/tidb/stable/tiflash-pipeline-model.md): 介绍 TiFlash 新的执行模型 Pipeline Model。
-- [TiFlash 兼容性说明](https://docs.pingcap.com/tidb/stable/tiflash-compatibility.md): 了解与 TiFlash 不兼容的 TiDB 特性。
-- [TiFlash 升级帮助](https://docs.pingcap.com/tidb/stable/tiflash-upgrade-guide.md): 了解升级 TiFlash 时的注意事项。
-- [TiFlash 命令行参数](https://docs.pingcap.com/tidb/stable/tiflash-command-line-flags.md): TiFlash 的命令行启动参数包括 server --config-file、dttool migrate、dttool bench 和 dttool inspect。server --config-file 用于指定配置文件路径，dttool migrate 用于迁移 DTFile 的文件格式，dttool bench 用于提供 DTFile 的简单 IO 速度测试，dttool inspect 用于检查 DTFile 的完整性。每个命令都有对应的参数，可以根据需求进行配置。警告：TiFlash 目前只支持默认压缩等级的 LZ4 算法，自定义压缩参数并未经过大量测试。注意：为保证安全，DTTool 在迁移模式下会尝试对工作目录进行加锁。
-- [TiFlash 存算分离架构与 S3 支持](https://docs.pingcap.com/tidb/stable/tiflash-disaggregated-and-s3.md): 了解 TiFlash 存算分离架构与 S3 支持。
-- [TiFlash 常见问题](https://docs.pingcap.com/tidb/stable/troubleshoot-tiflash.md): 介绍 TiFlash 的常见问题、原因及解决办法。
-- [TiFlash 延迟物化](https://docs.pingcap.com/tidb/stable/tiflash-late-materialization.md): 介绍通过使用 TiFlash 延迟物化的方式来加速 OLAP 场景的查询。
-- [TiFlash 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/tiflash-performance-tuning-methods.md): 本文介绍了 Performance Overview 面板中 TiFlash 部分，帮助你了解和监控 TiFlash 的工作负载。
-- [TiFlash 性能调优](https://docs.pingcap.com/tidb/stable/tune-tiflash-performance.md): 介绍 TiFlash 性能调优的方法，包括机器资源规划和 TiDB 参数调优。
-- [TiFlash 报警规则](https://docs.pingcap.com/tidb/stable/tiflash-alert-rules.md): TiFlash 报警规则介绍了 TiFlash 集群的报警规则。包括了TiFlash_schema_error、TiFlash_schema_apply_duration、TiFlash_raft_read_index_duration 和 TiFlash_raft_wait_index_duration 四种报警规则，以及它们的规则描述和处理方法。报警规则主要用于监控TiFlash集群的运行状态，及时发现问题并联系 TiFlash 开发人员进行处理。
-- [TiFlash 支持的计算下推](https://docs.pingcap.com/tidb/stable/tiflash-supported-pushdown-calculations.md): 了解 TiFlash 支持的计算下推。
-- [TiFlash 数据校验](https://docs.pingcap.com/tidb/stable/tiflash-data-validation.md): 了解 TiFlash 的数据校验机制以及相关的工具。
-- [TiFlash 数据落盘](https://docs.pingcap.com/tidb/stable/tiflash-spill-disk.md): 介绍 TiFlash 数据落盘功能。
-- [TiFlash 查询结果物化](https://docs.pingcap.com/tidb/stable/tiflash-results-materialization.md): 介绍如何在同一个事务中保存 TiFlash 的查询结果。
-- [TiFlash 简介](https://docs.pingcap.com/tidb/stable/tiflash-overview.md): TiFlash 是 TiDB HTAP 形态的关键组件，提供了良好的隔离性和强一致性。它使用列存扩展和 Raft Learner 协议异步复制，通过 Raft 校对索引配合 MVCC 实现一致性隔离级别。TiFlash 架构解决了 HTAP 场景的隔离性和列存同步问题。它提供列式存储和借助 ClickHouse 高效实现的协处理器层。TiFlash 可以兼容 TiDB 和 TiSpark，推荐与 TiKV 不同节点部署以实现 Workload 隔离。具有异步复制、一致性、智能选择和计算加速等核心特性。部署完成后需要手动指定需要同步的表。
-- [TiFlash 部署拓扑](https://docs.pingcap.com/tidb/stable/tiflash-deployment-topology.md): 了解在部署最小拓扑集群的基础上，部署 TiFlash 的拓扑结构。
-- [TiFlash 配置参数](https://docs.pingcap.com/tidb/stable/tiflash-configuration.md): TiFlash 配置参数包括 PD 调度参数和 TiFlash 配置参数。PD 调度参数可通过 pd-ctl 调整，包括 replica-schedule-limit 和 store-balance-rate。TiFlash 配置参数包括 tiflash.toml 和 tiflash-learner.toml，用于配置 TiFlash TCP/HTTP 服务的监听和存储路径。另外，通过拓扑 label 进行副本调度和多盘部署也是可行的。
-- [TiFlash 集群监控](https://docs.pingcap.com/tidb/stable/monitor-tiflash.md): TiFlash 集群监控包括 TiFlash-Summary、TiFlash-Proxy-Summary 和 TiFlash-Proxy-Details。监控指标包括存储、内存、CPU 使用率、请求处理、错误数量、线程数、任务调度、DDL、写入、读取、Raft 等信息。注意低版本监控信息不完善，建议使用 v4.0.5 或更高版本的 TiDB 集群。
-- [TiFlash 集群运维](https://docs.pingcap.com/tidb/stable/maintain-tiflash.md): TiFlash 集群运维包括查看版本、重要日志和系统表。查看版本有两种方法：通过命令或在日志中查看。重要日志包括数据同步和处理请求的信息。系统表包括数据库名、表名、副本数、位置标签、可用性和同步进度。
-- [TIFLASH_REPLICA](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-replica.md): 了解 INFORMATION_SCHEMA 表 `TIFLASH_REPLICA`。
-- [TIFLASH_SEGMENTS](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-segments.md): 了解 information_schema 表 `TIFLASH_SEGMENTS`。
-- [TIFLASH_TABLES](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-tables.md): 了解 information_schema 表 `TIFLASH_TABLES`。
-- [TiKV Control 使用说明](https://docs.pingcap.com/tidb/stable/tikv-control.md): TiKV Control（tikv-ctl）是 TiKV 的命令行工具，用于管理 TiKV 集群。它的安装目录在 `~/.tiup/components/ctl/{VERSION}/` 目录下。通过 TiUP 使用 TiKV Control，可以调用 `tikv-ctl` 工具。通用参数包括远程模式和本地模式，以及两个简单的命令 `--to-hex` 和 `--to-escaped`。其他子命令包括查看 Raft 状态机的信息、查看 Region 的大小、扫描查看给定范围的 MVCC、查看给定 key 的 MVCC、扫描 raw key、打印某个 key 的值、打印 Region 的 properties 信息、手动 compact 单个 TiKV 的数据、手动 compact 整个 TiKV 集群的数据、设置一个 Region 副本为 tombstone 状态、向 TiKV 发出 consistency-check 请求、Dump snapshot 元文件、打印 Raft 状态机出错的 Region、动态修改 TiKV 的配置、强制 Region 从多副本失败状态恢复服务、恢复损坏的 MVCC 数据、Ldb 命令、打印加密元数据、打印损坏的 SST 文件信息、获取一个 Region 的 RegionReadProgress 状态。
-- [TiKV MVCC 内存引擎](https://docs.pingcap.com/tidb/stable/tikv-in-memory-engine.md): 了解内存引擎的适用场景和工作原理，使用内存引擎加速多版本记录查询。
-- [TiKV 内存参数性能调优](https://docs.pingcap.com/tidb/stable/tune-tikv-memory-performance.md): TiKV 内存参数性能调优，根据机器配置情况调整参数以达到最佳性能。TiKV 使用 RocksDB 作为持久化存储，配置项包括 block-cache 大小和 write-buffer 大小。除此之外，系统内存还会被用于 page cache 和处理大查询时的数据结构生成。推荐将 TiKV 部署在 CPU 核数不低于 8 或内存不低于 32GiB 的机器上，对写入吞吐要求高时使用吞吐能力较好的磁盘，对读写延迟要求高时使用 IOPS 较高的 SSD 盘。
-- [TiKV 监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-tikv-dashboard.md): TiKV 监控指标详解：TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构详见 TiDB 监控框架概述。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。对于日常运维，通过观察 TiKV-Details 面板上的指标，可以了解 TiKV 当前的状态。根据性能地图，可以检查集群的状态是否符合预期。TiKV-Details 默认的监控信息包括 Cluster、Errors、Server、gRPC、Thread CPU、PD、Raft IO、Raft process、Raft message、Raft propose、Raft admin、Local reader、Unified Read Pool、Storage、Flow Control、Scheduler 等。
-- [TiKV 简介](https://docs.pingcap.com/tidb/stable/tikv-overview.md): TiKV 是一个分布式事务型的键值数据库，通过 Raft 协议保证了多副本数据一致性和高可用。整体架构采用 multi-raft-group 的副本机制，保证数据和读写负载均匀分散在各个 TiKV 上。TiKV 支持分布式事务，通过两阶段提交保证了 ACID 约束。同时，通过协处理器可以为 TiDB 分担一部分计算。
-- [TiKV 线程池性能调优](https://docs.pingcap.com/tidb/stable/tune-tikv-thread-performance.md): 了解 TiKV 线程池性能调优。
-- [TiKV 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tikv-configuration.md): TiKV 配置参数支持文件大小和时间的可读性好的单位转换。命令行参数包括监听地址、对外访问地址、服务状态监听端口、对外访问服务状态地址、配置文件、存储数据的容量、配置信息输出格式、数据存储路径、日志级别、日志文件、PD 地址列表。需要注意的是，PD 地址列表需要使用逗号分隔多个地址。
-- [TiKV 配置文件描述](https://docs.pingcap.com/tidb/stable/tikv-configuration-file.md): 了解 TiKV 的配置文件参数。
-- [TIKV_REGION_PEERS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-region-peers.md): 了解 INFORMATION_SCHEMA 表 `TIKV_REGION_PEERS`。
-- [TIKV_REGION_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-region-status.md): 了解 information_schema 表 `TIKV_REGION_STATUS`。
-- [TIKV_STORE_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-store-status.md): 了解 INFORMATION_SCHEMA 表 `TIKV_STORE_STATUS`。
-- [TiProxy API](https://docs.pingcap.com/tidb/stable/tiproxy-api.md): 了解如何使用 TiProxy API 获取 TiProxy 的配置、健康状况和监控数据等信息。
-- [TiProxy 命令行参数](https://docs.pingcap.com/tidb/stable/tiproxy-command-line-flags.md): 了解 TiProxy 的命令行参数。
-- [TiProxy 常见问题](https://docs.pingcap.com/tidb/stable/troubleshoot-tiproxy.md): 介绍 TiProxy 的常见问题、原因及解决办法。
-- [TiProxy 性能测试报告](https://docs.pingcap.com/tidb/stable/tiproxy-performance-test.md): TiProxy 的性能测试报告、与 HAProxy 的性能对比。
-- [TiProxy 流量回放](https://docs.pingcap.com/tidb/stable/tiproxy-traffic-replay.md): 介绍 TiProxy 的流量回放的使用场景和使用步骤。
-- [TiProxy 监控指标](https://docs.pingcap.com/tidb/stable/tiproxy-grafana.md): 了解 TiProxy 的监控指标。
-- [TiProxy 简介](https://docs.pingcap.com/tidb/stable/tiproxy-overview.md): 介绍 TiProxy 的主要功能、安装与使用方法。
-- [TiProxy 负载均衡策略](https://docs.pingcap.com/tidb/stable/tiproxy-load-balance.md): 介绍 TiProxy 的负载均衡策略及其适用场景。
-- [TiProxy 部署拓扑](https://docs.pingcap.com/tidb/stable/tiproxy-deployment-topology.md): 了解在部署最小拓扑集群的基础上，部署 TiProxy 的拓扑结构。
-- [TiProxy 配置文件](https://docs.pingcap.com/tidb/stable/tiproxy-configuration.md): 了解与 TiProxy 部署和使用相关的配置参数。
-- [TiSpark 用户指南](https://docs.pingcap.com/tidb/stable/tispark-overview.md): 使用 TiSpark 一站式解决用户的 HTAP 需求。
-- [TiSpark 部署拓扑](https://docs.pingcap.com/tidb/stable/tispark-deployment-topology.md): 介绍 TiUP 部署包含 TiSpark 组件的 TiDB 集群的拓扑结构。
-- [Titan 介绍](https://docs.pingcap.com/tidb/stable/titan-overview.md): Titan 是基于 RocksDB 的高性能单机 key-value 存储引擎插件。它支持将 value 从 LSM-tree 中分离出来单独存储，以降低写放大。Titan 适合前台写入量较大的场景，但不适合范围查询或对范围查询性能敏感的情况。开启 Titan 需要考虑 value 大小、范围查询敏感性和磁盘空间。从 v7.6.0 开始，TiDB 对 Titan 性能进行了优化，并将其作为默认的存储引擎。Titan 的 GC 方式有传统 GC 和 Level Merge，而 `min-blob-size` 的大小会影响性能。
-- [Titan 配置](https://docs.pingcap.com/tidb/stable/titan-configuration.md): Titan 配置介绍了如何开启、关闭 Titan、数据迁移原理、相关参数以及 Level Merge 功能。从 TiDB v7.6.0 开始，默认启用 Titan，支持宽表写入场景和 JSON。开启 Titan 方法包括使用 TiUP 部署集群、直接编辑 TiKV 配置文件、编辑 TiDB Operator 配置文件。数据迁移是逐步进行的，可以通过全量 Compaction 提高迁移速度。常用配置参数包括 `min-blob-size`、`blob-file-compression`、`blob-cache-size` 等。关闭 Titan 可通过设置 `blob-run-mode` 参数。Level Merge 是实验功能，可提升范围查询性能并降低 Titan GC 对前台写入性能的影响。
-- [tiup clean](https://docs.pingcap.com/tidb/stable/tiup-command-clean.md): tiup clean 命令用于清除组件运行过程中产生的数据。可以使用 --all 选项清除所有运行记录。
-- [TiUP Cluster](https://docs.pingcap.com/tidb/stable/tiup-component-cluster.md): TiUP Cluster 是使用 Golang 编写的集群管理组件，可进行部署、启动、关闭、销毁、弹性扩缩容、升级 TiDB 集群、管理参数。支持的命令有 import、template、check、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、rename、clean、destroy、audit、replay、enable、disable、meta backup、meta restore、help。
-- [tiup cluster audit](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-audit.md): tiup cluster audit 命令用于查看集群执行的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息。输出包括指定的执行日志或包含 ID、时间和命令的表格。
-- [tiup cluster audit cleanup](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-audit-cleanup.md): tiup cluster audit cleanup 命令用于清理 tiup cluster 产生的执行日志。--retain-days 选项用于设置执行日志保留天数，默认值为 60 天。-h, --help 选项用于输出帮助信息。执行命令后会输出 "clean audit log successfully"。
-- [tiup cluster check](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-check.md): TiUP Cluster 提供了 `check` 子命令，用于检查集群的硬件和软件环境是否满足正常运行条件。检查包括操作系统版本、CPU 支持、系统时间、内核参数、磁盘挂载参数等。用户可以通过指定选项来启用 CPU 核心数、内存大小和磁盘性能测试的检查。检查结果将以表格形式输出，包括目标节点、检查项、检查结果和结果描述。
-- [tiup cluster clean](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-clean.md): tiup cluster clean 命令用于在测试环境中重置集群到刚部署的状态。它会停止集群并删除数据。警告：生产环境禁止使用。语法：tiup cluster clean <cluster-name>。选项包括 --all（清理数据和日志）、--data（开启数据清理）、--log（开启日志清理）、--ignore-node（指定不清理的节点）、--ignore-role（指定不清理的角色）、-h, --help（输出帮助信息）。输出为 tiup-cluster 的执行日志。
-- [tiup cluster deploy](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-deploy.md): tiup cluster deploy 命令用于部署全新集群。语法为 tiup cluster deploy <cluster-name> <version> <topology.yaml> [flags]。选项包括 -u, -i, -p, --ignore-config-check, --no-labels, --skip-create-user, -h。输出为部署日志。
-- [tiup cluster destroy](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-destroy.md): tiup cluster destroy 命令用于销毁集群，包括停止集群、删除服务的日志目录、部署目录和数据目录。选项包括 --force（忽略错误）、--retain-node-data（指定保留数据的节点）、--retain-role-data（指定保留数据的角色）、-h（输出帮助信息）。执行日志将作为输出。
-- [tiup cluster disable](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-disable.md): tiup cluster disable 命令用于关闭集群服务在机器重启后的自启动。使用该命令可以指定要关闭自启的集群、节点和角色。如果不指定节点和角色，则默认关闭所有节点和角色的自启动。输出为 tiup-cluster 的执行日志。
-- [tiup cluster display](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-display.md): tiup cluster display 命令用于查看集群中每个组件的运行状态。可以通过指定选项来展示特定信息，如节点的 CPU 和内存使用情况，节点的 uptime 信息等。输出包括集群名称、版本、SSH 客户端类型、Dashboard 地址以及节点的 ID、角色、主机 IP、端口号、操作系统和机器架构、服务状态、数据目录和部署目录。节点服务状态包括在线、离线、已缩容下线、下线中和未知。详细状态含义可参考相关文档。
-- [tiup cluster edit-config](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-edit-config.md): tiup cluster edit-config 命令用于调整部署集群后的配置。执行命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意不能增删机器，需执行 tiup cluster reload 命令来重新加载配置。语法为 tiup cluster edit-config <cluster-name>，选项包括 -h, --help。执行命令后正常情况下无输出，若修改了不能修改的字段则会报错并提示用户重新编辑。
-- [tiup cluster enable](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-enable.md): tiup cluster enable 命令用于设置集群服务在机器重启后的自启动。命令会执行 systemctl enable <service> 来开启服务的自启。可以指定节点和角色来开启自启，同时可以输出帮助信息。执行日志将由 tiup-cluster 记录。
-- [tiup cluster help](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-help.md): tiup-cluster 是一个命令行工具，提供丰富的帮助信息。用户可以通过 `help` 命令或 `--help` 参数获取帮助信息。`tiup cluster help <command>` 等同于 `tiup cluster <command> --help`。语法为 `tiup cluster help [command] [flags]`。使用 `-h` 或 `--help` 输出帮助信息，默认关闭。输出为 `[command]` 或 tiup-cluster 的帮助信息。
-- [tiup cluster import](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-import.md): TiUP Cluster 提供了 `import` 命令，用于将 TiDB Ansible 部署的集群过渡到使用 tiup-cluster 组件管理。导入过程的日志信息将会输出。暂不支持导入启用了 TLS 加密功能、纯 KV 集群、启用了 Kafka 的集群、启用了 Spark 的集群、启用了 TiDB Lightning/Importer 的集群、仍使用老版本 `push` 的方式收集监控指标、单独为机器的 `node_exporter` / `blackbox_exporter` 设置了非默认端口的集群。如果集群中有部分节点未部署监控，应当先补充对应节点的信息，并将补充的监控组件部署完整。
-- [tiup cluster list](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-list.md): tiup-cluster 支持使用同一个中控机部署多套集群。命令 `tiup cluster list` 可以查看当前登录的用户使用该中控机部署了哪些集群。输出包含 Name、User、Version、Path、PrivateKey 字段的表格。注意：部署的集群数据默认放在 `~/.tiup/storage/cluster/clusters/` 目录下，当前登录用户无法查看其他用户部署的集群。
-- [tiup cluster meta backup](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-meta-backup.md): TiUP meta 文件丢失会导致无法管理集群。使用“tiup cluster meta backup”命令定期备份文件。命令语法为“tiup cluster meta backup <cluster-name>”。选项包括指定备份文件存储目录和帮助信息。输出为 tiup-cluster 的执行日志。
-- [tiup cluster meta restore](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-meta-restore.md): TiUP cluster meta restore 命令用于从备份文件中恢复 TiUP meta 文件。语法为 tiup cluster meta restore <cluster-name> <backup-file>。选项包括 -h, --help，用于输出帮助信息。恢复操作会覆盖当前的 meta 文件，建议仅在 meta 文件丢失的情况下进行恢复。执行日志将作为输出。
-- [tiup cluster patch](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-patch.md): tiup cluster patch 命令用于在集群运行过程中动态替换某个服务的二进制文件。它会上传替换的二进制包到目标机器，并通过 API 下线节点，停止目标服务，解压替换二进制包，最后启动目标服务。在使用命令前需要准备二进制包，包括确定组件名、版本、操作系统和平台，下载组件包，创建临时打包目录，解压原二进制包，复制要替换的文件到临时目录，最后打包所有文件。命令还包括一些选项，如 --overwrite、--transfer-timeout、-N、-R、--offline 等。
-- [tiup cluster prune](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-prune.md): tiup cluster prune 命令用于在缩容集群时清理数据。对于某些组件，需要等数据调度完成后，用户手动执行该命令。选项包括 -h 或 --help，用于输出帮助信息。清理过程会生成日志。
-- [tiup cluster reload](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-reload.md): tiup cluster reload 命令用于在修改集群配置后重新加载配置，使其生效。命令会将配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。可选参数包括 --force（忽略错误强制 reload）、--transfer-timeout（设置最长等待时间）、--ignore-config-check（跳过配置检查）、-N, --node（指定要重启的节点）、-R, --role（指定要重启的角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。执行日志会输出到 tiup-cluster。
-- [tiup cluster rename](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-rename.md): tiup cluster rename 命令用于更改部署集群后的集群名。如果要更改集群名，可以使用 tiup cluster rename <old-cluster-name> <new-cluster-name> 命令。注意：如果配置了 grafana_servers 的 dashboard_dir 字段，需要更新本地 dashboards 目录中的 *.json 文件的 datasource 字段的值，并执行 tiup cluster reload -R grafana 命令。执行日志将输出到 tiup-cluster。
-- [tiup cluster replay](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-replay.md): tiup cluster replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用 `tiup cluster audit` 查看历史命令及其 audit-id。执行命令：tiup cluster replay <audit-id>。选项：-h, --help。输出为对应命令的输出。
-- [tiup cluster restart](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-restart.md): tiup cluster restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup cluster restart <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
-- [tiup cluster scale-in](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-scale-in.md): tiup cluster scale-in 命令用于集群缩容，包括下线 TiKV 和 TiFlash 组件，以及其他组件。特殊处理包括通过 API 执行移除操作，并清理相关数据文件。命令语法为 tiup cluster scale-in <cluster-name>，必须指定要缩容的节点。其他选项包括 --force 用于强制移除宕机节点，--transfer-timeout 设置最长等待时间，-h 输出帮助信息。输出为缩容日志。
-- [tiup cluster scale-out](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-scale-out.md): tiup cluster scale-out 命令用于集群扩容，内部逻辑与部署类似。PD 节点的扩容通过 join 方式加入集群，并更新相关服务配置；其他服务直接启动加入集群。命令语法为 tiup cluster scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user, -i, --identity_file, -p, --password, --no-labels, --skip-create-user, -h, --help。输出为扩容日志。
-- [tiup cluster start](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-start.md): tiup cluster start 命令用于启动指定集群的所有或部分服务。语法为 tiup cluster start <cluster-name> [flags]。选项包括 --init（以安全方式启动集群）、-N, --node（指定要启动的节点）、-R, --role（指定要启动的角色）、-h, --help。输出为启动日志。
-- [tiup cluster stop](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-stop.md): tiup cluster stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup cluster stop <cluster-name>。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
-- [tiup cluster template](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-template.md): TiUP 内置了拓扑文件的模版，用户可以通过修改该模版来生成最终的拓扑文件。使用 tiup cluster template 命令可以输出 TiUP 内置的模版内容。该命令有多个选项，包括输出详细的拓扑模版、输出本地集群的简单拓扑模版以及输出多数据中心的拓扑模版。根据指定选项输出拓扑模版，可重定向到拓扑文件中用于部署。
-- [tiup cluster upgrade](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-upgrade.md): tiup cluster upgrade 命令用于将指定集群升级到特定版本。命令语法为 tiup cluster upgrade <cluster-name> <version> [flags]。可使用 --force 选项忽略升级过程的错误，强制替换二进制文件并启动集群。还可通过设置 --transfer-timeout 设置最长等待时间，超时后会跳过等待直接升级服务。其他选项包括 --ignore-config-check、--ignore-version-check、--offline 等。升级服务的日志将会输出。
-- [tiup completion](https://docs.pingcap.com/tidb/stable/tiup-command-completion.md): TiUP 提供了 `tiup completion` 命令，用于生成命令行自动补全的配置文件。目前支持 `bash` 和 `zsh` 两种 shell 的命令补全。安装方式包括在 macOS 上执行 `brew install bash-completion` 或 `brew install bash-completion@2`，在 Linux 上执行 `yum install bash-completion` 或 `apt install bash-completion`。使用方式包括在 `.bash_profile` 中执行 `source` 命令，并在 zsh 中执行 `tiup completion zsh > "${fpath[1]}/_tiup"`。
-- [TiUP DM](https://docs.pingcap.com/tidb/stable/tiup-component-dm.md): TiUP DM 是用于对 DM 集群进行日常运维工作的管理工具，包括部署、启动、关闭、销毁、弹性扩缩容、升级、参数管理等操作。命令包括 import、template、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、destroy、audit、replay、enable、disable、help。
-- [tiup dm audit](https://docs.pingcap.com/tidb/stable/tiup-component-dm-audit.md): tiup dm audit 命令用于查看所有集群上的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息，默认关闭。输出包括指定的 audit-id 对应的执行日志或包含 ID、时间和命令字段的表格。
-- [tiup dm deploy](https://docs.pingcap.com/tidb/stable/tiup-component-dm-deploy.md): tiup dm deploy 命令用于部署全新的集群。语法为 tiup dm deploy <cluster-name> <version> <topology.yaml> [flags]，其中 cluster-name 表示新集群的名字，version 为要部署的 DM 集群版本号，topology.yaml 为事先编写好的拓扑文件。选项包括 -u, -i, -p, -h，分别用于指定连接目标机器的用户名、密钥文件、密码登录和输出帮助信息。输出为部署日志。
-- [tiup dm destroy](https://docs.pingcap.com/tidb/stable/tiup-component-dm-destroy.md): tiup dm destroy 命令用于销毁集群，包括停止集群、删除日志目录、部署目录和数据目录。语法为 tiup dm destroy <cluster-name>。选项 -h, --help 用于输出帮助信息。输出为 tiup-dm 的执行日志。
-- [tiup dm disable](https://docs.pingcap.com/tidb/stable/tiup-component-dm-disable.md): tiup dm disable 命令用于关闭集群服务重启后的自启动。语法为 tiup dm disable <cluster-name>，其中 <cluster-name> 为要关闭自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要关闭自启的节点和角色。若不指定选项，默认关闭所有节点和角色的自启。执行该命令将输出 tiup-dm 的执行日志。
-- [tiup dm display](https://docs.pingcap.com/tidb/stable/tiup-component-dm-display.md): tiup-dm 提供了 `tiup dm display` 命令来高效查看集群中每个组件的运行状态。命令语法为 `tiup dm display <cluster-name>`，可指定要查询的节点和角色。输出包括集群名称、版本、SSH 客户端类型，以及节点 ID、角色、IP、端口号、操作系统、状态、数据目录和部署目录等信息。
-- [tiup dm edit-config](https://docs.pingcap.com/tidb/stable/tiup-component-dm-edit-config.md): tiup dm edit-config 命令用于调整部署集群服务的配置。使用命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意：修改配置时不能增删机器，需执行 tiup dm reload 命令来重新加载配置。语法：tiup dm edit-config <cluster-name>。选项：-h, --help 输出帮助信息。输出：正常情况无输出，若修改了不能修改的字段，则保存文件时报错并提示用户重新编辑。
-- [tiup dm enable](https://docs.pingcap.com/tidb/stable/tiup-component-dm-enable.md): tiup dm enable 命令用于设置集群服务在机器重启后的自启动。命令语法为 tiup dm enable <cluster-name>，其中 cluster-name 为要启用自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要开启自启的节点和角色。若不指定选项，默认开启所有节点和角色的自启。执行日志将作为输出。
-- [tiup dm help](https://docs.pingcap.com/tidb/stable/tiup-component-dm-help.md): tiup-dm 提供丰富的命令行界面帮助信息，可通过 `help` 命令或 `--help` 参数获取。`tiup dm help <command>` 等同于 `tiup dm <command> --help`。语法：`tiup dm help [command] [flags]`。`[command]` 用于指定要查看的命令帮助信息，若不指定，则查看 tiup-dm 自身的帮助信息。使用 `-h, --help` 输出帮助信息，数据类型为 `BOOLEAN`，默认关闭。输出为 `[command]` 或 tiup-dm 的帮助信息。
-- [tiup dm import](https://docs.pingcap.com/tidb/stable/tiup-component-dm-import.md): TiUP DM 提供了 `import` 命令，用于将 DM v1.0 集群导入到全新的 v2.0 集群。在导入前，请先停止原集群，并确认升级 TiUP DM 组件到最新版本。导入过程中会生成日志信息，不支持导入 v1.0 集群中的 DM Portal 组件。对于需要升级到 v2.0 的数据迁移任务，请不要执行 `stop-task`。具体语法和选项可以使用 `tiup dm import [flags]` 命令查看。
-- [tiup dm list](https://docs.pingcap.com/tidb/stable/tiup-component-dm-list.md): tiup-dm 支持使用同一个中控机部署多套集群。命令 `tiup dm list` 可以查看当前登录的用户使用该中控机部署了哪些集群。部署的集群数据默认放在 `~/.tiup/storage/dm/clusters/` 目录下。在同一台中控机上，当前登录用户无法查看其他用户部署的集群。该命令输出含有集群名字、部署用户、集群版本、集群部署数据在中控机上的路径、连接集群的私钥所在路径的表格。
-- [tiup dm prune](https://docs.pingcap.com/tidb/stable/tiup-component-dm-prune.md): tiup dm prune 命令用于在缩容集群后清理 etcd 中的少量元信息。通常情况下不会有问题，但如果需要清理，可以手动执行该命令。语法为 tiup dm prune <cluster-name>，选项包括 -h, --help，输出为清理过程的日志。
-- [tiup dm reload](https://docs.pingcap.com/tidb/stable/tiup-component-dm-reload.md): tiup dm reload 命令用于在修改集群配置后重新加载配置。该命令将中控机的配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。语法为 tiup dm reload <cluster-name>。选项包括 -N, --node（重启节点）、-R, --role（重启角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。输出为 tiup-dm 的执行日志。
-- [tiup dm replay](https://docs.pingcap.com/tidb/stable/tiup-component-dm-replay.md): tiup dm replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用命令时需指定要重试的命令对应的 audit-id，可通过 tiup dm audit 查看历史命令及其 audit-id。命令输出为对应命令的输出。
-- [tiup dm restart](https://docs.pingcap.com/tidb/stable/tiup-component-dm-restart.md): tiup dm restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup dm restart <cluster-name> [flags]，其中 <cluster-name> 为要操作的集群名字。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
-- [tiup dm scale-in](https://docs.pingcap.com/tidb/stable/tiup-component-dm-scale-in.md): tiup dm scale-in 命令用于集群缩容，即下线服务并移除指定节点和相关文件。语法为 tiup dm scale-in <cluster-name>，其中 <cluster-name> 为集群名。选项包括 -N, --node（必须非空，选择要缩容的节点），--force（强制移除宕机节点），-h, --help（输出帮助信息）。输出为缩容日志。
-- [tiup dm scale-out](https://docs.pingcap.com/tidb/stable/tiup-component-dm-scale-out.md): tiup dm scale-out 命令用于集群扩容，内部逻辑与部署类似。首先建立新节点的 SSH 连接，在目标节点上创建必要的目录，然后执行部署并启动服务。命令语法为 tiup dm scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user（string，默认为当前执行命令的用户），-i, --identity_file（string，默认 ~/.ssh/id_rsa），-p, --password，-h, --help。输出为扩容日志。
-- [tiup dm start](https://docs.pingcap.com/tidb/stable/tiup-component-dm-start.md): tiup dm start 命令用于启动指定集群的所有或部分服务。命令语法为 tiup dm start <cluster-name>。选项包括 -N, --node（指定要启动的节点），-R, --role（指定要启动的角色），-h, --help（输出帮助信息）。输出为启动日志。
-- [tiup dm stop](https://docs.pingcap.com/tidb/stable/tiup-component-dm-stop.md): tiup dm stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup dm stop <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
-- [tiup dm template](https://docs.pingcap.com/tidb/stable/tiup-component-dm-template.md): tiup dm template 命令用于输出 TiUP 内置的集群拓扑模版内容。可以通过修改模版来生成最终的拓扑文件。可选的 --full 选项输出详细的拓扑模版，带上可配置的参数。输出拓扑模版到标准输出，可重定向到拓扑文件中用于部署。
-- [tiup dm upgrade](https://docs.pingcap.com/tidb/stable/tiup-component-dm-upgrade.md): tiup dm upgrade 命令用于将指定集群升级到特定版本。语法为 tiup dm upgrade <cluster-name> <version> [flags]。cluster-name 为要操作的集群名字，version 为要升级到的目标版本。选项 --offline 声明当前集群处于离线状态，-h, --help 输出帮助信息。升级服务的日志可查看。
-- [tiup env](https://docs.pingcap.com/tidb/stable/tiup-command-env.md): TiUP 提供灵活的定制化接口，使用环境变量实现。命令 `tiup env` 用于查询 TiUP 支持的用户自定义环境变量及其值。若未指定环境变量，则输出"{key}"="{value}"列表。若指定了环境变量，则按顺序输出"{value}"列表。若值为空，则代表未设置环境变量的值，TiUP 会使用默认值。
-- [TiUP FAQ](https://docs.pingcap.com/tidb/stable/tiup-faq.md): TiUP 支持自定义镜像源，可以使用环境变量 TIUP_MIRRORS 指定镜像源地址。开发者可以通过 tiup-publish 组件将自己编写的组件发布到 TiUP 的官方镜像仓库。TiUP Playground 用于快速搭建开发环境，而 TiUP Cluster 用于部署生产环境集群。拓扑文件样例包括两地三中心、最小部署和完整拓扑文件。同一主机可以部署多个实例，但需要配置不同的端口和目录信息。集群部署期间可能出现 ssh 连接错误，可尝试加大 ssh 默认连接数并重启 sshd 服务解决。
-- [tiup help](https://docs.pingcap.com/tidb/stable/tiup-command-help.md): TiUP 命令行界面提供丰富的帮助信息，用户可通过 `help` 命令或 `--help` 参数查看。`tiup help <command>` 等同于 `tiup <command> --help`。语法为 `tiup help [command]`，若不指定命令，则查看 TiUP 自身的帮助信息。选项为无，输出为 `[command]` 或 TiUP 的帮助信息。
-- [tiup install](https://docs.pingcap.com/tidb/stable/tiup-command-install.md): tiup install 命令用于从镜像仓库下载指定版本的组件包，并在本地解压。当需要运行不存在于镜像仓库中的组件时，会尝试下载并自动运行，若不存在会报错。语法为 tiup install <component1>[version] [component2...N] [flags]。输出包括组件的下载信息，若组件不存在则报错"The component "%s" not found"，若版本不存在则报错"version %s not supported by component %s"。
-- [tiup list](https://docs.pingcap.com/tidb/stable/tiup-command-list.md): tiup list 命令用于查询镜像中可用的组件列表。可选的组件名称。若指定，则列出该组件的所有版本；若不指定，则列出所有组件列表。--all 显示所有组件。默认只显示非隐藏组件。--installed 只显示已经安装的组件或版本。--verbose 在组件列表中显示已安装的版本列表。若未指定组件名，输出组件名、组件管理员、组件描述构成的组件信息列表。若指定组件名，输出版本、是否已安装、发布时间、支持的平台构成的版本信息列表。
-- [tiup mirror](https://docs.pingcap.com/tidb/stable/tiup-command-mirror.md): TiUP 中的镜像是一个重要概念，支持本地镜像和远程镜像。命令 `tiup mirror` 用于管理镜像，包括创建、发布、密钥管理等功能。语法为 `tiup mirror <command> [flags]`，支持的子命令包括 genkey、sign、init、set、grant、publish、modify、rotate、clone、merge。详细信息请参考 TiUP 命令清单。
-- [tiup mirror clone](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-clone.md): tiup mirror clone 命令用于克隆已存在的镜像或部分组件生成新镜像。新旧镜像的组件相同，但使用的签名密钥不同。命令语法为 tiup mirror clone <target-dir> [global version] [flags]。选项包括 -f, --full, -a, --arch, -o, --os, --prefix, --{component}。
-- [tiup mirror genkey](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-genkey.md): TiUP 镜像命令 genkey 用于生成私钥。管理员有 root.json、index.json、snapshot.json 和 timestamp.json 的修改权限。组件管理员有相关组件的修改权限。普通用户可以下载并使用组件。私钥名默认为 private，可以显示对应的公钥。可以将公钥信息储存为文件。输出包括私钥已存在或已写入，以及公钥内容。
-- [tiup mirror grant](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-grant.md): tiup mirror grant 命令用于向当前镜像中添加组件管理员。组件管理员可以发布新组件或修改之前发布的组件。添加管理员时，需将公钥发送给镜像管理员。命令仅支持本地镜像使用。语法：tiup mirror grant <id>。选项：-k, --key（指定管理员密钥）、-n, --name（指定管理员名字）。输出：执行成功无输出，管理员 ID 重复报错，密钥被其他管理员使用报错。
-- [tiup mirror init](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-init.md): tiup mirror init 命令用于初始化一个空的镜像。初始化的镜像不包含任何组件和组件管理员，仅生成一些文件。语法为 tiup mirror init <path> [flags]，其中 <path> 为本地目录路径，可以为相对路径。选项包括 -k, --key-dir（string，默认 {path}/keys）。输出包括若成功则无输出，若 <path> 不为空则输出错误信息，若 <path> 不是目录则输出错误信息。
-- [tiup mirror merge](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-merge.md): tiup mirror merge 命令用于将一个或多个镜像合并到当前镜像。执行此命令需要目标镜像的管理员 ID 在当前镜像中存在，并且用户的 ${TIUP_HOME}/keys 目录中有对应的私钥。语法：tiup mirror merge <mirror-dir-1> [mirror-dir-N]。选项：无。输出：成功时无输出，否则会提示缺失管理员或私钥。
-- [tiup mirror modify](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-modify.md): tiup mirror modify 命令用于修改已发布的组件。只有合法的组件管理员才能修改组件，且只能修改自己发布的组件。命令语法为 tiup mirror modify <component>[version]。选项包括 -k, --key, --yank, --hide。成功时无输出，无权限时会有相应错误提示。
-- [tiup mirror publish](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-publish.md): tiup mirror publish 命令用于发布新组件或已有组件的新版本。只有有权限的组件管理员才可以发布组件。命令语法为 tiup mirror publish <comp-name> <version> <tarball> <entry> [flags]。其中各参数含义为组件名、版本号、tarball 包路径、组件可执行文件位置。命令还包含选项 -k, --key, --arch, --os, --desc, --hide。成功时无输出，无权限时会有相应错误提示。
-- [tiup mirror rotate](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-rotate.md): TiUP 的镜像中有一个重要文件 root.json，记录了系统需要使用的公钥和信任链基础。包含管理员签名、用于验证的公钥和过期时间。更新 root.json 需要管理员重新签名，使用命令 `tiup mirror rotate` 自动化更新流程。需要确保 TiUP 客户端升级到 v1.5.0 或以上版本。命令启动编辑器修改内容，等待管理员签名。选项包括临时服务器监听地址。输出为各个镜像管理员当前的签名状态。
-- [tiup mirror set](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-set.md): tiup mirror set 命令用于切换当前镜像，支持本地文件系统和远程网络两种镜像。命令语法为 tiup mirror set <mirror-addr> [flags]，其中 <mirror-addr> 为镜像地址，可以是网络地址或本地文件路径。选项 -r, --root 用于指定根证书。输出为无。
-- [tiup mirror sign](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-sign.md): tiup mirror sign 命令用于对镜像中定义的元信息文件进行签名。语法为 tiup mirror sign <manifest-file>。选项包括 -k, --key 和 --timeout。输出包括成功、文件已被指定的 key 签名过和文件不是合法的 manifest。
-- [tiup status](https://docs.pingcap.com/tidb/stable/tiup-command-status.md): tiup status 命令用于查看组件的运行信息，包括组件名称、进程 ID、运行状态、启动时间、数据目录、二进制文件路径和启动参数。组件可能处于在线、离线、无法访问、已缩容下线、下线中或未知状态。这些状态来自于 PD 的调度信息。
-- [tiup telemetry](https://docs.pingcap.com/tidb/stable/tiup-command-telemetry.md): TiUP 遥测功能在 v1.11.3 及以上版本默认关闭，以下版本默认开启。开启后会分享使用情况信息给 PingCAP，包括遥测标示符、命令执行情况、部署情况等。不会分享集群准确名字、拓扑结构、配置文件。使用命令 `tiup telemetry` 控制遥测，支持 status、reset、enable、disable 命令。
-- [tiup uninstall](https://docs.pingcap.com/tidb/stable/tiup-command-uninstall.md): tiup uninstall 命令用于卸载已安装的组件。语法为 tiup uninstall <component1> <version> [component2...N] [flags]。选项包括 --all 用于卸载指定组件的全部已安装版本，--self 用于卸载 TiUP 自身。正常退出时会显示"Uninstalled component "%s" successfully!"，若未指定 <version> 也未指定 --all 则会报错"Use "tiup uninstall tidbx --all" if you want to remove all versions."。
-- [tiup update](https://docs.pingcap.com/tidb/stable/tiup-command-update.md): tiup update 命令用于升级已安装的组件或自身。语法为 tiup update [组件名] [版本]，可指定多个组件或版本。选项包括 --all（升级所有组件）、--force（强制升级已安装版本）、--nightly（升级到 nightly 版本）、--self（升级 TiUP 自身）。
-- [TiUP 命令概览](https://docs.pingcap.com/tidb/stable/tiup-reference.md): TiUP 是 TiDB 生态的包管理器，管理着诸如 TiDB、PD、TiKV 等组件。它支持执行命令和运行组件，可以通过 `--help` 获取命令信息。选项包括打印二进制文件路径、指定组件路径、指定组件 tag、打印版本和帮助信息。TiUP 包含众多命令和子命令，以及组件清单。
-- [TiUP 常见运维操作](https://docs.pingcap.com/tidb/stable/maintain-tidb-using-tiup.md): TiUP 是用于管理 TiDB 集群的工具，可以进行查看集群列表、启动、关闭、修改配置参数、查看状态等常见运维操作。操作简单方便，适合用于 TiDB 集群的管理。
-- [TiUP 故障排查](https://docs.pingcap.com/tidb/stable/tiup-troubleshooting-guide.md): TiUP 故障排查包括命令故障排查和集群组件故障排查。命令故障包括强制刷新组件列表和版本信息，网络中断导致的下载问题，以及 checksum 错误。集群组件故障包括 SSH 私钥问题，升级中断和缺失组件文件的解决方法。可通过 Github Issues 或 AskTUG 求助。
-- [TiUP 文档地图](https://docs.pingcap.com/tidb/stable/tiup-documentation-guide.md): TiUP 文档地图包括使用文档和资源两部分。使用文档包括 TiUP 概览、TiUP 术语、TiUP 组件管理、TiUP FAQ、TiUP 故障排查和 TiUP 参考手册。资源包括 TiUP 版本发布说明、AskTUG TiUP 主题和 TiUP Issues。
-- [TiUP 术语及核心概念](https://docs.pingcap.com/tidb/stable/tiup-terminology-and-concepts.md): TiUP 是一个用于下载、更新、卸载组件的程序，通过各种组件来扩展其功能。组件是可以运行的程序或脚本，通过 tiup <component> 命令来运行。TiUP 组件可以从镜像仓库下载，用户可以通过设置 TIUP_MIRRORS 环境变量来自定义镜像仓库。
-- [TiUP 简介](https://docs.pingcap.com/tidb/stable/tiup-overview.md): TiUP 是 TiDB 生态中的包管理工具，简化了软件的安装和升级维护工作。安装 TiUP 十分简洁，只需执行一行命令即可完成。TiUP 的愿景是降低 TiDB 生态中所有工具的使用门槛，通过命令和组件来实现包管理和操作。
-- [TiUP 镜像参考指南](https://docs.pingcap.com/tidb/stable/tiup-mirror-reference.md): TiUP 镜像是存放 TiUP 组件和元信息的仓库。镜像存在两种形式：本地镜像和远程镜像。镜像可通过命令创建和更新。镜像目录结构包括根证书、索引、组件、快照和时间戳。客户端通过逻辑保证下载文件安全。
-- [TopN 和 Limit 下推](https://docs.pingcap.com/tidb/stable/topn-limit-push-down.md): TiDB 中的 LIMIT 子句对应 Limit 算子节点，ORDER BY 子句对应 Sort 算子节点。相邻的 Limit 和 Sort 算子组合成 TopN 算子节点，表示按排序规则提取记录的前 N 项。TopN 下推将尽可能下推到数据源附近，减少数据传输或计算的开销。可参考 [优化规则及表达式下推的黑名单](/blocklist-control-plan.md) 中的关闭方法。TopN 可下推到存储层 Coprocessor，减少计算开销。TopN 无法下推过 Join，排序规则仅依赖于外表列时可下推。TopN 也可转换成 Limit，简化排序操作。
-- [TRACE](https://docs.pingcap.com/tidb/stable/sql-statement-trace.md): TiDB 数据库中 TRACE 的使用概况。
-- [TRUNCATE](https://docs.pingcap.com/tidb/stable/sql-statement-truncate.md): TiDB 数据库中 TRUNCATE 的使用概况。
-- [TSO 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tso-configuration.md): TSO 配置参数可以通过命令行参数或环境变量配置。
-- [TSO 配置文件描述](https://docs.pingcap.com/tidb/stable/tso-configuration-file.md): TSO 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
-- [UNLOCK STATS](https://docs.pingcap.com/tidb/stable/sql-statement-unlock-stats.md): TiDB 数据库中 UNLOCK STATS 的使用概况。
-- [UPDATE](https://docs.pingcap.com/tidb/stable/sql-statement-update.md): TiDB 数据库中 UPDATE 的使用概况。
+- [TiDB 中的 TimeStamp Oracle (TSO)](https://docs.pingcap.com/zh/tidb/stable/tso.md): 了解 TiDB 中的 TimeStamp Oracle (TSO)。
+- [TiDB 中的各种超时](https://docs.pingcap.com/zh/tidb/stable/dev-guide-timeouts-in-tidb.md): 简单介绍 TiDB 中的各种超时，为排查错误提供依据。
+- [TiDB 乐观事务模型](https://docs.pingcap.com/zh/tidb/stable/optimistic-transaction.md): 了解 TiDB 的乐观事务模型。
+- [TiDB 事务概览](https://docs.pingcap.com/zh/tidb/stable/transaction-overview.md): 了解 TiDB 中的事务。
+- [TiDB 事务隔离级别](https://docs.pingcap.com/zh/tidb/stable/transaction-isolation-levels.md): 了解 TiDB 事务的隔离级别。
+- [TiDB 产品常见问题](https://docs.pingcap.com/zh/tidb/stable/tidb-faq.md): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理，具备水平扩容、高可用、实时 HTAP、云原生的特性。TiDB 不是基于 MySQL 开发的，而是由 PingCAP 团队完全自主开发的产品。TiDB 易用性很高，支持绝大部分 MySQL 8.0 的语法，但不支持触发器、存储过程、自定义函数等。TiDB 支持分布式事务，兼容 MySQL Client/Driver 的编程语言，支持其他存储引擎，如 TiKV、UniStore 和 MockTiKV。获取 TiDB 知识的途径包括官方文档、官方博客、AskTUG 社区论坛和 PingCAP Education。用户名长度限制为 32 个字符，最大列数为 1017，单行大小不超过 6MB。TiDB 不支持 XA，但支持对列存储引擎的高并发 INSERT 或 UPDATE 操作。
+- [TiDB 产品常见问题解答汇总](https://docs.pingcap.com/zh/tidb/stable/faq-overview.md): 汇总 TiDB 产品的常见问题解答。
+- [TiDB 使用限制](https://docs.pingcap.com/zh/tidb/stable/tidb-limitations.md): TiDB 中的使用限制包括标识符长度限制、数据库、表、视图、连接总个数限制、单个数据库和表的限制、单行限制、数据类型限制、SQL 语句限制和 TiKV 版本限制。
+- [TiDB 全局排序](https://docs.pingcap.com/zh/tidb/stable/tidb-global-sort.md): 了解 TiDB 全局排序功能的使用场景、限制、使用方法和实现原理。
+- [TiDB 内存控制文档](https://docs.pingcap.com/zh/tidb/stable/configure-memory-usage.md): TiDB 内存控制文档介绍了如何追踪和控制 SQL 查询过程中的内存使用情况，以及配置内存使用阈值和 tidb-server 实例的内存使用阈值。还介绍了使用 INFORMATION_SCHEMA 系统表查看内存使用情况，以及降低写入事务内存使用的方法。另外还介绍了流量控制和数据落盘的内存控制策略，以及通过设置环境变量 GOMEMLIMIT 缓解 OOM 问题。
+- [TiDB 分布式执行框架](https://docs.pingcap.com/zh/tidb/stable/tidb-distributed-execution-framework.md): 了解 TiDB 分布式执行框架的使用场景、限制、使用方法和实现原理。
+- [TiDB 功能概览](https://docs.pingcap.com/zh/tidb/stable/basic-features.md): 了解 TiDB 的功能概览。
+- [TiDB 增量备份与恢复使用指南](https://docs.pingcap.com/zh/tidb/stable/br-incremental-guide.md): 了解 TiDB 的增量备份与恢复功能使用。
+- [TiDB 备份与恢复功能使用概述](https://docs.pingcap.com/zh/tidb/stable/br-use-overview.md): 了解如何部署和使用 TiDB 集群的备份与恢复。
+- [TiDB 备份与恢复功能架构概述](https://docs.pingcap.com/zh/tidb/stable/backup-and-restore-design.md): 了解 TiDB 的备份与恢复功能的架构设计。
+- [TiDB 备份与恢复实践示例](https://docs.pingcap.com/zh/tidb/stable/backup-and-restore-use-cases.md): 介绍 TiDB 备份与恢复的具体使用示例，包括推荐环境配置、存储配置、备份策略及如何进行备份与恢复。
+- [TiDB 备份与恢复概述](https://docs.pingcap.com/zh/tidb/stable/backup-and-restore-overview.md): 了解不同场景下如何使用 TiDB 的备份与恢复功能，以及不同功能、版本间的兼容性。
+- [TiDB 安全配置最佳实践](https://docs.pingcap.com/zh/tidb/stable/best-practices-for-security-configuration.md): 介绍 TiDB 安全配置的最佳实践，帮助你降低潜在的安全风险。
+- [TiDB 安装部署常见问题](https://docs.pingcap.com/zh/tidb/stable/deploy-and-maintain-faq.md): 介绍 TiDB 集群安装部署的常见问题、原因及解决方法。
+- [TiDB 容灾方案概述](https://docs.pingcap.com/zh/tidb/stable/dr-solution-introduction.md): 了解 TiDB 提供的几种容灾方案，包括基于主备集群的容灾、基于多副本的单集群容灾和基于备份与恢复的容灾。
+- [TiDB 密码管理](https://docs.pingcap.com/zh/tidb/stable/password-management.md): 了解 TiDB 的用户密码管理机制。
+- [TiDB 工具下载](https://docs.pingcap.com/zh/tidb/stable/download-ecosystem-tools.md): 本文介绍如何下载 TiDB 工具包。TiDB 工具包包含常用工具如 Dumpling、TiDB Lightning、BR 等。如果部署环境能访问互联网，可直接通过 TiUP 命令一键部署所需的 TiDB 工具。操作系统需为 Linux，架构为 amd64 或 arm64。下载步骤包括访问 TiDB 社区版页面，找到 TiDB-community-toolkit 软件包并点击立即下载。注意，点击立即下载后默认下载当前 TiDB 的最新发布版本。根据要使用的工具选择安装对应的离线包。
+- [TiDB 工具功能概览](https://docs.pingcap.com/zh/tidb/stable/ecosystem-tool-user-guide.md): TiDB 提供了丰富的工具，包括部署运维工具 TiUP 和 TiDB Operator，数据管理工具如 TiDB Data Migration（DM）、Dumpling、TiDB Lightning、Backup & Restore（BR）、TiCDC、sync-diff-inspector，以及 OLAP 分析工具 TiSpark。这些工具可用于部署、数据迁移、备份恢复、数据校验等多种操作，满足不同需求。
+- [TiDB 工具的使用场景](https://docs.pingcap.com/zh/tidb/stable/ecosystem-tool-user-case.md): 本文档介绍 TiDB 工具的常见使用场景与工具选择。
+- [TiDB 快照备份与恢复使用指南](https://docs.pingcap.com/zh/tidb/stable/br-snapshot-guide.md): 了解如何使用 br 命令行工具进行 TiDB 快照备份与恢复。
+- [TiDB 快照备份与恢复功能架构](https://docs.pingcap.com/zh/tidb/stable/br-snapshot-architecture.md): 了解 TiDB 快照备份与恢复功能的架构设计。
+- [TiDB 快照备份与恢复命令行手册](https://docs.pingcap.com/zh/tidb/stable/br-snapshot-manual.md): 介绍备份与恢复 TiDB 集群快照的命令行。
+- [TiDB 性能分析和优化方法](https://docs.pingcap.com/zh/tidb/stable/performance-tuning-methods.md): 本文介绍了基于数据库时间的系统优化方法，以及如何利用 TiDB Performance Overview 面板进行性能分析和优化。
+- [TiDB 悲观事务模式](https://docs.pingcap.com/zh/tidb/stable/pessimistic-transaction.md): 了解 TiDB 的悲观事务模式。
+- [TiDB 执行计划概览](https://docs.pingcap.com/zh/tidb/stable/explain-overview.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划。
+- [TiDB 支持的第三方工具](https://docs.pingcap.com/zh/tidb/stable/dev-guide-third-party-support.md): TiDB 支持的第三方工具主要包括驱动、ORM 框架和 GUI。支持等级分为 Full 和 Compatible，其中 Full 表示绝大多数功能兼容性已得到支持，Compatible 表示大部分功能可使用但未经完整验证。对于支持的 Driver 或 ORM 框架并不包括应用端事务重试和错误处理。如果在使用工具连接 TiDB 时出现问题，可在 GitHub 上提交包含详细信息的 issue 以获得进展。
+- [TiDB 数据库快速上手指南](https://docs.pingcap.com/zh/tidb/stable/quick-start-with-tidb.md): 了解如何快速上手使用 TiDB 数据库。
+- [TiDB 数据库的存储](https://docs.pingcap.com/zh/tidb/stable/tidb-storage.md): 了解 TiDB 数据库的存储层。
+- [TiDB 数据库的计算](https://docs.pingcap.com/zh/tidb/stable/tidb-computing.md): 了解 TiDB 数据库的计算层。
+- [TiDB 数据库的调度](https://docs.pingcap.com/zh/tidb/stable/tidb-scheduling.md): TiDB 数据库的调度由 PD（Placement Driver）模块负责管理和实时调度集群数据。PD 需要收集节点和 Region 的状态信息，并根据调度策略制定调度计划，包括增加 / 删除副本、迁移 Leader 角色等基本操作。调度需满足副本数量、位置分布、负载均衡、存储空间利用等需求。PD 通过心跳包收集信息，并根据策略生成调度操作序列，但具体执行由 Region Leader 决定。
+- [TiDB 整体架构](https://docs.pingcap.com/zh/tidb/stable/tidb-architecture.md): 了解 TiDB 的整体架构。
+- [TiDB 日志备份与 PITR 使用指南](https://docs.pingcap.com/zh/tidb/stable/br-pitr-guide.md): 了解 TiDB 的日志备份与 PITR 功能使用。
+- [TiDB 日志备份与 PITR 功能架构](https://docs.pingcap.com/zh/tidb/stable/br-log-architecture.md): 了解 TiDB 的日志备份与 PITR 的架构设计。
+- [TiDB 日志备份与 PITR 命令行手册](https://docs.pingcap.com/zh/tidb/stable/br-pitr-manual.md): 介绍 TiDB 日志备份与 PITR 的命令行。
+- [TiDB 最佳实践](https://docs.pingcap.com/zh/tidb/stable/tidb-best-practices.md): TiDB 最佳实践总结了使用 TiDB 的一些优化技巧，包括 Raft 一致性协议、分布式事务、数据分片、负载均衡、SQL 到 KV 的映射方案、二级索引的实现方法等。建议阅读官方文档和知乎专栏了解更多细节。部署时推荐使用 TiUP，导入数据时可对 TiKV 参数进行调优。在写入和查询时需注意事务大小限制和并发度设置。监控系统和日志查看也是了解系统状态的重要方法。适用场景包括数据量大、不希望做 Sharding、需要事务和强一致性等。
+- [TiDB 热点问题处理](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-hot-spot-issues.md): TiDB 热点问题处理：介绍定位和解决读写热点问题，包括常见热点场景、确定存在热点问题的方法、使用 TiDB Dashboard 定位热点表、使用 SHARD_ROW_ID_BITS 处理热点表、使用 AUTO_RANDOM 处理自增主键热点表、小表热点的优化、打散读热点。
+- [TiDB 版本发布历史](https://docs.pingcap.com/zh/tidb/stable/release-notes.md): 介绍 TiDB 版本发布历史。
+- [TiDB 版本发布时间线](https://docs.pingcap.com/zh/tidb/stable/release-timeline.md): 了解 TiDB 的版本发布时间线。
+- [TiDB 版本规则](https://docs.pingcap.com/zh/tidb/stable/versioning.md): 了解 TiDB 版本发布的规则。
+- [TiDB 特有的函数](https://docs.pingcap.com/zh/tidb/stable/tidb-functions.md): 学习使用 TiDB 特有的函数。
+- [TiDB 环境与系统配置检查](https://docs.pingcap.com/zh/tidb/stable/check-before-deployment.md): 了解部署 TiDB 前的环境检查操作。
+- [TiDB 用户账户管理](https://docs.pingcap.com/zh/tidb/stable/user-account-management.md): TiDB 用户账户管理主要包括用户名和密码设置、添加用户、删除用户、保留用户账户、设置资源限制、设置密码、忘记密码处理和刷新权限。用户可以通过 SQL 语句或图形化界面工具进行用户管理，同时可以使用 `FLUSH PRIVILEGES` 命令立即生效修改。 TiDB 在数据库初始化时会生成一个默认账户。
+- [TiDB 监控常见问题](https://docs.pingcap.com/zh/tidb/stable/monitor-faq.md): 介绍在监控 TiDB 集群时的常见问题、原因及解决方法。
+- [TiDB 监控指标](https://docs.pingcap.com/zh/tidb/stable/grafana-tidb-dashboard.md): 了解 Grafana Dashboard 中展示的关键指标。
+- [TiDB 监控框架概述](https://docs.pingcap.com/zh/tidb/stable/tidb-monitoring-framework.md): TiDB 使用 Prometheus 作为监控和性能指标存储，Grafana 用于可视化展示，以及 TiDB Dashboard 图形化界面用于监控及诊断 TiDB 集群。Prometheus 提供多个组件，包括 Prometheus Server、Client 代码库和 Alertmanager。Grafana 展示 TiDB 集群各组件的相关监控，分组包括备份恢复、Binlog、网络探活、磁盘性能、Kafka、TiDB Lightning 等。每个分组包含多个监控项页签，以及详细的监控指标看板。观看培训视频可快速了解监控与报警系统的体系、数据流转方式、系统管理方法和常用监控指标。
+- [TiDB 磁盘 I/O 过高的处理办法](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-high-disk-io.md): 了解如何定位和处理 TiDB 存储 I/O 过高的问题。
+- [TiDB 社区荣誉列表](https://docs.pingcap.com/zh/tidb/stable/credits.md): 了解 TiDB 社区贡献者列表及角色。
+- [TiDB 离线包](https://docs.pingcap.com/zh/tidb/stable/binary-package.md): 了解 TiDB 离线包及其包含的内容。
+- [TiDB 简介](https://docs.pingcap.com/zh/tidb/stable/overview.md): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理 (HTAP)。具有水平扩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等特性。适用于高可用、强一致性要求高、数据规模大等各种应用场景。具有一键水平扩缩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等五大核心特性，以及金融行业、海量数据及高并发的 OLTP、实时 HTAP、数据汇聚、二次加工处理等四大核心应用场景。
+- [TiDB 证书鉴权使用指南](https://docs.pingcap.com/zh/tidb/stable/certificate-authentication.md): 了解使用 TiDB 的证书鉴权功能。
+- [TiDB 软件和硬件环境需求](https://docs.pingcap.com/zh/tidb/stable/hardware-and-software-requirements.md): TiDB 是一款开源的一站式实时 HTAP 数据库，支持部署在多种硬件环境和操作系统上。软件和硬件环境建议配置包括操作系统要求、编译和运行依赖库、Docker 镜像依赖、软件配置要求、服务器建议配置、网络要求、磁盘空间要求、客户端 Web 浏览器要求以及 TiFlash 存算分离架构的软硬件要求。
+- [TiDB 配置参数](https://docs.pingcap.com/zh/tidb/stable/command-line-flags-for-tidb-configuration.md): TiDB 配置参数包括启动参数和环境变量。启动参数包括 advertise-address、config、config-check、config-strict、cors 等。其中默认端口为 4000 和 10080。其他参数包括 log-file、metrics-addr、metrics-interval 等。注意配置文件的有效性和安全模式下的启动。
+- [TiDB 配置文件描述](https://docs.pingcap.com/zh/tidb/stable/tidb-configuration-file.md): 介绍未包含在命令行参数中的 TiDB 配置文件选项。
+- [TiDB 锁冲突问题处理](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-lock-conflicts.md): 了解 TiDB 锁冲突问题以及处理方式。
+- [TiDB 集群报警规则](https://docs.pingcap.com/zh/tidb/stable/alert-rules.md): TiDB 集群中各组件的报警规则详解。
+- [TiDB 集群故障诊断](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-tidb-cluster.md): TiDB 集群故障诊断包括收集出错信息、组件状态、日志信息、机器配置和 dmesg 中的问题。解决数据库连接问题需要确认服务是否启动，查看 tidb-server 日志并清空数据重新部署服务。解决 tidb-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 tikv-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 pd-server 启动报错需检查参数和端口占用。进程异常退出需检查是否在前台启动，使用 nohup+& 方式运行或写在脚本中。TiKV 进程异常重启需检查 OOM 信息和 panic log。连接被拒绝需确保网络参数正确。解决文件打开过多问题需确保 ulimit -n 足够大。数据库访问超时需检查拓扑结构、硬件配置、其他服务、操作、CPU 线程、网络 /IO 监控数据。
+- [TiDB 集群监控 API](https://docs.pingcap.com/zh/tidb/stable/tidb-monitoring-api.md): TiDB 提供状态接口和 Metrics 接口来监控集群状态。状态接口可获取 TiDB Server 的运行状态和存储信息，PD 的状态接口可查看整个 TiKV 集群的详细信息。Metrics 接口用于监控整个集群的状态和性能。部署 Prometheus 和 Grafana 后，配置 Grafana 即可使用 Metrics 接口。
+- [TiDB 集群管理常见问题](https://docs.pingcap.com/zh/tidb/stable/manage-cluster-faq.md): 介绍 TiDB 集群管理的常见问题、原因及解决方法。
+- [TiDB 集群问题导图](https://docs.pingcap.com/zh/tidb/stable/tidb-troubleshooting-map.md): 了解如何处理 TiDB 集群常见问题。
+- [TiDB 高并发写入场景最佳实践](https://docs.pingcap.com/zh/tidb/stable/high-concurrency-best-practices.md): 了解 TiDB 在高并发写入场景下的最佳实践。
+- [TIDB_CHECK_CONSTRAINTS](https://docs.pingcap.com/zh/tidb/stable/information-schema-tidb-check-constraints.md): 了解 INFORMATION_SCHEMA 表 `TIDB_CHECK_CONSTRAINTS`。
+- [TIDB_HOT_REGIONS](https://docs.pingcap.com/zh/tidb/stable/information-schema-tidb-hot-regions.md): 了解 information_schema 表 `TIDB_HOT_REGIONS`。
+- [TIDB_HOT_REGIONS_HISTORY](https://docs.pingcap.com/zh/tidb/stable/information-schema-tidb-hot-regions-history.md): 了解 information_schema 表 `TIDB_HOT_REGIONS_HISTORY`。
+- [TIDB_INDEX_USAGE](https://docs.pingcap.com/zh/tidb/stable/information-schema-tidb-index-usage.md): 了解 INFORMATION_SCHEMA 表 `TIDB_INDEX_USAGE`。
+- [TIDB_INDEXES](https://docs.pingcap.com/zh/tidb/stable/information-schema-tidb-indexes.md): 了解 information_schema 表 `TIDB_INDEXES`。
+- [TIDB_SERVERS_INFO](https://docs.pingcap.com/zh/tidb/stable/information-schema-tidb-servers-info.md): 了解 INFORMATION_SCHEMA 表 `TIDB_SERVERS_INFO`。
+- [TIDB_TRX](https://docs.pingcap.com/zh/tidb/stable/information-schema-tidb-trx.md): 了解 INFORMATION_SCHEMA 表 `TIDB_TRX`。
+- [TiFlash MinTSO 调度器](https://docs.pingcap.com/zh/tidb/stable/tiflash-mintso-scheduler.md): 了解 TiFlash MinTSO 调度器的实现原理。
+- [TiFlash Pipeline Model 执行模型](https://docs.pingcap.com/zh/tidb/stable/tiflash-pipeline-model.md): 介绍 TiFlash 新的执行模型 Pipeline Model。
+- [TiFlash 兼容性说明](https://docs.pingcap.com/zh/tidb/stable/tiflash-compatibility.md): 了解与 TiFlash 不兼容的 TiDB 特性。
+- [TiFlash 升级帮助](https://docs.pingcap.com/zh/tidb/stable/tiflash-upgrade-guide.md): 了解升级 TiFlash 时的注意事项。
+- [TiFlash 命令行参数](https://docs.pingcap.com/zh/tidb/stable/tiflash-command-line-flags.md): TiFlash 的命令行启动参数包括 server --config-file、dttool migrate、dttool bench 和 dttool inspect。server --config-file 用于指定配置文件路径，dttool migrate 用于迁移 DTFile 的文件格式，dttool bench 用于提供 DTFile 的简单 IO 速度测试，dttool inspect 用于检查 DTFile 的完整性。每个命令都有对应的参数，可以根据需求进行配置。警告：TiFlash 目前只支持默认压缩等级的 LZ4 算法，自定义压缩参数并未经过大量测试。注意：为保证安全，DTTool 在迁移模式下会尝试对工作目录进行加锁。
+- [TiFlash 存算分离架构与 S3 支持](https://docs.pingcap.com/zh/tidb/stable/tiflash-disaggregated-and-s3.md): 了解 TiFlash 存算分离架构与 S3 支持。
+- [TiFlash 常见问题](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-tiflash.md): 介绍 TiFlash 的常见问题、原因及解决办法。
+- [TiFlash 延迟物化](https://docs.pingcap.com/zh/tidb/stable/tiflash-late-materialization.md): 介绍通过使用 TiFlash 延迟物化的方式来加速 OLAP 场景的查询。
+- [TiFlash 性能分析和优化方法](https://docs.pingcap.com/zh/tidb/stable/tiflash-performance-tuning-methods.md): 本文介绍了 Performance Overview 面板中 TiFlash 部分，帮助你了解和监控 TiFlash 的工作负载。
+- [TiFlash 性能调优](https://docs.pingcap.com/zh/tidb/stable/tune-tiflash-performance.md): 介绍 TiFlash 性能调优的方法，包括机器资源规划和 TiDB 参数调优。
+- [TiFlash 报警规则](https://docs.pingcap.com/zh/tidb/stable/tiflash-alert-rules.md): TiFlash 报警规则介绍了 TiFlash 集群的报警规则。包括了TiFlash_schema_error、TiFlash_schema_apply_duration、TiFlash_raft_read_index_duration 和 TiFlash_raft_wait_index_duration 四种报警规则，以及它们的规则描述和处理方法。报警规则主要用于监控TiFlash集群的运行状态，及时发现问题并联系 TiFlash 开发人员进行处理。
+- [TiFlash 支持的计算下推](https://docs.pingcap.com/zh/tidb/stable/tiflash-supported-pushdown-calculations.md): 了解 TiFlash 支持的计算下推。
+- [TiFlash 数据校验](https://docs.pingcap.com/zh/tidb/stable/tiflash-data-validation.md): 了解 TiFlash 的数据校验机制以及相关的工具。
+- [TiFlash 数据落盘](https://docs.pingcap.com/zh/tidb/stable/tiflash-spill-disk.md): 介绍 TiFlash 数据落盘功能。
+- [TiFlash 查询结果物化](https://docs.pingcap.com/zh/tidb/stable/tiflash-results-materialization.md): 介绍如何在同一个事务中保存 TiFlash 的查询结果。
+- [TiFlash 简介](https://docs.pingcap.com/zh/tidb/stable/tiflash-overview.md): TiFlash 是 TiDB HTAP 形态的关键组件，提供了良好的隔离性和强一致性。它使用列存扩展和 Raft Learner 协议异步复制，通过 Raft 校对索引配合 MVCC 实现一致性隔离级别。TiFlash 架构解决了 HTAP 场景的隔离性和列存同步问题。它提供列式存储和借助 ClickHouse 高效实现的协处理器层。TiFlash 可以兼容 TiDB 和 TiSpark，推荐与 TiKV 不同节点部署以实现 Workload 隔离。具有异步复制、一致性、智能选择和计算加速等核心特性。部署完成后需要手动指定需要同步的表。
+- [TiFlash 部署拓扑](https://docs.pingcap.com/zh/tidb/stable/tiflash-deployment-topology.md): 了解在部署最小拓扑集群的基础上，部署 TiFlash 的拓扑结构。
+- [TiFlash 配置参数](https://docs.pingcap.com/zh/tidb/stable/tiflash-configuration.md): TiFlash 配置参数包括 PD 调度参数和 TiFlash 配置参数。PD 调度参数可通过 pd-ctl 调整，包括 replica-schedule-limit 和 store-balance-rate。TiFlash 配置参数包括 tiflash.toml 和 tiflash-learner.toml，用于配置 TiFlash TCP/HTTP 服务的监听和存储路径。另外，通过拓扑 label 进行副本调度和多盘部署也是可行的。
+- [TiFlash 集群监控](https://docs.pingcap.com/zh/tidb/stable/monitor-tiflash.md): TiFlash 集群监控包括 TiFlash-Summary、TiFlash-Proxy-Summary 和 TiFlash-Proxy-Details。监控指标包括存储、内存、CPU 使用率、请求处理、错误数量、线程数、任务调度、DDL、写入、读取、Raft 等信息。注意低版本监控信息不完善，建议使用 v4.0.5 或更高版本的 TiDB 集群。
+- [TiFlash 集群运维](https://docs.pingcap.com/zh/tidb/stable/maintain-tiflash.md): TiFlash 集群运维包括查看版本、重要日志和系统表。查看版本有两种方法：通过命令或在日志中查看。重要日志包括数据同步和处理请求的信息。系统表包括数据库名、表名、副本数、位置标签、可用性和同步进度。
+- [TIFLASH_REPLICA](https://docs.pingcap.com/zh/tidb/stable/information-schema-tiflash-replica.md): 了解 INFORMATION_SCHEMA 表 `TIFLASH_REPLICA`。
+- [TIFLASH_SEGMENTS](https://docs.pingcap.com/zh/tidb/stable/information-schema-tiflash-segments.md): 了解 information_schema 表 `TIFLASH_SEGMENTS`。
+- [TIFLASH_TABLES](https://docs.pingcap.com/zh/tidb/stable/information-schema-tiflash-tables.md): 了解 information_schema 表 `TIFLASH_TABLES`。
+- [TiKV Control 使用说明](https://docs.pingcap.com/zh/tidb/stable/tikv-control.md): TiKV Control（tikv-ctl）是 TiKV 的命令行工具，用于管理 TiKV 集群。它的安装目录在 `~/.tiup/components/ctl/{VERSION}/` 目录下。通过 TiUP 使用 TiKV Control，可以调用 `tikv-ctl` 工具。通用参数包括远程模式和本地模式，以及两个简单的命令 `--to-hex` 和 `--to-escaped`。其他子命令包括查看 Raft 状态机的信息、查看 Region 的大小、扫描查看给定范围的 MVCC、查看给定 key 的 MVCC、扫描 raw key、打印某个 key 的值、打印 Region 的 properties 信息、手动 compact 单个 TiKV 的数据、手动 compact 整个 TiKV 集群的数据、设置一个 Region 副本为 tombstone 状态、向 TiKV 发出 consistency-check 请求、Dump snapshot 元文件、打印 Raft 状态机出错的 Region、动态修改 TiKV 的配置、强制 Region 从多副本失败状态恢复服务、恢复损坏的 MVCC 数据、Ldb 命令、打印加密元数据、打印损坏的 SST 文件信息、获取一个 Region 的 RegionReadProgress 状态。
+- [TiKV MVCC 内存引擎](https://docs.pingcap.com/zh/tidb/stable/tikv-in-memory-engine.md): 了解内存引擎的适用场景和工作原理，使用内存引擎加速多版本记录查询。
+- [TiKV 内存参数性能调优](https://docs.pingcap.com/zh/tidb/stable/tune-tikv-memory-performance.md): TiKV 内存参数性能调优，根据机器配置情况调整参数以达到最佳性能。TiKV 使用 RocksDB 作为持久化存储，配置项包括 block-cache 大小和 write-buffer 大小。除此之外，系统内存还会被用于 page cache 和处理大查询时的数据结构生成。推荐将 TiKV 部署在 CPU 核数不低于 8 或内存不低于 32GiB 的机器上，对写入吞吐要求高时使用吞吐能力较好的磁盘，对读写延迟要求高时使用 IOPS 较高的 SSD 盘。
+- [TiKV 监控指标详解](https://docs.pingcap.com/zh/tidb/stable/grafana-tikv-dashboard.md): TiKV 监控指标详解：TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构详见 TiDB 监控框架概述。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。对于日常运维，通过观察 TiKV-Details 面板上的指标，可以了解 TiKV 当前的状态。根据性能地图，可以检查集群的状态是否符合预期。TiKV-Details 默认的监控信息包括 Cluster、Errors、Server、gRPC、Thread CPU、PD、Raft IO、Raft process、Raft message、Raft propose、Raft admin、Local reader、Unified Read Pool、Storage、Flow Control、Scheduler 等。
+- [TiKV 简介](https://docs.pingcap.com/zh/tidb/stable/tikv-overview.md): TiKV 是一个分布式事务型的键值数据库，通过 Raft 协议保证了多副本数据一致性和高可用。整体架构采用 multi-raft-group 的副本机制，保证数据和读写负载均匀分散在各个 TiKV 上。TiKV 支持分布式事务，通过两阶段提交保证了 ACID 约束。同时，通过协处理器可以为 TiDB 分担一部分计算。
+- [TiKV 线程池性能调优](https://docs.pingcap.com/zh/tidb/stable/tune-tikv-thread-performance.md): 了解 TiKV 线程池性能调优。
+- [TiKV 配置参数](https://docs.pingcap.com/zh/tidb/stable/command-line-flags-for-tikv-configuration.md): TiKV 配置参数支持文件大小和时间的可读性好的单位转换。命令行参数包括监听地址、对外访问地址、服务状态监听端口、对外访问服务状态地址、配置文件、存储数据的容量、配置信息输出格式、数据存储路径、日志级别、日志文件、PD 地址列表。需要注意的是，PD 地址列表需要使用逗号分隔多个地址。
+- [TiKV 配置文件描述](https://docs.pingcap.com/zh/tidb/stable/tikv-configuration-file.md): 了解 TiKV 的配置文件参数。
+- [TIKV_REGION_PEERS](https://docs.pingcap.com/zh/tidb/stable/information-schema-tikv-region-peers.md): 了解 INFORMATION_SCHEMA 表 `TIKV_REGION_PEERS`。
+- [TIKV_REGION_STATUS](https://docs.pingcap.com/zh/tidb/stable/information-schema-tikv-region-status.md): 了解 information_schema 表 `TIKV_REGION_STATUS`。
+- [TIKV_STORE_STATUS](https://docs.pingcap.com/zh/tidb/stable/information-schema-tikv-store-status.md): 了解 INFORMATION_SCHEMA 表 `TIKV_STORE_STATUS`。
+- [TiProxy API](https://docs.pingcap.com/zh/tidb/stable/tiproxy-api.md): 了解如何使用 TiProxy API 获取 TiProxy 的配置、健康状况和监控数据等信息。
+- [TiProxy 命令行参数](https://docs.pingcap.com/zh/tidb/stable/tiproxy-command-line-flags.md): 了解 TiProxy 的命令行参数。
+- [TiProxy 常见问题](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-tiproxy.md): 介绍 TiProxy 的常见问题、原因及解决办法。
+- [TiProxy 性能测试报告](https://docs.pingcap.com/zh/tidb/stable/tiproxy-performance-test.md): TiProxy 的性能测试报告、与 HAProxy 的性能对比。
+- [TiProxy 流量回放](https://docs.pingcap.com/zh/tidb/stable/tiproxy-traffic-replay.md): 介绍 TiProxy 的流量回放的使用场景和使用步骤。
+- [TiProxy 监控指标](https://docs.pingcap.com/zh/tidb/stable/tiproxy-grafana.md): 了解 TiProxy 的监控指标。
+- [TiProxy 简介](https://docs.pingcap.com/zh/tidb/stable/tiproxy-overview.md): 介绍 TiProxy 的主要功能、安装与使用方法。
+- [TiProxy 负载均衡策略](https://docs.pingcap.com/zh/tidb/stable/tiproxy-load-balance.md): 介绍 TiProxy 的负载均衡策略及其适用场景。
+- [TiProxy 部署拓扑](https://docs.pingcap.com/zh/tidb/stable/tiproxy-deployment-topology.md): 了解在部署最小拓扑集群的基础上，部署 TiProxy 的拓扑结构。
+- [TiProxy 配置文件](https://docs.pingcap.com/zh/tidb/stable/tiproxy-configuration.md): 了解与 TiProxy 部署和使用相关的配置参数。
+- [TiSpark 用户指南](https://docs.pingcap.com/zh/tidb/stable/tispark-overview.md): 使用 TiSpark 一站式解决用户的 HTAP 需求。
+- [TiSpark 部署拓扑](https://docs.pingcap.com/zh/tidb/stable/tispark-deployment-topology.md): 介绍 TiUP 部署包含 TiSpark 组件的 TiDB 集群的拓扑结构。
+- [Titan 介绍](https://docs.pingcap.com/zh/tidb/stable/titan-overview.md): Titan 是基于 RocksDB 的高性能单机 key-value 存储引擎插件。它支持将 value 从 LSM-tree 中分离出来单独存储，以降低写放大。Titan 适合前台写入量较大的场景，但不适合范围查询或对范围查询性能敏感的情况。开启 Titan 需要考虑 value 大小、范围查询敏感性和磁盘空间。从 v7.6.0 开始，TiDB 对 Titan 性能进行了优化，并将其作为默认的存储引擎。Titan 的 GC 方式有传统 GC 和 Level Merge，而 `min-blob-size` 的大小会影响性能。
+- [Titan 配置](https://docs.pingcap.com/zh/tidb/stable/titan-configuration.md): Titan 配置介绍了如何开启、关闭 Titan、数据迁移原理、相关参数以及 Level Merge 功能。从 TiDB v7.6.0 开始，默认启用 Titan，支持宽表写入场景和 JSON。开启 Titan 方法包括使用 TiUP 部署集群、直接编辑 TiKV 配置文件、编辑 TiDB Operator 配置文件。数据迁移是逐步进行的，可以通过全量 Compaction 提高迁移速度。常用配置参数包括 `min-blob-size`、`blob-file-compression`、`blob-cache-size` 等。关闭 Titan 可通过设置 `blob-run-mode` 参数。Level Merge 是实验功能，可提升范围查询性能并降低 Titan GC 对前台写入性能的影响。
+- [tiup clean](https://docs.pingcap.com/zh/tidb/stable/tiup-command-clean.md): tiup clean 命令用于清除组件运行过程中产生的数据。可以使用 --all 选项清除所有运行记录。
+- [TiUP Cluster](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster.md): TiUP Cluster 是使用 Golang 编写的集群管理组件，可进行部署、启动、关闭、销毁、弹性扩缩容、升级 TiDB 集群、管理参数。支持的命令有 import、template、check、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、rename、clean、destroy、audit、replay、enable、disable、meta backup、meta restore、help。
+- [tiup cluster audit](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-audit.md): tiup cluster audit 命令用于查看集群执行的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息。输出包括指定的执行日志或包含 ID、时间和命令的表格。
+- [tiup cluster audit cleanup](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-audit-cleanup.md): tiup cluster audit cleanup 命令用于清理 tiup cluster 产生的执行日志。--retain-days 选项用于设置执行日志保留天数，默认值为 60 天。-h, --help 选项用于输出帮助信息。执行命令后会输出 "clean audit log successfully"。
+- [tiup cluster check](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-check.md): TiUP Cluster 提供了 `check` 子命令，用于检查集群的硬件和软件环境是否满足正常运行条件。检查包括操作系统版本、CPU 支持、系统时间、内核参数、磁盘挂载参数等。用户可以通过指定选项来启用 CPU 核心数、内存大小和磁盘性能测试的检查。检查结果将以表格形式输出，包括目标节点、检查项、检查结果和结果描述。
+- [tiup cluster clean](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-clean.md): tiup cluster clean 命令用于在测试环境中重置集群到刚部署的状态。它会停止集群并删除数据。警告：生产环境禁止使用。语法：tiup cluster clean <cluster-name>。选项包括 --all（清理数据和日志）、--data（开启数据清理）、--log（开启日志清理）、--ignore-node（指定不清理的节点）、--ignore-role（指定不清理的角色）、-h, --help（输出帮助信息）。输出为 tiup-cluster 的执行日志。
+- [tiup cluster deploy](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-deploy.md): tiup cluster deploy 命令用于部署全新集群。语法为 tiup cluster deploy <cluster-name> <version> <topology.yaml> [flags]。选项包括 -u, -i, -p, --ignore-config-check, --no-labels, --skip-create-user, -h。输出为部署日志。
+- [tiup cluster destroy](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-destroy.md): tiup cluster destroy 命令用于销毁集群，包括停止集群、删除服务的日志目录、部署目录和数据目录。选项包括 --force（忽略错误）、--retain-node-data（指定保留数据的节点）、--retain-role-data（指定保留数据的角色）、-h（输出帮助信息）。执行日志将作为输出。
+- [tiup cluster disable](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-disable.md): tiup cluster disable 命令用于关闭集群服务在机器重启后的自启动。使用该命令可以指定要关闭自启的集群、节点和角色。如果不指定节点和角色，则默认关闭所有节点和角色的自启动。输出为 tiup-cluster 的执行日志。
+- [tiup cluster display](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-display.md): tiup cluster display 命令用于查看集群中每个组件的运行状态。可以通过指定选项来展示特定信息，如节点的 CPU 和内存使用情况，节点的 uptime 信息等。输出包括集群名称、版本、SSH 客户端类型、Dashboard 地址以及节点的 ID、角色、主机 IP、端口号、操作系统和机器架构、服务状态、数据目录和部署目录。节点服务状态包括在线、离线、已缩容下线、下线中和未知。详细状态含义可参考相关文档。
+- [tiup cluster edit-config](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-edit-config.md): tiup cluster edit-config 命令用于调整部署集群后的配置。执行命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意不能增删机器，需执行 tiup cluster reload 命令来重新加载配置。语法为 tiup cluster edit-config <cluster-name>，选项包括 -h, --help。执行命令后正常情况下无输出，若修改了不能修改的字段则会报错并提示用户重新编辑。
+- [tiup cluster enable](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-enable.md): tiup cluster enable 命令用于设置集群服务在机器重启后的自启动。命令会执行 systemctl enable <service> 来开启服务的自启。可以指定节点和角色来开启自启，同时可以输出帮助信息。执行日志将由 tiup-cluster 记录。
+- [tiup cluster help](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-help.md): tiup-cluster 是一个命令行工具，提供丰富的帮助信息。用户可以通过 `help` 命令或 `--help` 参数获取帮助信息。`tiup cluster help <command>` 等同于 `tiup cluster <command> --help`。语法为 `tiup cluster help [command] [flags]`。使用 `-h` 或 `--help` 输出帮助信息，默认关闭。输出为 `[command]` 或 tiup-cluster 的帮助信息。
+- [tiup cluster import](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-import.md): TiUP Cluster 提供了 `import` 命令，用于将 TiDB Ansible 部署的集群过渡到使用 tiup-cluster 组件管理。导入过程的日志信息将会输出。暂不支持导入启用了 TLS 加密功能、纯 KV 集群、启用了 Kafka 的集群、启用了 Spark 的集群、启用了 TiDB Lightning/Importer 的集群、仍使用老版本 `push` 的方式收集监控指标、单独为机器的 `node_exporter` / `blackbox_exporter` 设置了非默认端口的集群。如果集群中有部分节点未部署监控，应当先补充对应节点的信息，并将补充的监控组件部署完整。
+- [tiup cluster list](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-list.md): tiup-cluster 支持使用同一个中控机部署多套集群。命令 `tiup cluster list` 可以查看当前登录的用户使用该中控机部署了哪些集群。输出包含 Name、User、Version、Path、PrivateKey 字段的表格。注意：部署的集群数据默认放在 `~/.tiup/storage/cluster/clusters/` 目录下，当前登录用户无法查看其他用户部署的集群。
+- [tiup cluster meta backup](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-meta-backup.md): TiUP meta 文件丢失会导致无法管理集群。使用“tiup cluster meta backup”命令定期备份文件。命令语法为“tiup cluster meta backup <cluster-name>”。选项包括指定备份文件存储目录和帮助信息。输出为 tiup-cluster 的执行日志。
+- [tiup cluster meta restore](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-meta-restore.md): TiUP cluster meta restore 命令用于从备份文件中恢复 TiUP meta 文件。语法为 tiup cluster meta restore <cluster-name> <backup-file>。选项包括 -h, --help，用于输出帮助信息。恢复操作会覆盖当前的 meta 文件，建议仅在 meta 文件丢失的情况下进行恢复。执行日志将作为输出。
+- [tiup cluster patch](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-patch.md): tiup cluster patch 命令用于在集群运行过程中动态替换某个服务的二进制文件。它会上传替换的二进制包到目标机器，并通过 API 下线节点，停止目标服务，解压替换二进制包，最后启动目标服务。在使用命令前需要准备二进制包，包括确定组件名、版本、操作系统和平台，下载组件包，创建临时打包目录，解压原二进制包，复制要替换的文件到临时目录，最后打包所有文件。命令还包括一些选项，如 --overwrite、--transfer-timeout、-N、-R、--offline 等。
+- [tiup cluster prune](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-prune.md): tiup cluster prune 命令用于在缩容集群时清理数据。对于某些组件，需要等数据调度完成后，用户手动执行该命令。选项包括 -h 或 --help，用于输出帮助信息。清理过程会生成日志。
+- [tiup cluster reload](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-reload.md): tiup cluster reload 命令用于在修改集群配置后重新加载配置，使其生效。命令会将配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。可选参数包括 --force（忽略错误强制 reload）、--transfer-timeout（设置最长等待时间）、--ignore-config-check（跳过配置检查）、-N, --node（指定要重启的节点）、-R, --role（指定要重启的角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。执行日志会输出到 tiup-cluster。
+- [tiup cluster rename](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-rename.md): tiup cluster rename 命令用于更改部署集群后的集群名。如果要更改集群名，可以使用 tiup cluster rename <old-cluster-name> <new-cluster-name> 命令。注意：如果配置了 grafana_servers 的 dashboard_dir 字段，需要更新本地 dashboards 目录中的 *.json 文件的 datasource 字段的值，并执行 tiup cluster reload -R grafana 命令。执行日志将输出到 tiup-cluster。
+- [tiup cluster replay](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-replay.md): tiup cluster replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用 `tiup cluster audit` 查看历史命令及其 audit-id。执行命令：tiup cluster replay <audit-id>。选项：-h, --help。输出为对应命令的输出。
+- [tiup cluster restart](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-restart.md): tiup cluster restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup cluster restart <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
+- [tiup cluster scale-in](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-scale-in.md): tiup cluster scale-in 命令用于集群缩容，包括下线 TiKV 和 TiFlash 组件，以及其他组件。特殊处理包括通过 API 执行移除操作，并清理相关数据文件。命令语法为 tiup cluster scale-in <cluster-name>，必须指定要缩容的节点。其他选项包括 --force 用于强制移除宕机节点，--transfer-timeout 设置最长等待时间，-h 输出帮助信息。输出为缩容日志。
+- [tiup cluster scale-out](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-scale-out.md): tiup cluster scale-out 命令用于集群扩容，内部逻辑与部署类似。PD 节点的扩容通过 join 方式加入集群，并更新相关服务配置；其他服务直接启动加入集群。命令语法为 tiup cluster scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user, -i, --identity_file, -p, --password, --no-labels, --skip-create-user, -h, --help。输出为扩容日志。
+- [tiup cluster start](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-start.md): tiup cluster start 命令用于启动指定集群的所有或部分服务。语法为 tiup cluster start <cluster-name> [flags]。选项包括 --init（以安全方式启动集群）、-N, --node（指定要启动的节点）、-R, --role（指定要启动的角色）、-h, --help。输出为启动日志。
+- [tiup cluster stop](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-stop.md): tiup cluster stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup cluster stop <cluster-name>。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
+- [tiup cluster template](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-template.md): TiUP 内置了拓扑文件的模版，用户可以通过修改该模版来生成最终的拓扑文件。使用 tiup cluster template 命令可以输出 TiUP 内置的模版内容。该命令有多个选项，包括输出详细的拓扑模版、输出本地集群的简单拓扑模版以及输出多数据中心的拓扑模版。根据指定选项输出拓扑模版，可重定向到拓扑文件中用于部署。
+- [tiup cluster upgrade](https://docs.pingcap.com/zh/tidb/stable/tiup-component-cluster-upgrade.md): tiup cluster upgrade 命令用于将指定集群升级到特定版本。命令语法为 tiup cluster upgrade <cluster-name> <version> [flags]。可使用 --force 选项忽略升级过程的错误，强制替换二进制文件并启动集群。还可通过设置 --transfer-timeout 设置最长等待时间，超时后会跳过等待直接升级服务。其他选项包括 --ignore-config-check、--ignore-version-check、--offline 等。升级服务的日志将会输出。
+- [tiup completion](https://docs.pingcap.com/zh/tidb/stable/tiup-command-completion.md): TiUP 提供了 `tiup completion` 命令，用于生成命令行自动补全的配置文件。目前支持 `bash` 和 `zsh` 两种 shell 的命令补全。安装方式包括在 macOS 上执行 `brew install bash-completion` 或 `brew install bash-completion@2`，在 Linux 上执行 `yum install bash-completion` 或 `apt install bash-completion`。使用方式包括在 `.bash_profile` 中执行 `source` 命令，并在 zsh 中执行 `tiup completion zsh > "${fpath[1]}/_tiup"`。
+- [TiUP DM](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm.md): TiUP DM 是用于对 DM 集群进行日常运维工作的管理工具，包括部署、启动、关闭、销毁、弹性扩缩容、升级、参数管理等操作。命令包括 import、template、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、destroy、audit、replay、enable、disable、help。
+- [tiup dm audit](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-audit.md): tiup dm audit 命令用于查看所有集群上的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息，默认关闭。输出包括指定的 audit-id 对应的执行日志或包含 ID、时间和命令字段的表格。
+- [tiup dm deploy](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-deploy.md): tiup dm deploy 命令用于部署全新的集群。语法为 tiup dm deploy <cluster-name> <version> <topology.yaml> [flags]，其中 cluster-name 表示新集群的名字，version 为要部署的 DM 集群版本号，topology.yaml 为事先编写好的拓扑文件。选项包括 -u, -i, -p, -h，分别用于指定连接目标机器的用户名、密钥文件、密码登录和输出帮助信息。输出为部署日志。
+- [tiup dm destroy](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-destroy.md): tiup dm destroy 命令用于销毁集群，包括停止集群、删除日志目录、部署目录和数据目录。语法为 tiup dm destroy <cluster-name>。选项 -h, --help 用于输出帮助信息。输出为 tiup-dm 的执行日志。
+- [tiup dm disable](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-disable.md): tiup dm disable 命令用于关闭集群服务重启后的自启动。语法为 tiup dm disable <cluster-name>，其中 <cluster-name> 为要关闭自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要关闭自启的节点和角色。若不指定选项，默认关闭所有节点和角色的自启。执行该命令将输出 tiup-dm 的执行日志。
+- [tiup dm display](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-display.md): tiup-dm 提供了 `tiup dm display` 命令来高效查看集群中每个组件的运行状态。命令语法为 `tiup dm display <cluster-name>`，可指定要查询的节点和角色。输出包括集群名称、版本、SSH 客户端类型，以及节点 ID、角色、IP、端口号、操作系统、状态、数据目录和部署目录等信息。
+- [tiup dm edit-config](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-edit-config.md): tiup dm edit-config 命令用于调整部署集群服务的配置。使用命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意：修改配置时不能增删机器，需执行 tiup dm reload 命令来重新加载配置。语法：tiup dm edit-config <cluster-name>。选项：-h, --help 输出帮助信息。输出：正常情况无输出，若修改了不能修改的字段，则保存文件时报错并提示用户重新编辑。
+- [tiup dm enable](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-enable.md): tiup dm enable 命令用于设置集群服务在机器重启后的自启动。命令语法为 tiup dm enable <cluster-name>，其中 cluster-name 为要启用自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要开启自启的节点和角色。若不指定选项，默认开启所有节点和角色的自启。执行日志将作为输出。
+- [tiup dm help](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-help.md): tiup-dm 提供丰富的命令行界面帮助信息，可通过 `help` 命令或 `--help` 参数获取。`tiup dm help <command>` 等同于 `tiup dm <command> --help`。语法：`tiup dm help [command] [flags]`。`[command]` 用于指定要查看的命令帮助信息，若不指定，则查看 tiup-dm 自身的帮助信息。使用 `-h, --help` 输出帮助信息，数据类型为 `BOOLEAN`，默认关闭。输出为 `[command]` 或 tiup-dm 的帮助信息。
+- [tiup dm import](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-import.md): TiUP DM 提供了 `import` 命令，用于将 DM v1.0 集群导入到全新的 v2.0 集群。在导入前，请先停止原集群，并确认升级 TiUP DM 组件到最新版本。导入过程中会生成日志信息，不支持导入 v1.0 集群中的 DM Portal 组件。对于需要升级到 v2.0 的数据迁移任务，请不要执行 `stop-task`。具体语法和选项可以使用 `tiup dm import [flags]` 命令查看。
+- [tiup dm list](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-list.md): tiup-dm 支持使用同一个中控机部署多套集群。命令 `tiup dm list` 可以查看当前登录的用户使用该中控机部署了哪些集群。部署的集群数据默认放在 `~/.tiup/storage/dm/clusters/` 目录下。在同一台中控机上，当前登录用户无法查看其他用户部署的集群。该命令输出含有集群名字、部署用户、集群版本、集群部署数据在中控机上的路径、连接集群的私钥所在路径的表格。
+- [tiup dm prune](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-prune.md): tiup dm prune 命令用于在缩容集群后清理 etcd 中的少量元信息。通常情况下不会有问题，但如果需要清理，可以手动执行该命令。语法为 tiup dm prune <cluster-name>，选项包括 -h, --help，输出为清理过程的日志。
+- [tiup dm reload](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-reload.md): tiup dm reload 命令用于在修改集群配置后重新加载配置。该命令将中控机的配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。语法为 tiup dm reload <cluster-name>。选项包括 -N, --node（重启节点）、-R, --role（重启角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。输出为 tiup-dm 的执行日志。
+- [tiup dm replay](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-replay.md): tiup dm replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用命令时需指定要重试的命令对应的 audit-id，可通过 tiup dm audit 查看历史命令及其 audit-id。命令输出为对应命令的输出。
+- [tiup dm restart](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-restart.md): tiup dm restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup dm restart <cluster-name> [flags]，其中 <cluster-name> 为要操作的集群名字。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
+- [tiup dm scale-in](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-scale-in.md): tiup dm scale-in 命令用于集群缩容，即下线服务并移除指定节点和相关文件。语法为 tiup dm scale-in <cluster-name>，其中 <cluster-name> 为集群名。选项包括 -N, --node（必须非空，选择要缩容的节点），--force（强制移除宕机节点），-h, --help（输出帮助信息）。输出为缩容日志。
+- [tiup dm scale-out](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-scale-out.md): tiup dm scale-out 命令用于集群扩容，内部逻辑与部署类似。首先建立新节点的 SSH 连接，在目标节点上创建必要的目录，然后执行部署并启动服务。命令语法为 tiup dm scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user（string，默认为当前执行命令的用户），-i, --identity_file（string，默认 ~/.ssh/id_rsa），-p, --password，-h, --help。输出为扩容日志。
+- [tiup dm start](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-start.md): tiup dm start 命令用于启动指定集群的所有或部分服务。命令语法为 tiup dm start <cluster-name>。选项包括 -N, --node（指定要启动的节点），-R, --role（指定要启动的角色），-h, --help（输出帮助信息）。输出为启动日志。
+- [tiup dm stop](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-stop.md): tiup dm stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup dm stop <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
+- [tiup dm template](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-template.md): tiup dm template 命令用于输出 TiUP 内置的集群拓扑模版内容。可以通过修改模版来生成最终的拓扑文件。可选的 --full 选项输出详细的拓扑模版，带上可配置的参数。输出拓扑模版到标准输出，可重定向到拓扑文件中用于部署。
+- [tiup dm upgrade](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-upgrade.md): tiup dm upgrade 命令用于将指定集群升级到特定版本。语法为 tiup dm upgrade <cluster-name> <version> [flags]。cluster-name 为要操作的集群名字，version 为要升级到的目标版本。选项 --offline 声明当前集群处于离线状态，-h, --help 输出帮助信息。升级服务的日志可查看。
+- [tiup env](https://docs.pingcap.com/zh/tidb/stable/tiup-command-env.md): TiUP 提供灵活的定制化接口，使用环境变量实现。命令 `tiup env` 用于查询 TiUP 支持的用户自定义环境变量及其值。若未指定环境变量，则输出"{key}"="{value}"列表。若指定了环境变量，则按顺序输出"{value}"列表。若值为空，则代表未设置环境变量的值，TiUP 会使用默认值。
+- [TiUP FAQ](https://docs.pingcap.com/zh/tidb/stable/tiup-faq.md): TiUP 支持自定义镜像源，可以使用环境变量 TIUP_MIRRORS 指定镜像源地址。开发者可以通过 tiup-publish 组件将自己编写的组件发布到 TiUP 的官方镜像仓库。TiUP Playground 用于快速搭建开发环境，而 TiUP Cluster 用于部署生产环境集群。拓扑文件样例包括两地三中心、最小部署和完整拓扑文件。同一主机可以部署多个实例，但需要配置不同的端口和目录信息。集群部署期间可能出现 ssh 连接错误，可尝试加大 ssh 默认连接数并重启 sshd 服务解决。
+- [tiup help](https://docs.pingcap.com/zh/tidb/stable/tiup-command-help.md): TiUP 命令行界面提供丰富的帮助信息，用户可通过 `help` 命令或 `--help` 参数查看。`tiup help <command>` 等同于 `tiup <command> --help`。语法为 `tiup help [command]`，若不指定命令，则查看 TiUP 自身的帮助信息。选项为无，输出为 `[command]` 或 TiUP 的帮助信息。
+- [tiup install](https://docs.pingcap.com/zh/tidb/stable/tiup-command-install.md): tiup install 命令用于从镜像仓库下载指定版本的组件包，并在本地解压。当需要运行不存在于镜像仓库中的组件时，会尝试下载并自动运行，若不存在会报错。语法为 tiup install <component1>[version] [component2...N] [flags]。输出包括组件的下载信息，若组件不存在则报错"The component "%s" not found"，若版本不存在则报错"version %s not supported by component %s"。
+- [tiup list](https://docs.pingcap.com/zh/tidb/stable/tiup-command-list.md): tiup list 命令用于查询镜像中可用的组件列表。可选的组件名称。若指定，则列出该组件的所有版本；若不指定，则列出所有组件列表。--all 显示所有组件。默认只显示非隐藏组件。--installed 只显示已经安装的组件或版本。--verbose 在组件列表中显示已安装的版本列表。若未指定组件名，输出组件名、组件管理员、组件描述构成的组件信息列表。若指定组件名，输出版本、是否已安装、发布时间、支持的平台构成的版本信息列表。
+- [tiup mirror](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror.md): TiUP 中的镜像是一个重要概念，支持本地镜像和远程镜像。命令 `tiup mirror` 用于管理镜像，包括创建、发布、密钥管理等功能。语法为 `tiup mirror <command> [flags]`，支持的子命令包括 genkey、sign、init、set、grant、publish、modify、rotate、clone、merge。详细信息请参考 TiUP 命令清单。
+- [tiup mirror clone](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-clone.md): tiup mirror clone 命令用于克隆已存在的镜像或部分组件生成新镜像。新旧镜像的组件相同，但使用的签名密钥不同。命令语法为 tiup mirror clone <target-dir> [global version] [flags]。选项包括 -f, --full, -a, --arch, -o, --os, --prefix, --{component}。
+- [tiup mirror genkey](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-genkey.md): TiUP 镜像命令 genkey 用于生成私钥。管理员有 root.json、index.json、snapshot.json 和 timestamp.json 的修改权限。组件管理员有相关组件的修改权限。普通用户可以下载并使用组件。私钥名默认为 private，可以显示对应的公钥。可以将公钥信息储存为文件。输出包括私钥已存在或已写入，以及公钥内容。
+- [tiup mirror grant](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-grant.md): tiup mirror grant 命令用于向当前镜像中添加组件管理员。组件管理员可以发布新组件或修改之前发布的组件。添加管理员时，需将公钥发送给镜像管理员。命令仅支持本地镜像使用。语法：tiup mirror grant <id>。选项：-k, --key（指定管理员密钥）、-n, --name（指定管理员名字）。输出：执行成功无输出，管理员 ID 重复报错，密钥被其他管理员使用报错。
+- [tiup mirror init](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-init.md): tiup mirror init 命令用于初始化一个空的镜像。初始化的镜像不包含任何组件和组件管理员，仅生成一些文件。语法为 tiup mirror init <path> [flags]，其中 <path> 为本地目录路径，可以为相对路径。选项包括 -k, --key-dir（string，默认 {path}/keys）。输出包括若成功则无输出，若 <path> 不为空则输出错误信息，若 <path> 不是目录则输出错误信息。
+- [tiup mirror merge](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-merge.md): tiup mirror merge 命令用于将一个或多个镜像合并到当前镜像。执行此命令需要目标镜像的管理员 ID 在当前镜像中存在，并且用户的 ${TIUP_HOME}/keys 目录中有对应的私钥。语法：tiup mirror merge <mirror-dir-1> [mirror-dir-N]。选项：无。输出：成功时无输出，否则会提示缺失管理员或私钥。
+- [tiup mirror modify](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-modify.md): tiup mirror modify 命令用于修改已发布的组件。只有合法的组件管理员才能修改组件，且只能修改自己发布的组件。命令语法为 tiup mirror modify <component>[version]。选项包括 -k, --key, --yank, --hide。成功时无输出，无权限时会有相应错误提示。
+- [tiup mirror publish](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-publish.md): tiup mirror publish 命令用于发布新组件或已有组件的新版本。只有有权限的组件管理员才可以发布组件。命令语法为 tiup mirror publish <comp-name> <version> <tarball> <entry> [flags]。其中各参数含义为组件名、版本号、tarball 包路径、组件可执行文件位置。命令还包含选项 -k, --key, --arch, --os, --desc, --hide。成功时无输出，无权限时会有相应错误提示。
+- [tiup mirror rotate](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-rotate.md): TiUP 的镜像中有一个重要文件 root.json，记录了系统需要使用的公钥和信任链基础。包含管理员签名、用于验证的公钥和过期时间。更新 root.json 需要管理员重新签名，使用命令 `tiup mirror rotate` 自动化更新流程。需要确保 TiUP 客户端升级到 v1.5.0 或以上版本。命令启动编辑器修改内容，等待管理员签名。选项包括临时服务器监听地址。输出为各个镜像管理员当前的签名状态。
+- [tiup mirror set](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-set.md): tiup mirror set 命令用于切换当前镜像，支持本地文件系统和远程网络两种镜像。命令语法为 tiup mirror set <mirror-addr> [flags]，其中 <mirror-addr> 为镜像地址，可以是网络地址或本地文件路径。选项 -r, --root 用于指定根证书。输出为无。
+- [tiup mirror sign](https://docs.pingcap.com/zh/tidb/stable/tiup-command-mirror-sign.md): tiup mirror sign 命令用于对镜像中定义的元信息文件进行签名。语法为 tiup mirror sign <manifest-file>。选项包括 -k, --key 和 --timeout。输出包括成功、文件已被指定的 key 签名过和文件不是合法的 manifest。
+- [tiup status](https://docs.pingcap.com/zh/tidb/stable/tiup-command-status.md): tiup status 命令用于查看组件的运行信息，包括组件名称、进程 ID、运行状态、启动时间、数据目录、二进制文件路径和启动参数。组件可能处于在线、离线、无法访问、已缩容下线、下线中或未知状态。这些状态来自于 PD 的调度信息。
+- [tiup telemetry](https://docs.pingcap.com/zh/tidb/stable/tiup-command-telemetry.md): TiUP 遥测功能在 v1.11.3 及以上版本默认关闭，以下版本默认开启。开启后会分享使用情况信息给 PingCAP，包括遥测标示符、命令执行情况、部署情况等。不会分享集群准确名字、拓扑结构、配置文件。使用命令 `tiup telemetry` 控制遥测，支持 status、reset、enable、disable 命令。
+- [tiup uninstall](https://docs.pingcap.com/zh/tidb/stable/tiup-command-uninstall.md): tiup uninstall 命令用于卸载已安装的组件。语法为 tiup uninstall <component1> <version> [component2...N] [flags]。选项包括 --all 用于卸载指定组件的全部已安装版本，--self 用于卸载 TiUP 自身。正常退出时会显示"Uninstalled component "%s" successfully!"，若未指定 <version> 也未指定 --all 则会报错"Use "tiup uninstall tidbx --all" if you want to remove all versions."。
+- [tiup update](https://docs.pingcap.com/zh/tidb/stable/tiup-command-update.md): tiup update 命令用于升级已安装的组件或自身。语法为 tiup update [组件名] [版本]，可指定多个组件或版本。选项包括 --all（升级所有组件）、--force（强制升级已安装版本）、--nightly（升级到 nightly 版本）、--self（升级 TiUP 自身）。
+- [TiUP 命令概览](https://docs.pingcap.com/zh/tidb/stable/tiup-reference.md): TiUP 是 TiDB 生态的包管理器，管理着诸如 TiDB、PD、TiKV 等组件。它支持执行命令和运行组件，可以通过 `--help` 获取命令信息。选项包括打印二进制文件路径、指定组件路径、指定组件 tag、打印版本和帮助信息。TiUP 包含众多命令和子命令，以及组件清单。
+- [TiUP 常见运维操作](https://docs.pingcap.com/zh/tidb/stable/maintain-tidb-using-tiup.md): TiUP 是用于管理 TiDB 集群的工具，可以进行查看集群列表、启动、关闭、修改配置参数、查看状态等常见运维操作。操作简单方便，适合用于 TiDB 集群的管理。
+- [TiUP 故障排查](https://docs.pingcap.com/zh/tidb/stable/tiup-troubleshooting-guide.md): TiUP 故障排查包括命令故障排查和集群组件故障排查。命令故障包括强制刷新组件列表和版本信息，网络中断导致的下载问题，以及 checksum 错误。集群组件故障包括 SSH 私钥问题，升级中断和缺失组件文件的解决方法。可通过 Github Issues 或 AskTUG 求助。
+- [TiUP 文档地图](https://docs.pingcap.com/zh/tidb/stable/tiup-documentation-guide.md): TiUP 文档地图包括使用文档和资源两部分。使用文档包括 TiUP 概览、TiUP 术语、TiUP 组件管理、TiUP FAQ、TiUP 故障排查和 TiUP 参考手册。资源包括 TiUP 版本发布说明、AskTUG TiUP 主题和 TiUP Issues。
+- [TiUP 术语及核心概念](https://docs.pingcap.com/zh/tidb/stable/tiup-terminology-and-concepts.md): TiUP 是一个用于下载、更新、卸载组件的程序，通过各种组件来扩展其功能。组件是可以运行的程序或脚本，通过 tiup <component> 命令来运行。TiUP 组件可以从镜像仓库下载，用户可以通过设置 TIUP_MIRRORS 环境变量来自定义镜像仓库。
+- [TiUP 简介](https://docs.pingcap.com/zh/tidb/stable/tiup-overview.md): TiUP 是 TiDB 生态中的包管理工具，简化了软件的安装和升级维护工作。安装 TiUP 十分简洁，只需执行一行命令即可完成。TiUP 的愿景是降低 TiDB 生态中所有工具的使用门槛，通过命令和组件来实现包管理和操作。
+- [TiUP 镜像参考指南](https://docs.pingcap.com/zh/tidb/stable/tiup-mirror-reference.md): TiUP 镜像是存放 TiUP 组件和元信息的仓库。镜像存在两种形式：本地镜像和远程镜像。镜像可通过命令创建和更新。镜像目录结构包括根证书、索引、组件、快照和时间戳。客户端通过逻辑保证下载文件安全。
+- [TopN 和 Limit 下推](https://docs.pingcap.com/zh/tidb/stable/topn-limit-push-down.md): TiDB 中的 LIMIT 子句对应 Limit 算子节点，ORDER BY 子句对应 Sort 算子节点。相邻的 Limit 和 Sort 算子组合成 TopN 算子节点，表示按排序规则提取记录的前 N 项。TopN 下推将尽可能下推到数据源附近，减少数据传输或计算的开销。可参考 [优化规则及表达式下推的黑名单](/blocklist-control-plan.md) 中的关闭方法。TopN 可下推到存储层 Coprocessor，减少计算开销。TopN 无法下推过 Join，排序规则仅依赖于外表列时可下推。TopN 也可转换成 Limit，简化排序操作。
+- [TRACE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-trace.md): TiDB 数据库中 TRACE 的使用概况。
+- [TRUNCATE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-truncate.md): TiDB 数据库中 TRUNCATE 的使用概况。
+- [TSO 配置参数](https://docs.pingcap.com/zh/tidb/stable/command-line-flags-for-tso-configuration.md): TSO 配置参数可以通过命令行参数或环境变量配置。
+- [TSO 配置文件描述](https://docs.pingcap.com/zh/tidb/stable/tso-configuration-file.md): TSO 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
+- [UNLOCK STATS](https://docs.pingcap.com/zh/tidb/stable/sql-statement-unlock-stats.md): TiDB 数据库中 UNLOCK STATS 的使用概况。
+- [UPDATE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-update.md): TiDB 数据库中 UPDATE 的使用概况。
 - [Upgrade A Tidb Cluster](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster
-- [USE](https://docs.pingcap.com/tidb/stable/sql-statement-use.md): TiDB 数据库中 USE 的使用概况。
-- [USER_ATTRIBUTES](https://docs.pingcap.com/tidb/stable/information-schema-user-attributes.md): 了解 INFORMATION_SCHEMA 表 `USER_ATTRIBUTES`。
-- [USER_PRIVILEGES](https://docs.pingcap.com/tidb/stable/information-schema-user-privileges.md): 了解 INFORMATION_SCHEMA 表 `USER_PRIVILEGES`。
-- [UUID 最佳实践](https://docs.pingcap.com/tidb/stable/uuid.md): 了解在 TiDB 中使用 UUID 的最佳实践和策略。
-- [VARIABLES_INFO](https://docs.pingcap.com/tidb/stable/information-schema-variables-info.md): 了解 information_schema 表 `VARIABLES_INFO`。
-- [VIEWS](https://docs.pingcap.com/tidb/stable/information-schema-views.md): 了解 INFORMATION_SCHEMA 表 `VIEWS`。
-- [What's New in TiDB 5.0](https://docs.pingcap.com/tidb/stable/release-5.0.0.md): TiDB 5.0 版本新增了许多功能和优化，包括 MPP 架构、聚簇索引、异步提交事务、Raft Joint Consensus 算法等。此外，还优化了系统变量、配置文件参数、性能、稳定性和数据迁移功能。TiUP 工具也进行了多项优化，包括部署操作逻辑、升级稳定性、升级时长和运维功能。遥测方面新增了集群使用指标的收集。
-- [WITH](https://docs.pingcap.com/tidb/stable/sql-statement-with.md): TiDB 数据库中 WITH (公共表表达式) 的使用概况。
+- [USE](https://docs.pingcap.com/zh/tidb/stable/sql-statement-use.md): TiDB 数据库中 USE 的使用概况。
+- [USER_ATTRIBUTES](https://docs.pingcap.com/zh/tidb/stable/information-schema-user-attributes.md): 了解 INFORMATION_SCHEMA 表 `USER_ATTRIBUTES`。
+- [USER_PRIVILEGES](https://docs.pingcap.com/zh/tidb/stable/information-schema-user-privileges.md): 了解 INFORMATION_SCHEMA 表 `USER_PRIVILEGES`。
+- [UUID 最佳实践](https://docs.pingcap.com/zh/tidb/stable/uuid.md): 了解在 TiDB 中使用 UUID 的最佳实践和策略。
+- [VARIABLES_INFO](https://docs.pingcap.com/zh/tidb/stable/information-schema-variables-info.md): 了解 information_schema 表 `VARIABLES_INFO`。
+- [VIEWS](https://docs.pingcap.com/zh/tidb/stable/information-schema-views.md): 了解 INFORMATION_SCHEMA 表 `VIEWS`。
+- [What's New in TiDB 5.0](https://docs.pingcap.com/zh/tidb/stable/release-5.0.0.md): TiDB 5.0 版本新增了许多功能和优化，包括 MPP 架构、聚簇索引、异步提交事务、Raft Joint Consensus 算法等。此外，还优化了系统变量、配置文件参数、性能、稳定性和数据迁移功能。TiUP 工具也进行了多项优化，包括部署操作逻辑、升级稳定性、升级时长和运维功能。遥测方面新增了集群使用指标的收集。
+- [WITH](https://docs.pingcap.com/zh/tidb/stable/sql-statement-with.md): TiDB 数据库中 WITH (公共表表达式) 的使用概况。
 - [Zh](https://docs.pingcap.com/zh): External documentation: https://docs.pingcap.com/zh
-- [三节点混合部署最佳实践](https://docs.pingcap.com/tidb/stable/three-nodes-hybrid-deployment.md): 了解三节点混合部署最佳实践。
-- [上游使用 pt-osc/gh-ost 工具的持续同步场景](https://docs.pingcap.com/tidb/stable/migrate-with-pt-ghost.md): 介绍在使用 DM 持续增量数据同步，上游使用 pt-osc/gh-ost 工具进行在线 DDL 变更时 DM 的处理方式和注意事项。
-- [下推到 TiKV 的表达式列表](https://docs.pingcap.com/tidb/stable/expressions-pushed-down.md): TiDB 中下推到 TiKV 的表达式列表及相关设置。
-- [下推计算结果缓存](https://docs.pingcap.com/tidb/stable/coprocessor-cache.md): TiDB 4.0 支持下推计算结果缓存，配置位于 `tikv-client.copr-cache`，缓存仅存储在 TiDB 内存中，不共享缓存，对 Region 写入会导致缓存失效。缓存命中率可通过 `EXPLAIN ANALYZE` 或 Grafana 监控面板查看。
-- [下游存在更多列的迁移场景](https://docs.pingcap.com/tidb/stable/migrate-with-more-columns-downstream.md): 介绍下游存在更多列的迁移场景。
-- [不同库名或表名的数据校验](https://docs.pingcap.com/tidb/stable/route-diff.md): TiDB DM 等同步工具可以使用 route-rules 设置数据同步到下游指定表中。sync-diff-inspector 通过设置 rules 提供了校验不同库名、表名的表的功能。可以通过 rules 设置映射关系来简化配置，校验大量的不同库名或者表名的表。表路由的初始化和示例包括规则中存在 target-schema/target-table 表名为 schema.table 的行为，规则中只存在 target-schema 的行为，以及规则中不存在 target-schema.target-table 的行为。
-- [与 Apache Kafka 和 Apache Flink 进行数据集成](https://docs.pingcap.com/tidb/stable/replicate-data-to-kafka.md): 了解如何使用 TiCDC 从 TiDB 同步数据至 Apache Kafka 和 Apache Flink。
-- [与 Confluent Cloud 和 Snowflake 进行数据集成](https://docs.pingcap.com/tidb/stable/integrate-confluent-using-ticdc.md): 了解如何使用 TiCDC 从 TiDB 同步数据至 Confluent Cloud 以及 Snowflake、ksqlDB、SQL Server。
-- [与 MySQL 兼容性对比](https://docs.pingcap.com/tidb/stable/mysql-compatibility.md): 本文对 TiDB 和 MySQL 二者之间从语法和功能特性上做出详细的对比。
-- [与 MySQL 安全特性差异](https://docs.pingcap.com/tidb/stable/security-compatibility-with-mysql.md): TiDB 支持与 MySQL 5.7 类似的安全特性，同时也支持 MySQL 8.0 的部分安全特性。然而，在实现上存在一些差异，包括不支持列级别权限设置和部分权限属性。此外，TiDB 的密码过期策略和密码复杂度策略与 MySQL 存在一些差异。另外，TiDB 支持多种身份验证方式，包括 TLS 证书和 JWT。
-- [临时表](https://docs.pingcap.com/tidb/stable/dev-guide-use-temporary-tables.md): 介绍 TiDB 临时表创建、删除、限制。
-- [临时表](https://docs.pingcap.com/tidb/stable/temporary-tables.md): 了解 TiDB 中的临时表功能，使用临时表存储业务中间数据，减少表管理开销，并提升性能。
-- [为 DM 的连接开启加密传输](https://docs.pingcap.com/tidb/stable/dm-enable-tls.md): 了解如何为 DM 的连接开启加密传输。
-- [为 TiDB 客户端服务端间通信开启加密传输](https://docs.pingcap.com/tidb/stable/enable-tls-between-clients-and-servers.md): TiDB 服务端与客户端间默认采用非加密连接，容易造成信息泄露。建议使用加密连接确保安全性。要开启 TLS 加密传输，需要在服务端配置开启 TLS 支持，并在客户端应用程序中配置使用 TLS 加密连接。可以通过配置系统变量或在创建 / 修改用户时指定要求加密连接。可通过命令检查当前连接是否是加密连接。TLS 版本为 TLSv1.2 和 TLSv1.3，支持的加密算法包括 AES 和 CHACHA20_POLY1305。
-- [为 TiDB 组件间通信开启加密传输](https://docs.pingcap.com/tidb/stable/enable-tls-between-components.md): 了解如何为 TiDB 集群内各组件间开启加密传输。
-- [为 TiDB 落盘文件开启加密](https://docs.pingcap.com/tidb/stable/enable-disk-spill-encrypt.md): 了解如何为 TiDB 落盘文件开启加密。
-- [主从集群一致性读和数据校验](https://docs.pingcap.com/tidb/stable/ticdc-upstream-downstream-check.md): TiCDC 提供了 Syncpoint 功能，通过利用 TiDB 的 snapshot 特性，在同步过程中维护了一个上下游具有一致性 snapshot 的 `ts-map`。启用 Syncpoint 功能后，可以进行一致性快照读和数据一致性校验。要开启 Syncpoint 功能，只需在创建同步任务时把 TiCDC 的配置项 `enable-sync-point` 设置为 `true`。通过配置 `snapshot` 可以对 TiDB 主从集群的数据进行校验。
-- [乐观事务和悲观事务](https://docs.pingcap.com/tidb/stable/dev-guide-optimistic-and-pessimistic-transaction.md): 介绍 TiDB 中的乐观事务和悲观事务，乐观事务的重试等。
-- [乐观事务模型下写写冲突问题排查](https://docs.pingcap.com/tidb/stable/troubleshoot-write-conflicts.md): 介绍 TiDB 中乐观锁下写写冲突出现的原因以及解决方案。
-- [乐观模式下分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge-optimistic.md): 介绍 DM 提供的乐观模式下分库分表的合并迁移功能。
-- [事务概览](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-overview.md): 简单介绍 TiDB 中的事务。
-- [事务错误处理](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-troubleshoot.md): 介绍 TiDB 中的事务错误处理办法。
-- [事务限制](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-restraints.md): 介绍 TiDB 中的事务限制。
-- [从 Amazon Aurora 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-aurora-to-tidb.md): 介绍如何使用快照从 Amazon Aurora 迁移数据到 TiDB。
-- [从 CSV 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-csv-files-to-tidb.md): 介绍如何从 CSV 等文件迁移数据到 TiDB。
-- [从 MariaDB 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-mariadb.md): 介绍如何将数据从 MariaDB 文件迁移数据到 TiDB。
-- [从 Parquet 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-parquet-files-to-tidb.md): 介绍如何使用 TiDB Lightning 从 Parquet 文件迁移数据到 TiDB。
-- [从 SQL 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-sql-files-to-tidb.md): 介绍如何使用 TiDB Lightning 从 MySQL SQL 文件迁移数据到 TiDB。
-- [从 TiDB 集群迁移数据至兼容 MySQL 的数据库](https://docs.pingcap.com/tidb/stable/migrate-from-tidb-to-mysql.md): 了解如何将数据从 TiDB 集群迁移至与 MySQL 兼容的数据库。
-- [从 TiDB 集群迁移数据至另一 TiDB 集群](https://docs.pingcap.com/tidb/stable/migrate-from-tidb-to-tidb.md): 了解如何将数据从一个 TiDB 集群迁移至另一 TiDB 集群。
-- [从 Vitess 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-vitess.md): 介绍从 Vitess 迁移数据到 TiDB 所使用的工具。
-- [从大数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-large-mysql-to-tidb.md): 介绍如何从大数据量 MySQL 迁移数据到 TiDB。
-- [从大数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-large-mysql-shards-to-tidb.md): 使用 Dumpling 和 TiDB Lightning 合并导入分表数据到 TiDB，以及如何使用 DM 持续增量复制数据。本文介绍的方法适用于导入数据总量大于 1 TiB 的场景。
-- [从小数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-small-mysql-to-tidb.md): 介绍如何从小数据量 MySQL 迁移数据到 TiDB。
-- [从小数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-small-mysql-shards-to-tidb.md): 介绍如何从 TB 级以下分库分表 MySQL 迁移数据到 TiDB。
-- [从窗口函数中推导 TopN 或 Limit](https://docs.pingcap.com/tidb/stable/derive-topn-from-window.md): 介绍从窗口函数中推导 TopN 或 Limit 的优化规则，以及如何开启该规则。
-- [代价模型](https://docs.pingcap.com/tidb/stable/cost-model.md): 介绍 TiDB 进行物理优化时所使用的代价模型的原理。
-- [优化向量搜索性能](https://docs.pingcap.com/tidb/stable/vector-search-improve-performance.md): 了解优化 TiDB 向量搜索性能的最佳实践。
-- [优化规则与表达式下推的黑名单](https://docs.pingcap.com/tidb/stable/blocklist-control-plan.md): 了解优化规则与表达式下推的黑名单。
-- [位函数和操作符](https://docs.pingcap.com/tidb/stable/bit-functions-and-operators.md): TiDB 支持 MySQL 8.0 中的所有位函数和操作符。
-- [使用 AS OF TIMESTAMP 语法读取历史数据](https://docs.pingcap.com/tidb/stable/as-of-timestamp.md): 了解如何使用 AS OF TIMESTAMP 语法读取历史数据。
-- [使用 Django 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-django.md): 了解如何使用 Django 连接到 TiDB。本文提供了使用 Django 与 TiDB 交互的 Python 示例代码片段。
-- [使用 DM binary 部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-binary.md): 本文介绍了如何使用 DM binary 快速部署 DM 集群。首先需要下载 DM 安装包，然后在五台服务器上部署两个 DM-worker 实例和三个 DM-master 实例。对于 DM-master 的部署，可以使用命令行参数或配置文件两种方式。而对于 DM-worker 的部署，也可以使用命令行参数或配置文件两种方式。部署完成后，需要确保各组件间端口可正常连通。
-- [使用 DM 迁移数据](https://docs.pingcap.com/tidb/stable/migrate-data-using-dm.md): 本文介绍如何使用 DM 工具迁移数据。首先部署 DM 集群，然后检查集群信息和创建数据源。配置任务后，启动任务并查询任务状态。最后，停止任务并监控任务与查看日志。
-- [使用 dmctl 运维 TiDB Data Migration 集群](https://docs.pingcap.com/tidb/stable/dmctl-introduction.md): 了解如何使用 dmctl 运维 DM 集群。
-- [使用 Dumpling 和 TiDB Lightning 备份与恢复](https://docs.pingcap.com/tidb/stable/backup-and-restore-using-dumpling-lightning.md): 了解如何使用 Dumpling 和 TiDB Lightning 备份与恢复集群数据。
-- [使用 Dumpling 导出数据](https://docs.pingcap.com/tidb/stable/dumpling-overview.md): 使用 Dumpling 从 TiDB 导出数据。
-- [使用 EXPLAIN 解读执行计划](https://docs.pingcap.com/tidb/stable/explain-walkthrough.md): 通过示例了解如何使用 EXPLAIN 分析执行计划。
-- [使用 FastScan 功能](https://docs.pingcap.com/tidb/stable/use-fastscan.md): 介绍通过使用 FastScan 来加速 OLAP 场景的查询的方法。
-- [使用 Go-MySQL-Driver 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-golang-sql-driver.md): 了解如何使用 Go-MySQL-Driver 连接到 TiDB。本文提供了使用 Go-MySQL-Driver 与 TiDB 交互的 Golang 示例代码片段。
-- [使用 GORM 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-golang-gorm.md): 了解如何使用 GORM 连接到 TiDB。本文提供了使用 GORM 与 TiDB 交互的 Golang 示例代码片段。
-- [使用 Grafana 监控 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/grafana-monitor-best-practices.md): 了解高效利用 Grafana 监控 TiDB 的七个技巧。
-- [使用 Hibernate 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-hibernate.md): 了解如何使用 Hibernate 连接到 TiDB。本文提供了使用 Hibernate 与 TiDB 交互的 Java 示例代码片段。
-- [使用 JDBC 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-jdbc.md): 了解如何使用 JDBC 连接到 TiDB。本文提供了使用 JDBC 与 TiDB 交互的 Java 示例代码片段。
-- [使用 MPP 模式](https://docs.pingcap.com/tidb/stable/use-tiflash-mpp-mode.md): 了解如何使用 MPP 模式。
-- [使用 MyBatis 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-mybatis.md): 了解如何使用 MyBatis 连接到 TiDB。本文提供了使用 MyBatis 与 TiDB 交互的 Java 示例代码片段。
-- [使用 MySQL Connector/Python 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-mysql-connector.md): 了解如何使用 MySQL Connector/Python 连接到 TiDB。本文提供了使用 MySQL Connector/Python 与 TiDB 交互的 Python 示例代码片段。
-- [使用 MySQL Workbench 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-gui-mysql-workbench.md): 了解如何使用 MySQL Workbench 连接到 TiDB。
-- [使用 mysql.js 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-mysqljs.md): 本文描述了 TiDB 和 mysql.js 的连接步骤，并给出了简单示例代码片段。
-- [使用 mysql2 连接 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-ruby-mysql2.md): 本文描述了 TiDB 和 mysql2 的连接步骤，并给出了使用 mysql2 gem 连接 TiDB 的简单示例代码片段。
-- [使用 mysqlclient 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-mysqlclient.md): 了解如何使用 mysqlclient 连接到 TiDB。本文提供了使用 mysqlclient 与 TiDB 交互的 Python 示例代码片段。
-- [使用 Navicat 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-gui-navicat.md): 了解如何使用 Navicat 连接到 TiDB。
-- [使用 node-mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-mysql2.md): 本文描述了 TiDB 和 node-mysql2 的连接步骤，并给出了简单示例代码片段。
-- [使用 OpenAPI 运维 TiDB Data Migration 集群](https://docs.pingcap.com/tidb/stable/dm-open-api.md): 了解如何使用 OpenAPI 接口来管理 DM 集群状态和数据同步。
-- [使用 peewee 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-peewee.md): 了解如何使用 peewee 连接到 TiDB。本文提供了使用 peewee 与 TiDB 交互的 Python 示例代码片段。
-- [使用 PingCAP Clinic Diag 采集 SQL 查询计划信息](https://docs.pingcap.com/tidb/stable/clinic-collect-sql-query-plan.md): 了解如何使用 PingCAP Clinic Diag 采集 TiUP 部署集群的 SQL 查询计划信息。
-- [使用 PingCAP Clinic 生成诊断报告](https://docs.pingcap.com/tidb/stable/clinic-report.md): 介绍 PingCAP Clinic 诊断报告的使用场景、方法以及如何解读报告。
-- [使用 PingCAP Clinic 诊断集群](https://docs.pingcap.com/tidb/stable/clinic-user-guide-for-tiup.md): 详细介绍在使用 TiUP 部署的 TiDB 集群或 DM 集群上如何通过 PingCAP Clinic 诊断服务远程定位集群问题和本地快速检查集群状态。
-- [使用 PLAN REPLAYER 保存和恢复集群现场信息](https://docs.pingcap.com/tidb/stable/sql-plan-replayer.md): 了解如何使用 PLAN REPLAY 命令保存和恢复集群现场信息。
-- [使用 Prisma 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-prisma.md): 本文描述了 TiDB 和 Prisma 的连接步骤，并给出了简单示例代码片段。
-- [使用 PyMySQL 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-pymysql.md): 了解如何使用 PyMySQL 连接到 TiDB。本文提供了使用 PyMySQL 与 TiDB 交互的 Python 示例代码片段。
-- [使用 Python 开始向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-get-started-using-python.md): 了解如何使用 Python 和 TiDB 向量搜索快速开发可执行语义搜索的人工智能应用程序。
-- [使用 Rails 框架和 ActiveRecord ORM 连接 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-ruby-rails.md): 本文描述了 TiDB 和 Rails 框架的连接步骤，并给出了使用 Rails 框架和 ActiveRecord ORM 连接 TiDB 的简单示例代码片段。
-- [使用 Sequelize 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-sequelize.md): 本文描述了 TiDB 和 Sequelize 的连接步骤，并给出了简单示例代码片段。
-- [使用 Spring Boot 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-spring-boot.md): 了解如何使用 Spring Boot 连接到 TiDB。本文提供了使用 Spring Boot 与 TiDB 交互的 Java 示例代码片段。
-- [使用 SQL 开始向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-get-started-using-sql.md): 了解如何在 TiDB 中使用 SQL 语句快速开始向量搜索，从而为你的生成式 AI 应用提供支持。
-- [使用 SQLAlchemy 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-sqlalchemy.md): 了解如何使用 SQLAlchemy 连接到 TiDB。本文提供了使用 SQLAlchemy 与 TiDB 交互的 Python 示例代码片段。
-- [使用 TiDB Cloud Serverless 构建 TiDB 集群](https://docs.pingcap.com/tidb/stable/dev-guide-build-cluster-in-cloud.md): 使用 TiDB Cloud Serverless 构建 TiDB 集群，并连接 TiDB Cloud Serverless 集群。
-- [使用 TiDB Dashboard 诊断报告定位问题](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-usage.md): 本文介绍了使用 TiDB Dashboard 诊断报告定位问题的方法。通过对比两个时间段的监控项差异来帮助 DBA 定位问题。示例中展示了大查询/写入导致 QPS 抖动或延迟上升的诊断方法，以及如何用对比报告定位问题。对比报告可以帮助 DBA 更快速地定位问题，例如通过查看监控项的差异大小排序来发现异常。通过对比报告定位问题，可以更准确地诊断可能的慢查询和影响查询执行的负载。
-- [使用 TiDB Data Migration 处理出错的 DDL 语句](https://docs.pingcap.com/tidb/stable/handle-failed-ddl-statements.md): 了解在使用 TiDB Data Migration 迁移数据时，如何处理出错的 DDL 语句。
-- [使用 TiDB 的增删改查 SQL](https://docs.pingcap.com/tidb/stable/dev-guide-tidb-crud-sql.md): 简单介绍 TiDB 的增删改查 SQL。
-- [使用 TiDB 读取 TiFlash](https://docs.pingcap.com/tidb/stable/use-tidb-to-read-tiflash.md): 了解如何使用 TiDB 读取 TiFlash 副本。
-- [使用 TiSpark 读取 TiFlash](https://docs.pingcap.com/tidb/stable/use-tispark-to-read-tiflash.md): 了解如何使用 TiSpark 读取 TiFlash。
-- [使用 TiUP bench 组件压测 TiDB](https://docs.pingcap.com/tidb/stable/tiup-bench.md): TiUP bench 组件集成了多种压测 workloads，包括 TPC-C、TPC-H、CH-benCHmark、YCSB 和自定义 SQL 文件。每种压测都有对应的命令和参数，可以通过 TiUP 运行。TPC-C 测试包括准备数据、运行测试、检查一致性和清理数据等步骤。TPC-H 测试也有类似的步骤，包括准备数据、运行测试和清理数据。YCSB 测试可以分别针对 TiDB 和 TiKV 节点进行，包括准备数据和运行测试。此外，还可以通过 RawSQL 文件进行测试，包括准备数据和执行查询。
-- [使用 TiUP no-sudo 模式部署运维 TiDB 线上集群](https://docs.pingcap.com/tidb/stable/tiup-cluster-no-sudo-mode.md): 了解如何使用 TiUP no-sudo 模式部署运维 TiDB 线上集群。
-- [使用 TiUP 升级 TiDB](https://docs.pingcap.com/tidb/stable/upgrade-tidb-using-tiup.md): TiUP 可用于 TiDB 升级。升级过程中需注意不支持 TiFlash 组件从 5.3 之前的老版本在线升级至 5.3 及之后的版本，只能采用停机升级。在升级过程中，不要执行 DDL 语句，避免出现行为未定义的问题。升级前需查看集群中是否有正在进行的 DDL Job，并等待其完成或取消后再进行升级。升级完成后，可使用 TiUP 安装对应版本的 `ctl` 组件来更新相关工具版本。
-- [使用 TiUP 命令管理组件](https://docs.pingcap.com/tidb/stable/tiup-component-management.md): TiUP 是一个用于管理组件的命令行工具。它提供了一系列命令来查询组件列表、安装、升级、运行、查看状态、清理实例和卸载组件。此外，还可以使用实验性的 `link` 和 `unlink` 命令来将组件的二进制符号链接到可执行文件目录。
-- [使用 TiUP 扩容缩容 PD 微服务节点](https://docs.pingcap.com/tidb/stable/scale-microservices-using-tiup.md): 介绍如何使用 TiUP 扩容缩容集群中的 PD 微服务节点，以及如何切换 PD 工作模式。
-- [使用 TiUP 扩容缩容 TiDB 集群](https://docs.pingcap.com/tidb/stable/scale-tidb-using-tiup.md): TiUP 可以在不中断线上服务的情况下扩容和缩容 TiDB 集群。使用 `tiup cluster list` 查看当前集群名称列表。扩容 TiDB/PD/TiKV 节点需要编写扩容拓扑配置，并执行扩容命令。扩容后，使用 `tiup cluster display <cluster-name>` 检查集群状态。缩容 TiDB/PD/TiKV 节点需要查看节点 ID 信息，执行缩容操作，然后检查集群状态。缩容 TiFlash/TiCDC 节点也需要执行相似的操作。
-- [使用 TiUP 离线镜像部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-tiup-offline.md): 学习如何使用 TiUP DM 组件来离线部署 TiDB Data Migration 工具。
-- [使用 TiUP 运维 DM 集群](https://docs.pingcap.com/tidb/stable/maintain-dm-using-tiup.md): 学习如何使用 TiUP 运维 DM 集群。
-- [使用 TiUP 部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-tiup.md): 学习如何使用 TiUP DM 组件来部署 TiDB Data Migration 工具。
-- [使用 TiUP 部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/production-deployment-using-tiup.md): 了解如何使用 TiUP 部署 TiDB 集群。
-- [使用 TiUP 部署运维 TiDB 线上集群](https://docs.pingcap.com/tidb/stable/tiup-cluster.md): 使用 TiUP 的 cluster 组件可以快速部署生产集群，并提供强大的生产集群管理功能，包括升级、缩容、扩容、操作、审计等。部署集群的命令为 tiup cluster deploy，部署完成后可以通过 tiup cluster list 查看集群列表。启动集群的命令为 tiup cluster start，查看集群状态的命令为 tiup cluster display。可以使用 tiup cluster scale-in 进行集群缩容，tiup cluster scale-out 进行集群扩容。另外，还可以使用 tiup cluster upgrade 进行滚动升级，使用 tiup cluster edit-config 进行配置更新。最后，可以使用 tiup cluster exec 在集群节点机器上执行命令。
-- [使用 TTL (Time to Live) 定期删除过期数据](https://docs.pingcap.com/tidb/stable/time-to-live.md): Time to Live (TTL) 提供了行级别的生命周期控制策略。本篇文档介绍如何通过 TTL (Time to Live) 来管理表数据的生命周期。
-- [使用 TypeORM 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-typeorm.md): 本文描述了 TiDB 和 TypeORM 的连接步骤，并给出了简单示例代码片段。
-- [使用 WebUI 管理 DM 迁移任务](https://docs.pingcap.com/tidb/stable/dm-webui-guide.md): 学习如何使用 WebUI 来方便的管理数据迁移任务。
-- [使用物理导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-physical-import-mode-usage.md): 了解如何使用 TiDB Lightning 的物理导入模式。
-- [使用资源管控 (Resource Control) 实现资源组限制和流控](https://docs.pingcap.com/tidb/stable/tidb-resource-control-ru-groups.md): 介绍如何通过资源管控能力来实现对应用资源消耗的控制和有效调度。
-- [使用资源管控 (Resource Control) 管理后台任务](https://docs.pingcap.com/tidb/stable/tidb-resource-control-background-tasks.md): 介绍如何通过资源管控 (Resource Control) 控制后台任务。
-- [使用逻辑导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-logical-import-mode-usage.md): 了解在 TiDB Lightning 的逻辑导入模式下，如何编写数据导入任务的配置文件，如何进行性能调优等。
-- [信息函数](https://docs.pingcap.com/tidb/stable/information-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分信息函数。
-- [修改 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-modify.md): 了解修改 JSON 值的 JSON 函数。
-- [停止 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-stop-task.md): 了解 TiDB Data Migration 如何停止数据迁移任务。
-- [元数据锁](https://docs.pingcap.com/tidb/stable/metadata-lock.md): 介绍 TiDB 中元数据锁的概念、原理、实现和影响。
-- [公共表表达式 (CTE)](https://docs.pingcap.com/tidb/stable/dev-guide-use-common-table-expression.md): 介绍 TiDB 公共表表达式能力，用以简化 SQL。
-- [关联子查询去关联](https://docs.pingcap.com/tidb/stable/correlated-subquery-optimization.md): 了解如何给关联子查询解除关联。
-- [关键字](https://docs.pingcap.com/tidb/stable/keywords.md): 本文介绍 TiDB 的关键字。
-- [其他函数](https://docs.pingcap.com/tidb/stable/miscellaneous-functions.md): TiDB 支持使用 MySQL 8.0 中提供的大部分其他函数。
-- [函数和操作符概述](https://docs.pingcap.com/tidb/stable/functions-and-operators-overview.md): TiDB 中的函数和操作符使用方法与 MySQL 基本一致。在 SQL 语句中，表达式可用于诸如 SELECT 语句的 ORDER BY 或 HAVING 子句，SELECT/DELETE/UPDATE 语句的 WHERE 子句，或 SET 语句之类的地方。可使用字面值，列名，NULL，内置函数，操作符等来书写表达式。其中有些表达式下推到 TiKV 上执行，详见下推到 TiKV 的表达式列表。
-- [分享 TiDB Dashboard 会话](https://docs.pingcap.com/tidb/stable/dashboard-session-share.md): 了解如何将当前的 TiDB Dashboard 会话分享给其他用户访问。
-- [分区表](https://docs.pingcap.com/tidb/stable/partitioned-table.md): 了解如何使用 TiDB 的分区表。
-- [分区裁剪](https://docs.pingcap.com/tidb/stable/partition-pruning.md): 了解 TiDB 分区裁剪的使用场景。
-- [分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge.md): DM 提供了分库分表的合并迁移功能，可将上游 MySQL/MariaDB 实例中的表迁移到下游 TiDB 的同一个表中。支持悲观协调和乐观协调两种模式。悲观模式保证数据不出错，但可能会阻塞迁移；乐观模式处理 DDL 时不会阻塞数据迁移，但可能导致数据不一致。
-- [分库分表场景下的数据校验](https://docs.pingcap.com/tidb/stable/shard-diff.md): sync-diff-inspector 支持对分库分表场景进行数据校验。使用 Datasource config 进行配置，设置对应 rules，配置上游表与下游表的映射关系。当上游分表较多且符合一定规则时，可以使用 table-rules 进行配置。注意事项：如果上游数据库有 test.table-0 也会被下游数据库匹配到。
-- [分析慢查询](https://docs.pingcap.com/tidb/stable/analyze-slow-queries.md): 学习如何定位和分析慢查询。
-- [分表合并数据迁移最佳实践](https://docs.pingcap.com/tidb/stable/shard-merge-best-practices.md): 使用 DM 对分库分表进行合并迁移时的最佳实践。
-- [分页查询](https://docs.pingcap.com/tidb/stable/dev-guide-paginate-results.md): 介绍 TiDB 的分页查询功能。
-- [切换 DM-worker 与上游 MySQL 实例的连接](https://docs.pingcap.com/tidb/stable/usage-scenario-master-slave-switch.md): 了解如何切换 DM-worker 与上游 MySQL 实例的连接。
-- [列裁剪](https://docs.pingcap.com/tidb/stable/column-pruning.md): 列裁剪是优化器在优化过程中删除不需要的列的基本思想。这样可以减少 I/O 资源占用并为后续优化带来便利。TiDB 会在逻辑优化阶段进行列裁剪，减少资源浪费。该扫描过程称作“列裁剪”，对应逻辑优化规则中的 columnPruner。如果要关闭这个规则，可以参照优化规则及表达式下推的黑名单中的关闭方法。
-- [创建 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-create.md): 了解创建 JSON 值的 JSON 函数。
-- [创建 TiDB Data Migration 数据源](https://docs.pingcap.com/tidb/stable/quick-start-create-source.md): 了解如何为 DM 创建数据源。
-- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-create-task.md): 了解 TiDB Data Migration 如何创建数据迁移任务。
-- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/quick-start-create-task.md): 了解在部署 DM 集群后，如何快速创建数据迁移任务。
-- [创建二级索引](https://docs.pingcap.com/tidb/stable/dev-guide-create-secondary-indexes.md): 创建二级索引的方法、规范及例子。
-- [创建数据库](https://docs.pingcap.com/tidb/stable/dev-guide-create-database.md): 创建数据库的方法、规范及例子。
-- [创建表](https://docs.pingcap.com/tidb/stable/dev-guide-create-table.md): 创建表的方法、规范及例子。
-- [删除数据](https://docs.pingcap.com/tidb/stable/dev-guide-delete-data.md): 删除数据、批量删除数据的方法、最佳实践及例子。
-- [加密和压缩函数](https://docs.pingcap.com/tidb/stable/encryption-and-compression-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分加密和压缩函数。
-- [升级与升级后常见问题](https://docs.pingcap.com/tidb/stable/upgrade-faq.md): TiDB 升级与升级后的常见问题与解决办法。
-- [升级集群监控组件](https://docs.pingcap.com/tidb/stable/upgrade-monitoring-services.md): 介绍如何升级 TiDB 集群监控组件 Prometheus、Grafana 和 Alertmanager。
-- [单区域双 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/two-data-centers-in-one-city-deployment.md): 了解单个区域两个可用区自适应同步模式部署方式。
-- [单区域多 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/multi-data-centers-in-one-city-deployment.md): 本文档介绍单个区域多个可用区部署 TiDB 的方案。
-- [单表查询](https://docs.pingcap.com/tidb/stable/dev-guide-get-data-from-single-table.md): 介绍 TiDB 中的单表查询功能。
-- [双区域多 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/three-data-centers-in-two-cities-deployment.md): 介绍在两个区域多个可用区部署 TiDB 的方式。
-- [只读存储节点最佳实践](https://docs.pingcap.com/tidb/stable/readonly-nodes.md): 介绍如何通过使用只读存储节点，达到物理隔离部分流量的目的。
-- [同步数据到 Kafka](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-kafka.md): 了解如何使用 TiCDC 将数据同步到 Kafka。
-- [同步数据到 MySQL 兼容数据库](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-mysql.md): 了解如何使用 TiCDC 将数据同步到 TiDB 或 MySQL
-- [同步数据到 Pulsar](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-pulsar.md): 了解如何使用 TiCDC 将数据同步到 Pulsar。
-- [同步数据到存储服务](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-cloud-storage.md): 了解如何使用 TiCDC 将数据同步到存储服务，以及数据变更记录的存储路径。
-- [向量函数和操作符](https://docs.pingcap.com/tidb/stable/vector-search-functions-and-operators.md): 本文介绍 TiDB 的向量相关函数和操作。
-- [向量搜索概述](https://docs.pingcap.com/tidb/stable/vector-search-overview.md): 介绍 TiDB 向量搜索功能。TiDB 向量搜索可以对文档、图像、音频和视频等多种数据类型进行语义搜索。
-- [向量搜索索引](https://docs.pingcap.com/tidb/stable/vector-search-index.md): 了解如何在 TiDB 中构建并使用向量搜索索引加速 K 近邻 (K-Nearest Neighbors, KNN) 查询。
-- [向量搜索限制](https://docs.pingcap.com/tidb/stable/vector-search-limitations.md): 了解 TiDB 向量搜索功能的限制。
-- [向量搜索集成概览](https://docs.pingcap.com/tidb/stable/vector-search-integration-overview.md): 介绍 TiDB 向量搜索支持的 AI 框架、嵌入模型和 ORM 库。
-- [向量数据类型](https://docs.pingcap.com/tidb/stable/vector-search-data-types.md): 本文介绍 TiDB 的向量数据类型。
-- [唯一序列号生成方案](https://docs.pingcap.com/tidb/stable/dev-guide-unique-serial-number-generation.md): 唯一序列号生成方案，为自行生成唯一 ID 的开发者提供帮助。
-- [在 AWS Lambda 函数中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-aws-lambda.md): 本文介绍如何在 AWS Lambda 函数中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
-- [在 Django ORM 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-django-orm.md): 了解如何在 Django ORM 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
-- [在 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/tidb-in-kubernetes.md): 你可以使用 TiDB Operator 在 Kubernetes 上部署 TiDB。TiDB Operator 是 Kubernetes 上的 TiDB 集群自动运维系统，提供部署、升级、扩缩容、备份恢复、配置变更的 TiDB 全生命周期管理。借助 TiDB Operator，TiDB 可以无缝运行在公有云或自托管的 Kubernetes 集群上。TiDB Operator 的文档目前独立于 TiDB 文档。要查看如何在 Kubernetes 上部署 TiDB 的详细步骤，请参阅对应版本的 TiDB Operator 文档。
-- [在 LangChain 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-langchain.md): 展示如何在 LangChain 中使用 TiDB 向量搜索
-- [在 LlamaIndex 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-llamaindex.md): 了解如何在 LlamaIndex 中使用 TiDB 向量搜索。
-- [在 Next.js 中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nextjs.md): 本文介绍了如何在 Next.js 中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
-- [在 peewee 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-peewee.md): 了解如何在 peewee 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
-- [在 SQLAlchemy 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-sqlalchemy.md): 了解如何在 SQLAlchemy 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
-- [在三数据中心下就近读取数据](https://docs.pingcap.com/tidb/stable/three-dc-local-read.md): 了解通过 Stale Read 功能在三数据中心下就近读取数据，减少跨数据中心请求。
-- [在公有云上部署 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/best-practices-on-public-cloud.md): 了解在公有云上部署 TiDB 的最佳实践。
-- [在线修改集群配置](https://docs.pingcap.com/tidb/stable/dynamic-config.md): 介绍在线修改集群配置的功能。
-- [在线应用 Hotfix 到 DM 集群](https://docs.pingcap.com/tidb/stable/tiup-component-dm-patch.md): 了解如何应用 hotfix 补丁包到 DM 集群。
-- [基于 Avro 的 TiCDC 行数据 Checksum 校验](https://docs.pingcap.com/tidb/stable/ticdc-avro-checksum-verification.md): 介绍 TiCDC 行数据 Checksum 校验的具体实现。
-- [基于 DM 同步场景下的数据校验](https://docs.pingcap.com/tidb/stable/dm-diff.md): 了解如何使用 TiDB DM 拉取指定配置进行数据校验。
-- [基于主备集群的容灾方案](https://docs.pingcap.com/tidb/stable/dr-secondary-cluster.md): 了解如何使用 TiCDC 构建主备集群进行容灾。
-- [基于备份与恢复的容灾方案](https://docs.pingcap.com/tidb/stable/dr-backup-restore.md): 了解如何基于 TiDB 的备份与恢复功能实现容灾。
-- [基于多副本的单集群容灾方案](https://docs.pingcap.com/tidb/stable/dr-multi-replica.md): 了解 TiDB 提供的基于多副本的单集群容灾方案。
-- [基于角色的访问控制](https://docs.pingcap.com/tidb/stable/role-based-access-control.md): TiDB 的基于角色的访问控制 (RBAC) 系统类似于 MySQL 8.0 的 RBAC 系统。用户可以创建、删除和授予角色权限，也可以将角色授予其他用户。角色需要在用户启用后才能生效。用户可以通过 `SHOW GRANTS` 查看角色权限，也可以设置默认启用角色。角色授权具有原子性，失败会回滚。除了角色授权外，还有用户管理和权限管理相关操作。
-- [备份与恢复 RawKV 数据](https://docs.pingcap.com/tidb/stable/rawkv-backup-and-restore.md): 了解如何使用 tikv-br 命令行工具备份和恢复 RawKV 数据。
-- [备份与恢复常见问题](https://docs.pingcap.com/tidb/stable/backup-and-restore-faq.md): 了解备份恢复相关的常见问题以及解决方法。
-- [备份存储](https://docs.pingcap.com/tidb/stable/backup-and-restore-storages.md): 了解 BR 支持的备份存储服务的 URI 格式、鉴权方案和使用方式。
-- [备份恢复监控告警](https://docs.pingcap.com/tidb/stable/br-monitoring-and-alert.md): 了解备份恢复的监控告警。
-- [备份自动调节](https://docs.pingcap.com/tidb/stable/br-auto-tune.md): 了解 TiDB 的自动调节备份功能，在集群资源占用率较高的情况下，BR 会自动限制备份使用的资源以求减少对集群的影响。
-- [外部存储服务的 URI 格式](https://docs.pingcap.com/tidb/stable/external-storage-uri.md): 介绍了外部存储服务 Amazon S3、GCS、和 Azure Blob Storage 的 URI 格式。
-- [外键约束](https://docs.pingcap.com/tidb/stable/foreign-key.md): TiDB 数据库中外键约束的使用概况。
-- [多表连接查询](https://docs.pingcap.com/tidb/stable/dev-guide-join-tables.md): 介绍 TiDB 中的多表连接查询功能。
-- [如何对 TiDB 进行 CH-benCHmark 测试](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-ch.md): 本文介绍如何对 TiDB 进行 CH-benCHmark 测试。
-- [如何对 TiDB 进行 TPC-C 测试](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-tpcc.md): 本文介绍了如何对 TiDB 进行 TPC-C 测试。TPC-C 是一个对 OLTP 系统进行测试的规范，使用商品销售模型对系统进行测试，包含五类事务：NewOrder、Payment、OrderStatus、Delivery、StockLevel。测试使用 tpmC 值衡量系统最大有效吞吐量，以 NewOrder Transaction 为准。使用 go-tpc 进行测试实现，通过 TiUP 命令下载测试程序。测试包括数据导入、运行测试和清理测试数据。
-- [如何用 Sysbench 测试 TiDB](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-sysbench.md): 使用 Sysbench 1.0 或更新版本测试 TiDB 性能。调整 TiDB 和 TiKV 的日志级别以提高性能。配置 RocksDB 的 block cache 以充分利用内存。调整 Sysbench 配置文件并导入数据。进行数据预热和统计信息收集。执行 Point select、Update index 和 Read-only 测试命令。解决可能出现的性能问题。
-- [如何过滤 binlog 事件](https://docs.pingcap.com/tidb/stable/filter-binlog-event.md): 介绍如何过滤 binlog 事件。
-- [如何通过 SQL 表达式过滤 DML](https://docs.pingcap.com/tidb/stable/filter-dml-event.md): 介绍如何通过 SQL 表达式过滤 DML 事件
-- [子查询](https://docs.pingcap.com/tidb/stable/dev-guide-use-subqueries.md): 介绍 TiDB 子查询功能。
-- [子查询相关的优化](https://docs.pingcap.com/tidb/stable/subquery-optimization.md): 了解子查询相关的优化。
-- [字符串函数](https://docs.pingcap.com/tidb/stable/string-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分字符串函数以及 Oracle 21 中提供的部分函数。
-- [字符串类型](https://docs.pingcap.com/tidb/stable/data-type-string.md): TiDB 支持 MySQL 所有字符串类型，包括 CHAR、VARCHAR、BINARY、VARBINARY、BLOB、TEXT、ENUM 和 SET。CHAR 是定长字符串，长度固定为创建表时声明的长度。VARCHAR 是变长字符串，空间占用大小不得超过 65535 字节。TEXT 是文本串，最大列长为 65535 字节。TINYTEXT 最大列长度为 255。MEDIUMTEXT 最大列长度为 16777215。LONGTEXT 最大列长度为 4294967295。BINARY 存储二进制字符串。VARBINARY 存储二进制字符串。BLOB 是二进制大文件，最大列长度为 65535 字节。TINYBLOB 最大列长度为 255。MEDIUMBLOB 最大列长度为 16777215。LONGBLOB 最大列长度为 4294967295。ENUM 是枚举类型，值必须从固定集合中选取。SET 是集合类型，包含零个或多个值的字符串。
-- [字符集和排序规则](https://docs.pingcap.com/tidb/stable/character-set-and-collation.md): TiDB 支持的字符集包括 ascii、binary、gbk、latin1、utf8 和 utf8mb4。排序规则包括 ascii_bin、binary、gbk_bin、gbk_chinese_ci、latin1_bin、utf8_bin、utf8_general_ci、utf8_unicode_ci、utf8mb4_0900_ai_ci、utf8mb4_0900_bin、utf8mb4_bin、utf8mb4_general_ci 和 utf8mb4_unicode_ci。TiDB 强烈建议使用 utf8mb4 字符集，因为它支持更多字符。在 TiDB 中，默认的排序规则受到客户端的连接排序规则设置的影响。如果客户端使用 utf8mb4_0900_ai_ci 作为连接排序规则，TiDB 将遵循客户端的配置。TiDB 还支持新的排序规则框架，用于在语义上支持不同的排序规则。
-- [字面值](https://docs.pingcap.com/tidb/stable/literal-values.md): 本文介绍了 TiDB SQL 语句的字面值。
-- [定位消耗系统资源多的查询](https://docs.pingcap.com/tidb/stable/identify-expensive-queries.md): TiDB 会将执行时间超过 tidb_expensive_query_time_threshold 限制（默认值为 60s），或使用内存超过 tidb_mem_quota_query 限制（默认值为 1 GB）的语句输出到 tidb-server 日志文件中，用于定位消耗系统资源多的查询语句。expensive query 日志和慢查询日志的区别在于，expensive query 日志可以将正在执行的语句的相关信息打印出来。当一条语句在执行过程中达到资源使用阈值时，TiDB 会即时将这条语句的相关信息写入日志。
-- [对象命名规范](https://docs.pingcap.com/tidb/stable/dev-guide-object-naming-guidelines.md): 介绍 TiDB 中的对象命名规范。
-- [将 Grafana 监控数据导出成快照](https://docs.pingcap.com/tidb/stable/exporting-grafana-snapshots.md): 了解如何将 Grafana 监控数据导出为快照以及如何将快照文件可视化。
-- [已知的第三方工具兼容问题](https://docs.pingcap.com/tidb/stable/dev-guide-third-party-tools-compatibility.md): 介绍在测试中发现的 TiDB 与第三方工具的兼容性问题。
-- [常规统计信息](https://docs.pingcap.com/tidb/stable/statistics.md): 介绍 TiDB 中常规统计信息的收集和使用。
-- [平滑升级 TiDB](https://docs.pingcap.com/tidb/stable/smooth-upgrade-tidb.md): 本文介绍支持无需手动取消 DDL 的平滑升级集群功能。
-- [序列函数](https://docs.pingcap.com/tidb/stable/sequence-functions.md): 了解 TiDB 中的序列函数。
-- [延迟的拆解分析](https://docs.pingcap.com/tidb/stable/latency-breakdown.md): 详细介绍 TiDB 运行各阶段中时间消耗带来的延迟，以及如何在真实场景中分析延迟。
-- [开发 Java 应用使用 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/java-app-best-practices.md): 本文介绍了开发 Java 应用程序使用 TiDB 的常见问题与解决办法。TiDB 是高度兼容 MySQL 协议的数据库，基于 MySQL 开发的 Java 应用的最佳实践也多适用于 TiDB。
-- [开发者手册概览](https://docs.pingcap.com/tidb/stable/dev-guide-overview.md): 整体叙述了开发者手册，罗列了开发者手册的大致脉络。
-- [性能优化概述](https://docs.pingcap.com/tidb/stable/performance-tuning-overview.md): 本文介绍性能优化的基本概念，比如用户响应时间、吞吐和数据库时间，以及性能优化的通用流程。
-- [性能调优最佳实践](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql-best-practices.md): 介绍使用 TiDB 的性能调优最佳实践。
-- [恢复 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-resume-task.md): 了解 TiDB Data Migration 如何恢复数据迁移任务。
-- [悲观模式下分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge-pessimistic.md): 介绍 DM 提供的悲观模式（默认模式）下分库分表的合并迁移功能。
-- [慢查询日志](https://docs.pingcap.com/tidb/stable/identify-slow-queries.md): TiDB 会将执行时间超过 300 毫秒的语句输出到慢查询日志中，用于帮助用户定位慢查询语句。可以通过修改系统变量来启用或禁用慢查询日志。日志示例包括执行时间、用户信息、执行计划等字段。用户可通过查询 SLOW_QUERY 表来查询慢查询日志中的内容。还可以使用 pt-query-digest 工具分析 TiDB 慢日志。ADMIN SHOW SLOW 命令可以显示最近的慢查询记录或最慢的查询记录。
-- [手动处理 Sharding DDL Lock](https://docs.pingcap.com/tidb/stable/manually-handling-sharding-ddl-locks.md): DM 使用 sharding DDL lock 来确保分库分表的 DDL 操作可以正确执行。在异常情况下，需要手动处理异常的 DDL lock。使用 shard-ddl-lock 命令查看 DDL lock 信息，使用 shard-ddl-lock unlock 命令请求 DM-master 解除指定的 DDL lock。支持处理部分 MySQL source 被移除和 unlock 过程中部分 DM-worker 异常停止或网络中断的情况。
-- [执行计划管理 (SPM)](https://docs.pingcap.com/tidb/stable/sql-plan-management.md): 介绍 TiDB 的执行计划管理 (SQL Plan Management) 功能。
-- [扩展统计信息](https://docs.pingcap.com/tidb/stable/extended-statistics.md): 了解如何使用扩展统计信息指导优化器。
-- [批量建表](https://docs.pingcap.com/tidb/stable/br-batch-create-table.md): 了解如何使用批量建表功能。在恢复备份数据时，可以通过批量建表功能加快数据的恢复速度。
-- [控制执行计划](https://docs.pingcap.com/tidb/stable/control-execution-plan.md): 本章节介绍了控制执行计划的方法，包括使用提示指导执行计划、执行计划管理、优化规则及表达式下推的黑名单。此外，还介绍了一些系统变量对执行计划的影响，以及引入的特殊变量 `tidb_opt_fix_control`，用于更细粒度地控制优化器的行为。
-- [控制流程函数](https://docs.pingcap.com/tidb/stable/control-flow-functions.md): TiDB 支持 MySQL 8.0 中的控制流程函数，包括 CASE、IF()、IFNULL() 和 NULLIF()。这些函数可以用于构建 if/else 语句和处理 NULL 值。
-- [提升 TiDB 建表性能](https://docs.pingcap.com/tidb/stable/accelerated-table-creation.md): 介绍 TiDB 加速建表中的概念、原理、实现和影响。
-- [提高 TiDB Dashboard 安全性](https://docs.pingcap.com/tidb/stable/dashboard-ops-security.md): TiDB Dashboard 需要提高安全性。建议为 `root` 用户设置强密码或禁用 `root` 账户，并为 TiDB Dashboard 创建最小权限用户。使用防火墙阻止不可信访问，配置反向代理仅代理 TiDB Dashboard，并为反向代理开启 TLS。其他建议的安全措施包括为组件间通信和客户端服务端间通信开启加密传输。
-- [插入数据](https://docs.pingcap.com/tidb/stable/dev-guide-insert-data.md): 插入数据、批量导入数据的方法、最佳实践及例子。
-- [搜索 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-search.md): 了解搜索 JSON 值的 JSON 函数。
-- [搭建双集群主从复制](https://docs.pingcap.com/tidb/stable/replicate-between-primary-and-secondary-clusters.md): 了解如何配置一个 TiDB 集群以及该集群的 TiDB 或 MySQL 从集群，并将增量数据实时从主集群同步到从集群，
-- [搭建私有镜像](https://docs.pingcap.com/tidb/stable/tiup-mirror.md): TiUP 提供了构建私有镜像的方案，使用 mirror 指令来实现，可用于离线部署。执行 `tiup mirror clone` 命令，可构建本地地镜像。克隆完成后，可以通过 SCP、NFS、HTTP 或 HTTPS 共享仓库。使用 `TIUP_MIRRORS` 环境变量来使用镜像。重新运行 `tiup mirror clone` 命令会创建新的 manifest，并下载可用的最新版本的组件。可以创建自定义仓库，并使用自己构建的 TiDB 组件。
-- [操作符](https://docs.pingcap.com/tidb/stable/operators.md): 操作符是用于在 MySQL 中执行各种操作的关键元素。它们包括逻辑操作符（如 AND、OR、NOT、XOR）、赋值操作符（如 =、:=）、比较操作符（如 =、<、>、LIKE、BETWEEN）、以及其他操作符（如 +、-、*、/）。操作符具有不同的优先级，可以用于执行各种复杂的操作。需要注意的是，MySQL 不支持 ILIKE 操作符。
-- [操作系统性能参数调优](https://docs.pingcap.com/tidb/stable/tune-operating-system.md): 了解如何进行 CentOS 7 系统的性能调优。
-- [支持资源](https://docs.pingcap.com/tidb/stable/support.md): 在使用 TiDB 时遇到问题，如何获取支持。
-- [数值函数与操作符](https://docs.pingcap.com/tidb/stable/numeric-functions-and-operators.md): TiDB 支持 MySQL 8.0 中的所有数值函数和操作符。
-- [数值类型](https://docs.pingcap.com/tidb/stable/data-type-numeric.md): TiDB 支持 MySQL 的所有数值类型，包括整数类型、浮点类型和定点类型。整数类型包括 BIT、BOOLEAN、TINYINT、SMALLINT、MEDIUMINT、INTEGER 和 BIGINT，存储空间和取值范围各不相同。浮点类型包括 FLOAT 和 DOUBLE，存储空间分别为 4 和 8 字节。定点类型包括 DECIMAL 和 NUMERIC，可设置小数位数和小数点后位数。建议使用 DECIMAL 类型存储精确值。
-- [数据批量处理](https://docs.pingcap.com/tidb/stable/batch-processing.md): 介绍了 TiDB 为数据批量处理场景提供的功能，包括 Pipelined DML、非事务性 DML、IMPORT INTO 语句以及已被废弃的 batch-dml。
-- [数据类型概述](https://docs.pingcap.com/tidb/stable/data-type-overview.md): TiDB 支持除了空间类型（SPATIAL）之外的所有 MySQL 数据类型，包括数值型类型、字符串类型、时间和日期类型、JSON 类型。数据类型定义一般为 T(M[, D])，其中 T 表示具体的类型，M 在整数类型中表示最大显示长度，在浮点数或者定点数中表示精度，在字符类型中表示最大长度，D 表示浮点数、定点数的小数位长度，fsp 在时间和日期类型里的 TIME、DATETIME 以及 TIMESTAMP 中表示秒的精度，其取值范围是 0 到 6，值为 0 表示没有小数部分，如果省略，则默认精度为 0。
-- [数据类型的默认值](https://docs.pingcap.com/tidb/stable/data-type-default-values.md): 数据类型的默认值描述了列的默认值设置规则。默认值必须是常量，对于时间类型可以使用特定函数。从 v8.0.0 开始，BLOB、TEXT 和 JSON 可以设置表达式默认值。如果列没有设置 DEFAULT，TiDB 会根据规则添加隐式默认值。对于 NOT NULL 列，根据 SQL_MODE 进行不同行为。表达式默认值是实验特性，不建议在生产环境中使用。MySQL 8.0.13 开始支持在 DEFAULT 子句中指定表达式为默认值。TiDB 支持为 BLOB、TEXT 和 JSON 数据类型分配默认值，但仅支持通过表达式来设置。
-- [数据索引一致性错误](https://docs.pingcap.com/tidb/stable/troubleshoot-data-inconsistency-errors.md): TiDB 在执行事务或执行 ADMIN CHECK 命令时会检查数据索引的一致性。如果发现不一致，会报错并记录相关错误日志。报错处理可通过改写 SQL 或关闭错误检查来绕过。对于特定错误代码，可通过设置 @@tidb_enable_mutation_checker=0 或 @@tidb_txn_assertion_level=OFF 来跳过检查。需注意关闭开关会关闭所有 SQL 语句的对应检查。
-- [数据迁移工具概览](https://docs.pingcap.com/tidb/stable/migration-tools.md): 介绍 TiDB 的数据迁移工具。
-- [数据迁移概述](https://docs.pingcap.com/tidb/stable/migration-overview.md): 了解各种数据迁移场景和对应的数据迁移方案。
-- [数据集成概述](https://docs.pingcap.com/tidb/stable/integration-overview.md): 了解使用 TiCDC 进行数据集成的具体场景。
-- [断点备份](https://docs.pingcap.com/tidb/stable/br-checkpoint-backup.md): 了解断点备份功能，包括它的使用场景、实现原理以及使用方法。
-- [断点恢复](https://docs.pingcap.com/tidb/stable/br-checkpoint-restore.md): 了解断点恢复功能，包括它的使用场景、实现原理以及使用方法。
-- [日常巡检](https://docs.pingcap.com/tidb/stable/daily-check.md): 介绍 TiDB 集群需要常关注的性能指标。
-- [日志脱敏](https://docs.pingcap.com/tidb/stable/log-redaction.md): 了解 TiDB 各组件中的日志脱敏。
-- [日期和时间函数](https://docs.pingcap.com/tidb/stable/date-and-time-functions.md): TiDB 支持 MySQL 8.0 中的所有日期和时间函数。
-- [日期和时间类型](https://docs.pingcap.com/tidb/stable/data-type-date-and-time.md): TiDB 支持 MySQL 的所有日期和时间类型，包括 DATE、TIME、DATETIME、TIMESTAMP 和 YEAR。每种类型都有有效值范围，值为 0 表示无效值。TIMESTAMP 和 DATETIME 类型能自动生成新的时间值。关于日期和时间值类型，需要注意日期部分必须是“年 - 月 - 日”的格式，如果日期的年份部分是 2 位数，TiDB 会根据具体规则进行转换。不同类型的零值如下表所示：DATE:0000-00-00, TIME:00:00:00, DATETIME:0000-00-00 00:00:00, TIMESTAMP:0000-00-00 00:00:00, YEAR:0000。如果 SQL 模式允许使用无效的 DATE、DATETIME、TIMESTAMP 值，无效值会自动转换为相应的零值。
-- [时区支持](https://docs.pingcap.com/tidb/stable/configure-time-zone.md): TiDB 的时区设置由 `time_zone` 系统变量控制，可以在会话级别或全局级别进行设置。`TIMESTAMP` 数据类型的的显示值受时区设置影响，但 `DATETIME`、`DATE` 或 `TIME` 数据类型不受影响。在数据迁移时，需要特别注意主库和从库的时区设置是否一致。
-- [暂停 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-pause-task.md): 了解 TiDB Data Migration 如何暂停数据迁移任务。
-- [更新数据](https://docs.pingcap.com/tidb/stable/dev-guide-update-data.md): 更新数据、批量更新数据的方法、最佳实践及例子。
-- [最小拓扑架构](https://docs.pingcap.com/tidb/stable/minimal-deployment-topology.md): 介绍 TiDB 集群的最小拓扑。
-- [服务器状态变量](https://docs.pingcap.com/tidb/stable/status-variables.md): 使用状态变量查看系统和会话状态。
-- [本地快速部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/tiup-playground.md): TiDB 集群是分布式系统，由多个组件构成。想要快速体验 TiDB，可以使用 TiUP 中的 playground 组件快速搭建本地测试环境。通过命令行参数可以设置各组件的数量和配置，也可以启动多个组件实例。使用 `tiup client` 可以快速连接到本地启动的 TiDB 集群。还可以查看已启动集群的信息，扩容或缩容集群。
-- [术语表](https://docs.pingcap.com/tidb/stable/glossary.md): 了解 TiDB 相关术语。
-- [权限管理](https://docs.pingcap.com/tidb/stable/privilege-management.md): TiDB 支持 MySQL 5.7 和 MySQL 8.0 的权限管理系统。权限相关操作包括授予权限、收回权限、查看用户权限和动态权限。权限系统的实现包括授权表和连接验证。权限生效时机是在 TiDB 启动时加载到内存，并且可以手动刷新。
-- [构建 TiFlash 副本](https://docs.pingcap.com/tidb/stable/create-tiflash-replicas.md): 了解如何构建 TiFlash 副本。
-- [概览](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql-overview.md): 介绍 TiDB 的 SQL 性能调优概览。
-- [概述](https://docs.pingcap.com/tidb/stable/dev-guide-schema-design-overview.md): TiDB 数据库模式设计的概述。
-- [注释语法](https://docs.pingcap.com/tidb/stable/comment-syntax.md): 本文介绍 TiDB 支持的注释语法。
-- [海量 Region 集群调优最佳实践](https://docs.pingcap.com/tidb/stable/massive-regions-best-practices.md): 了解海量 Region 导致性能问题的原因和优化方法。
-- [混合部署拓扑](https://docs.pingcap.com/tidb/stable/hybrid-deployment-topology.md): 介绍混合部署 TiDB 集群的拓扑结构。
-- [物理优化](https://docs.pingcap.com/tidb/stable/sql-physical-optimization.md): 物理优化是基于代价的优化，为逻辑执行计划制定物理执行计划。优化器根据数据统计信息选择时间复杂度、资源消耗和物理属性最小的物理执行计划。TiDB 执行计划文档介绍了索引选择、统计信息、错误索引解决方案、Distinct 优化和代价模型。
-- [物理导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-physical-import-mode.md): 了解 TiDB Lightning 的物理导入模式。
-- [理解 TiKV 中的 Stale Read 和 safe-ts](https://docs.pingcap.com/tidb/stable/troubleshoot-stale-read.md): TiKV 中的 Stale Read 依赖于 safe-ts，保证读取历史数据版本的安全性。safe-ts 由每个 Region 中的 peer 维护，resolved-ts 则由 Region leader 维护。诊断 Stale Read 问题可通过 Grafana、tikv-ctl 和日志。常见原因包括事务提交时间过长、事务存在时间过长以及 CheckLeader 信息推送延迟。处理慢事务提交可通过识别锁所属的事务和检查应用程序逻辑。处理长事务可通过识别事务、检查应用程序逻辑和处理慢查询。解决 CheckLeader 问题可通过检查网络和监控面板指标。
-- [生成列](https://docs.pingcap.com/tidb/stable/generated-columns.md): 生成列是由列定义中的表达式计算得到的值。它包括存储生成列和虚拟生成列，存储生成列会将计算得到的值存储起来，而虚拟生成列不会存储其值。生成列可以用于从 JSON 数据类型中解出数据，并为该数据建立索引。在 INSERT 和 UPDATE 语句中，会检查生成列计算得到的值是否满足生成列的定义。生成列的局限性包括不能增加存储生成列，不能转换存储生成列为普通列，不能修改存储生成列的生成列表达式，以及不支持所有的 JSON 函数。
-- [生成自签名证书](https://docs.pingcap.com/tidb/stable/generate-self-signed-certificates.md): 本文介绍了使用 openssl 生成自签名证书的示例。用户可以根据需要生成符合要求的证书和密钥。首先安装 OpenSSL，然后生成 CA 证书和各个组件的证书，最后为客户端签发证书。证书的作用是为各个组件和客户端验证身份。
-- [用 EXPLAIN 查看 JOIN 查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-joins.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看 MPP 模式查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-mpp.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看分区查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-partitions.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看子查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-subqueries.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看带视图的 SQL 执行计划](https://docs.pingcap.com/tidb/stable/explain-views.md): 了解 TiDB 中视图相关语句的执行计划。
-- [用 EXPLAIN 查看索引合并的 SQL 执行计划](https://docs.pingcap.com/tidb/stable/explain-index-merge.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看索引查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-indexes.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看聚合查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-aggregation.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用户自定义变量](https://docs.pingcap.com/tidb/stable/user-defined-variables.md): 本文介绍 TiDB 的用户自定义变量。
-- [窗口函数](https://docs.pingcap.com/tidb/stable/window-functions.md): TiDB 中的窗口函数与 MySQL 8.0 基本一致。可以将 `tidb_enable_window_function` 设置为 `0` 来解决升级后无法解析语法的问题。TiDB 支持除 `GROUP_CONCAT()` 和 `APPROX_PERCENTILE()` 以外的所有 `GROUP BY` 聚合函数。其他支持的窗口函数包括 `CUME_DIST()`、`DENSE_RANK()`、`FIRST_VALUE()`、`LAG()`、`LAST_VALUE()`、`LEAD()`、`NTH_VALUE()`、`NTILE()`、`PERCENT_RANK()`、`RANK()` 和 `ROW_NUMBER()`。这些函数可以下推到 TiFlash。
-- [管理 Changefeed](https://docs.pingcap.com/tidb/stable/ticdc-manage-changefeed.md): 了解 Changefeed 相关的各种管理手段。
-- [管理 TiDB Data Migration 上游数据源](https://docs.pingcap.com/tidb/stable/dm-manage-source.md): 了解如何管理上游 MySQL 实例。
-- [管理 TiDB Data Migration 迁移表的表结构](https://docs.pingcap.com/tidb/stable/dm-manage-schema.md): 了解如何管理待迁移表在 DM 内部的表结构。
-- [管理资源消耗超出预期的查询 (Runaway Queries)](https://docs.pingcap.com/tidb/stable/tidb-resource-control-runaway-queries.md): 介绍如何通过资源管控能力来实现对资源消耗超出预期的语句 (Runaway Queries) 进行控制和降级。
-- [精度数学](https://docs.pingcap.com/tidb/stable/precision-math.md): TiDB 中的精确数值运算与 MySQL 基本一致。精确数值运算包括整型和 DECIMAL 类型，以及精确值数字字面量。DECIMAL 数据类型是定点数类型，其运算是精确计算。在表达式计算中，TiDB 会尽可能不做任何修改的使用每个输入的数值。数值修约时，`round()` 函数将使用四舍五入的规则。向 DECIMAL 或整数类型列插入数据时，round 的规则将采用 round half away from zero 的方式。
-- [系统变量](https://docs.pingcap.com/tidb/stable/system-variables.md): 使用 TiDB 系统变量来优化性能或修改运行行为。
-- [系统变量索引](https://docs.pingcap.com/tidb/stable/system-variable-reference.md): 查看 TiDB 所有的系统变量，以及引用这些变量的文档。
-- [索引推荐 (Index Advisor)](https://docs.pingcap.com/tidb/stable/index-advisor.md): 了解如何使用 TiDB 索引推荐 (Index Advisor) 功能优化查询性能。
-- [索引的最佳实践](https://docs.pingcap.com/tidb/stable/dev-guide-index-best-practice.md): 介绍 TiDB 中索引的最佳实践。
-- [索引的选择](https://docs.pingcap.com/tidb/stable/choose-index.md): 介绍 TiDB 如何选择索引去读入数据，以及相关的一些控制索引选择的方式。
-- [约束](https://docs.pingcap.com/tidb/stable/constraints.md): TiDB 支持的约束与 MySQL 基本相同，包括非空约束和 CHECK 约束。非空约束规则与 MySQL 相同，而 CHECK 约束需要在 tidb_enable_check_constraint 设置为 ON 后才能开启。可以通过 CREATE TABLE 或 ALTER TABLE 语句添加 CHECK 约束。唯一约束和主键约束也与 MySQL 相似，但 TiDB 目前仅支持对 NONCLUSTERED 的主键进行添加和删除操作。外键约束从 v6.6.0 开始支持，可以使用 CREATE TABLE 和 ALTER TABLE 命令来添加和删除外键。
-- [结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-jinaai-embedding.md): 了解如何结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索，以存储向量嵌入信息并执行语义搜索。
-- [结果集不稳定](https://docs.pingcap.com/tidb/stable/dev-guide-unstable-result-set.md): 结果集不稳定错误的处理办法。
-- [缓存表](https://docs.pingcap.com/tidb/stable/cached-tables.md): 了解 TiDB 中的缓存表功能，用于很少被修改的热点小表，提升读性能。
-- [聚合 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-aggregate.md): 了解聚合 JSON 值的 JSON 函数。
-- [聚簇索引](https://docs.pingcap.com/tidb/stable/clustered-indexes.md): 本文档介绍了聚簇索引的概念、使用场景、使用方法、限制和兼容性。
-- [自定义监控组件的配置](https://docs.pingcap.com/tidb/stable/customized-montior-in-tiup-environment.md): 了解如何自定义 TiUP 管理的监控组件的配置。
-- [表属性](https://docs.pingcap.com/tidb/stable/table-attributes.md): 介绍 TiDB 的 `ATTRIBUTES` 使用方法。
-- [表库过滤](https://docs.pingcap.com/tidb/stable/table-filter.md): 在 TiDB 数据迁移工具中使用表库过滤功能。
-- [表达式求值的类型转换](https://docs.pingcap.com/tidb/stable/type-conversion-in-expression-evaluation.md): TiDB 中的表达式求值类型转换与 MySQL 基本一致。详情请参见 MySQL 表达式求值类型转换文档。
-- [表达式语法](https://docs.pingcap.com/tidb/stable/expression-syntax.md): 本文列出 TiDB 的表达式语法。
-- [视图](https://docs.pingcap.com/tidb/stable/dev-guide-use-views.md): 介绍 TiDB 中的视图功能。
-- [视图](https://docs.pingcap.com/tidb/stable/views.md): TiDB 支持视图，视图是虚拟表，结构由创建时的 SELECT 语句定义。使用视图可保证数据安全，简化复杂查询。查询视图类似查询表，TiDB 执行查询时会展开视图。可通过 SHOW CREATE TABLE 或 SHOW CREATE VIEW 查看视图创建语句及相关信息。也可查询 INFORMATION_SCHEMA.VIEWS 表或访问 HTTP API 获取视图元信息。视图有局限性，不支持物化视图，且为只读视图，不支持写入操作。已创建的视图仅支持 DROP 操作。
-- [访问 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-access.md): TiDB Dashboard 可通过浏览器访问，支持多 PD 实例访问。浏览器兼容性包括 Chrome、Firefox 和 Edge。登录界面可使用 root 用户或自定义 SQL 用户登录。支持简体中文和英文语言切换。可在用户页面登出当前用户。
-- [读写延迟增加](https://docs.pingcap.com/tidb/stable/troubleshoot-cpu-issues.md): 介绍读写延时增加、抖动时的排查思路，可能的原因和解决方法。
-- [谓词下推](https://docs.pingcap.com/tidb/stable/predicate-push-down.md): TiDB 逻辑优化规则中的谓词下推旨在尽早完成数据过滤，减少数据传输或计算的开销。谓词下推适用于将过滤表达式计算下推到数据源，如示例 1、2、3。但对于存储层不支持的谓词、外连接中的谓词和包含用户变量的谓词则不能下推。
-- [资源管控 (Resource Control) 监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-resource-control-dashboard.md): 了解资源管控 (Resource Control) 的 Grafana Dashboard 中所展示的关键指标。
-- [跨数据中心部署拓扑](https://docs.pingcap.com/tidb/stable/geo-distributed-deployment-topology.md): 介绍跨数据中心部署 TiDB 集群的拓扑结构。
-- [迁移使用 GH-ost/PT-osc 的源数据库](https://docs.pingcap.com/tidb/stable/feature-online-ddl.md): 使用 GH-ost/PT-osc 进行在线 DDL 工具执行 DDL 时，会产生锁表操作，阻塞数据库读写。为降低影响，可选择在线 DDL 工具 gh-ost 和 pt-osc。在 DM 迁移 MySQL 到 TiDB 时，可开启 `online-ddl` 配置，实现 DM 工具与 gh-ost 或 pt-osc 的协同。 DM 与 online DDL 工具协作细节包括 gh-ost 和 pt-osc 的实现过程，以及自定义规则配置。
-- [迁移升级 TiDB 集群](https://docs.pingcap.com/tidb/stable/tidb-upgrade-migration-guide.md): 本文介绍如何使用 BR 全量备份恢复与 TiCDC 增量数据同步实现 TiDB 集群的迁移升级。
-- [迁移常见问题](https://docs.pingcap.com/tidb/stable/migration-tidb-faq.md): 介绍 TiDB 迁移中的常见问题。
-- [返回 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-return.md): 了解返回 JSON 值的 JSON 函数。
-- [连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-connect-to-tidb.md): 介绍连接到 TiDB 的方法。
-- [连接池与连接参数](https://docs.pingcap.com/tidb/stable/dev-guide-connection-parameters.md): 针对开发者的 TiDB 连接池与连接参数的说明。
-- [选择驱动或 ORM 框架](https://docs.pingcap.com/tidb/stable/dev-guide-choose-driver-or-orm.md): 选择驱动或 ORM 框架连接 TiDB。
-- [通过 SQL 表达式过滤 DML](https://docs.pingcap.com/tidb/stable/feature-expression-filter.md): 增量数据迁移时可通过 SQL 表达式过滤 binlog event，例如不向下游迁移 `DELETE` 事件。从 v2.0.5 起，DM 支持使用 `binlog value filter` 过滤迁移数据。在 `ROW` 格式的 binlog 中，可以基于列的值配置 SQL 表达式。如果表达式结果为 `TRUE`，DM 就不会向下游迁移该条行变更。具体操作步骤和实现细节，请参考如何通过 SQL 表达式过滤 DML。
-- [通过 TiUP 部署 DM 集群的拓扑文件配置](https://docs.pingcap.com/tidb/stable/tiup-dm-topology-reference.md): TiUP 部署 DM 集群的拓扑文件配置包括全局配置、组件配置、master 服务器配置、worker 服务器配置、监控服务器配置、Grafana 服务器配置和 Alertmanager 服务器配置。每个配置包含不同字段，如部署目录、数据目录、日志目录等。部署完成后部分字段不能再修改。
-- [通过 TiUP 部署 TiDB 集群的拓扑文件配置](https://docs.pingcap.com/tidb/stable/tiup-cluster-topology-reference.md): 介绍通过 TiUP 部署或扩容 TiDB 集群时提供的拓扑文件配置和示例。
-- [通过反向代理使用 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-ops-reverse-proxy.md): TiDB Dashboard 可通过反向代理安全提供给外部网络。首先获取实际地址，然后配置反向代理，最后修改路径前缀。详细步骤可参考官方文档。
-- [通过拓扑 label 进行副本调度](https://docs.pingcap.com/tidb/stable/schedule-replicas-by-topology-labels.md): TiDB v5.3.0 引入了通过拓扑 label 进行副本调度的功能。为了提升集群的高可用性和数据容灾能力，推荐让 TiKV 节点在物理层面上尽可能分散。通过设置 TiKV 和 TiFlash 的 labels，可以标识它们的地理位置。同时，需要配置 PD 的 location-labels 和 isolation-level 来使 PD 理解 TiKV 节点拓扑并加强拓扑隔离要求。PD 在副本调度时会保证同一份数据的不同副本尽可能分散，以提高集群容灾能力。
-- [通过系统变量 `tidb_external_ts` 读取历史数据](https://docs.pingcap.com/tidb/stable/tidb-external-ts.md): 了解如何通过系统变量 `tidb_external_ts` 读取历史数据。
-- [通过系统变量 `tidb_read_staleness` 读取历史数据](https://docs.pingcap.com/tidb/stable/tidb-read-staleness.md): 了解如何通过系统变量 `tidb_read_staleness` 读取历史数据。
-- [通过系统变量 tidb_snapshot 读取历史数据](https://docs.pingcap.com/tidb/stable/read-historical-data.md): 本文介绍了通过系统变量 `tidb_snapshot` 读取历史数据的操作流程和历史数据的保留策略。TiDB 实现了通过标准 SQL 接口读取历史数据功能，无需特殊的 client 或者 driver。当数据被更新、删除后，依然可以通过 SQL 接口将更新 / 删除前的数据读取出来。历史数据保留策略使用 MVCC 管理版本，超过一定时间的历史数据会被彻底删除，以减小空间占用以及避免历史版本过多引入的性能开销。
-- [逻辑优化](https://docs.pingcap.com/tidb/stable/sql-logical-optimization.md): 本章节介绍了 TiDB 查询计划的关键逻辑改写，包括子查询优化、列裁剪、关联子查询去关联、Max/Min 消除、谓词下推、分区裁剪、TopN 和 Limit 下推以及 Join 重排序。这些改写帮助 TiDB 生成最终的查询计划，提高查询效率。
-- [逻辑导入模式简介](https://docs.pingcap.com/tidb/stable/tidb-lightning-logical-import-mode.md): 了解 TiDB Lightning 的逻辑导入模式 (Logical Import Mode)。
-- [遥测](https://docs.pingcap.com/tidb/stable/telemetry.md): 介绍遥测的场景，如何禁用功能和查看遥测状态。
-- [避免隐式类型转换](https://docs.pingcap.com/tidb/stable/dev-guide-implicit-type-conversion.md): 介绍 TiDB 中隐式类型转换可能会带来的后果和避免方法。
-- [部署 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-ops-deploy.md): TiDB Dashboard 是内置于 TiDB 4.0 或更高版本的 PD 组件中的界面，无需额外部署。对于 TiDB v6.5.0 及 TiDB Operator v1.4.0 之后的版本，在 Kubernetes 上支持将 TiDB Dashboard 作为独立的 Pod 部署。部署标准 TiDB 集群的文档可参考快速试用 TiDB 集群、生产环境部署和 Kubernetes 环境部署。当集群中部署了多个 PD 实例时，仅有一个 PD 实例会提供 TiDB Dashboard 服务。可通过 TiUP 查看实际运行 TiDB Dashboard 服务的 PD 实例，并切换其他 PD 实例提供 TiDB Dashboard 服务。也可以禁用和重新启用 TiDB Dashboard。
-- [部署 TiDB Lightning](https://docs.pingcap.com/tidb/stable/deploy-tidb-lightning.md): 了解如何部署 TiDB Lightning，包括在线部署和离线部署。
-- [配置 TiDB Dashboard 使用 SSO 登录](https://docs.pingcap.com/tidb/stable/dashboard-session-sso.md): 了解如何配置 TiDB Dashboard 启用 SSO 登录。
-- [锁函数](https://docs.pingcap.com/tidb/stable/locking-functions.md): 了解 TiDB 中的用户级锁函数。
-- [错误码与故障诊断](https://docs.pingcap.com/tidb/stable/error-codes.md): TiDB 错误码包括 MySQL 兼容的错误码和 TiDB 特有的错误码。如果遇到错误码，请参考官方文档或社区获取支持。常见错误码包括内存使用超限、写入冲突、表数据损坏、事务过大、写入冲突等。另外，TiDB 还提供了故障诊断文档供参考。
-- [错误索引的解决方案](https://docs.pingcap.com/tidb/stable/wrong-index-solution.md): 了解如何处理错误索引问题。
-- [集合运算](https://docs.pingcap.com/tidb/stable/set-operators.md): 了解 TiDB 支持的集合运算。
-- [集群监控部署](https://docs.pingcap.com/tidb/stable/deploy-monitoring-services.md): 本文适用于手动部署 TiDB 监控报警系统的用户。假设 TiDB 的拓扑结构如下：Node1 主机 IP 为 192.168.199.113，服务包括 PD1、TiDB、node_export、Prometheus、Grafana；Node2 主机 IP 为 192.168.199.114，服务包括 PD2、node_export；Node3 主机 IP 为 192.168.199.115，服务包括 PD3、node_export；Node4 主机 IP 为 192.168.199.116，服务包括 TiKV1、node_export；Node5 主机 IP 为 192.168.199.117，服务包括 TiKV2、node_export；Node6 主机 IP 为 192.168.199.118，服务包括 TiKV3、node_export。具体部署步骤包括下载二进制包、启动 node_exporter 服务、启动 Prometheus 服务、启动 Grafana 服务、配置 Grafana 数据源和导入 Grafana 面板。可查看 TiDB Server、PD Server 和 TiKV Server 的监控信息。
-- [静态加密](https://docs.pingcap.com/tidb/stable/encryption-at-rest.md): 了解如何启用静态加密功能保护敏感数据。
-- [非 Prepare 语句执行计划缓存](https://docs.pingcap.com/tidb/stable/sql-non-prepared-plan-cache.md): 介绍 TiDB 中非 Prepare 语句执行计划缓存的原理、使用方法及示例。
-- [非事务 DML 语句](https://docs.pingcap.com/tidb/stable/non-transactional-dml.md): 以事务的原子性和隔离性为代价，将 DML 语句拆成多个语句依次执行，用以提升批量数据处理场景的稳定性和易用性。
-- [预处理语句](https://docs.pingcap.com/tidb/stable/dev-guide-prepared-statement.md): 介绍 TiDB 的预处理语句功能。
-- [验证 JSON 文档的函数](https://docs.pingcap.com/tidb/stable/json-functions-validate.md): 了解验证 JSON 文档的函数。
-- [验证集群运行状态](https://docs.pingcap.com/tidb/stable/post-installation-check.md): 介绍如何验证集群运行状态。
-- [高可用常见问题](https://docs.pingcap.com/tidb/stable/high-availability-faq.md): 介绍高可用相关的常见问题。
-- [高可靠常见问题](https://docs.pingcap.com/tidb/stable/high-reliability-faq.md): 介绍高可靠相关的常见问题。
+- [三节点混合部署最佳实践](https://docs.pingcap.com/zh/tidb/stable/three-nodes-hybrid-deployment.md): 了解三节点混合部署最佳实践。
+- [上游使用 pt-osc/gh-ost 工具的持续同步场景](https://docs.pingcap.com/zh/tidb/stable/migrate-with-pt-ghost.md): 介绍在使用 DM 持续增量数据同步，上游使用 pt-osc/gh-ost 工具进行在线 DDL 变更时 DM 的处理方式和注意事项。
+- [下推到 TiKV 的表达式列表](https://docs.pingcap.com/zh/tidb/stable/expressions-pushed-down.md): TiDB 中下推到 TiKV 的表达式列表及相关设置。
+- [下推计算结果缓存](https://docs.pingcap.com/zh/tidb/stable/coprocessor-cache.md): TiDB 4.0 支持下推计算结果缓存，配置位于 `tikv-client.copr-cache`，缓存仅存储在 TiDB 内存中，不共享缓存，对 Region 写入会导致缓存失效。缓存命中率可通过 `EXPLAIN ANALYZE` 或 Grafana 监控面板查看。
+- [下游存在更多列的迁移场景](https://docs.pingcap.com/zh/tidb/stable/migrate-with-more-columns-downstream.md): 介绍下游存在更多列的迁移场景。
+- [不同库名或表名的数据校验](https://docs.pingcap.com/zh/tidb/stable/route-diff.md): TiDB DM 等同步工具可以使用 route-rules 设置数据同步到下游指定表中。sync-diff-inspector 通过设置 rules 提供了校验不同库名、表名的表的功能。可以通过 rules 设置映射关系来简化配置，校验大量的不同库名或者表名的表。表路由的初始化和示例包括规则中存在 target-schema/target-table 表名为 schema.table 的行为，规则中只存在 target-schema 的行为，以及规则中不存在 target-schema.target-table 的行为。
+- [与 Apache Kafka 和 Apache Flink 进行数据集成](https://docs.pingcap.com/zh/tidb/stable/replicate-data-to-kafka.md): 了解如何使用 TiCDC 从 TiDB 同步数据至 Apache Kafka 和 Apache Flink。
+- [与 Confluent Cloud 和 Snowflake 进行数据集成](https://docs.pingcap.com/zh/tidb/stable/integrate-confluent-using-ticdc.md): 了解如何使用 TiCDC 从 TiDB 同步数据至 Confluent Cloud 以及 Snowflake、ksqlDB、SQL Server。
+- [与 MySQL 兼容性对比](https://docs.pingcap.com/zh/tidb/stable/mysql-compatibility.md): 本文对 TiDB 和 MySQL 二者之间从语法和功能特性上做出详细的对比。
+- [与 MySQL 安全特性差异](https://docs.pingcap.com/zh/tidb/stable/security-compatibility-with-mysql.md): TiDB 支持与 MySQL 5.7 类似的安全特性，同时也支持 MySQL 8.0 的部分安全特性。然而，在实现上存在一些差异，包括不支持列级别权限设置和部分权限属性。此外，TiDB 的密码过期策略和密码复杂度策略与 MySQL 存在一些差异。另外，TiDB 支持多种身份验证方式，包括 TLS 证书和 JWT。
+- [临时表](https://docs.pingcap.com/zh/tidb/stable/dev-guide-use-temporary-tables.md): 介绍 TiDB 临时表创建、删除、限制。
+- [临时表](https://docs.pingcap.com/zh/tidb/stable/temporary-tables.md): 了解 TiDB 中的临时表功能，使用临时表存储业务中间数据，减少表管理开销，并提升性能。
+- [为 DM 的连接开启加密传输](https://docs.pingcap.com/zh/tidb/stable/dm-enable-tls.md): 了解如何为 DM 的连接开启加密传输。
+- [为 TiDB 客户端服务端间通信开启加密传输](https://docs.pingcap.com/zh/tidb/stable/enable-tls-between-clients-and-servers.md): TiDB 服务端与客户端间默认采用非加密连接，容易造成信息泄露。建议使用加密连接确保安全性。要开启 TLS 加密传输，需要在服务端配置开启 TLS 支持，并在客户端应用程序中配置使用 TLS 加密连接。可以通过配置系统变量或在创建 / 修改用户时指定要求加密连接。可通过命令检查当前连接是否是加密连接。TLS 版本为 TLSv1.2 和 TLSv1.3，支持的加密算法包括 AES 和 CHACHA20_POLY1305。
+- [为 TiDB 组件间通信开启加密传输](https://docs.pingcap.com/zh/tidb/stable/enable-tls-between-components.md): 了解如何为 TiDB 集群内各组件间开启加密传输。
+- [为 TiDB 落盘文件开启加密](https://docs.pingcap.com/zh/tidb/stable/enable-disk-spill-encrypt.md): 了解如何为 TiDB 落盘文件开启加密。
+- [主从集群一致性读和数据校验](https://docs.pingcap.com/zh/tidb/stable/ticdc-upstream-downstream-check.md): TiCDC 提供了 Syncpoint 功能，通过利用 TiDB 的 snapshot 特性，在同步过程中维护了一个上下游具有一致性 snapshot 的 `ts-map`。启用 Syncpoint 功能后，可以进行一致性快照读和数据一致性校验。要开启 Syncpoint 功能，只需在创建同步任务时把 TiCDC 的配置项 `enable-sync-point` 设置为 `true`。通过配置 `snapshot` 可以对 TiDB 主从集群的数据进行校验。
+- [乐观事务和悲观事务](https://docs.pingcap.com/zh/tidb/stable/dev-guide-optimistic-and-pessimistic-transaction.md): 介绍 TiDB 中的乐观事务和悲观事务，乐观事务的重试等。
+- [乐观事务模型下写写冲突问题排查](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-write-conflicts.md): 介绍 TiDB 中乐观锁下写写冲突出现的原因以及解决方案。
+- [乐观模式下分库分表合并迁移](https://docs.pingcap.com/zh/tidb/stable/feature-shard-merge-optimistic.md): 介绍 DM 提供的乐观模式下分库分表的合并迁移功能。
+- [事务概览](https://docs.pingcap.com/zh/tidb/stable/dev-guide-transaction-overview.md): 简单介绍 TiDB 中的事务。
+- [事务错误处理](https://docs.pingcap.com/zh/tidb/stable/dev-guide-transaction-troubleshoot.md): 介绍 TiDB 中的事务错误处理办法。
+- [事务限制](https://docs.pingcap.com/zh/tidb/stable/dev-guide-transaction-restraints.md): 介绍 TiDB 中的事务限制。
+- [从 Amazon Aurora 迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-aurora-to-tidb.md): 介绍如何使用快照从 Amazon Aurora 迁移数据到 TiDB。
+- [从 CSV 文件迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-from-csv-files-to-tidb.md): 介绍如何从 CSV 等文件迁移数据到 TiDB。
+- [从 MariaDB 文件迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-from-mariadb.md): 介绍如何将数据从 MariaDB 文件迁移数据到 TiDB。
+- [从 Parquet 文件迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-from-parquet-files-to-tidb.md): 介绍如何使用 TiDB Lightning 从 Parquet 文件迁移数据到 TiDB。
+- [从 SQL 文件迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-from-sql-files-to-tidb.md): 介绍如何使用 TiDB Lightning 从 MySQL SQL 文件迁移数据到 TiDB。
+- [从 TiDB 集群迁移数据至兼容 MySQL 的数据库](https://docs.pingcap.com/zh/tidb/stable/migrate-from-tidb-to-mysql.md): 了解如何将数据从 TiDB 集群迁移至与 MySQL 兼容的数据库。
+- [从 TiDB 集群迁移数据至另一 TiDB 集群](https://docs.pingcap.com/zh/tidb/stable/migrate-from-tidb-to-tidb.md): 了解如何将数据从一个 TiDB 集群迁移至另一 TiDB 集群。
+- [从 Vitess 迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-from-vitess.md): 介绍从 Vitess 迁移数据到 TiDB 所使用的工具。
+- [从大数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-large-mysql-to-tidb.md): 介绍如何从大数据量 MySQL 迁移数据到 TiDB。
+- [从大数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-large-mysql-shards-to-tidb.md): 使用 Dumpling 和 TiDB Lightning 合并导入分表数据到 TiDB，以及如何使用 DM 持续增量复制数据。本文介绍的方法适用于导入数据总量大于 1 TiB 的场景。
+- [从小数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-small-mysql-to-tidb.md): 介绍如何从小数据量 MySQL 迁移数据到 TiDB。
+- [从小数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/zh/tidb/stable/migrate-small-mysql-shards-to-tidb.md): 介绍如何从 TB 级以下分库分表 MySQL 迁移数据到 TiDB。
+- [从窗口函数中推导 TopN 或 Limit](https://docs.pingcap.com/zh/tidb/stable/derive-topn-from-window.md): 介绍从窗口函数中推导 TopN 或 Limit 的优化规则，以及如何开启该规则。
+- [代价模型](https://docs.pingcap.com/zh/tidb/stable/cost-model.md): 介绍 TiDB 进行物理优化时所使用的代价模型的原理。
+- [优化向量搜索性能](https://docs.pingcap.com/zh/tidb/stable/vector-search-improve-performance.md): 了解优化 TiDB 向量搜索性能的最佳实践。
+- [优化规则与表达式下推的黑名单](https://docs.pingcap.com/zh/tidb/stable/blocklist-control-plan.md): 了解优化规则与表达式下推的黑名单。
+- [位函数和操作符](https://docs.pingcap.com/zh/tidb/stable/bit-functions-and-operators.md): TiDB 支持 MySQL 8.0 中的所有位函数和操作符。
+- [使用 AS OF TIMESTAMP 语法读取历史数据](https://docs.pingcap.com/zh/tidb/stable/as-of-timestamp.md): 了解如何使用 AS OF TIMESTAMP 语法读取历史数据。
+- [使用 Django 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-python-django.md): 了解如何使用 Django 连接到 TiDB。本文提供了使用 Django 与 TiDB 交互的 Python 示例代码片段。
+- [使用 DM binary 部署 DM 集群](https://docs.pingcap.com/zh/tidb/stable/deploy-a-dm-cluster-using-binary.md): 本文介绍了如何使用 DM binary 快速部署 DM 集群。首先需要下载 DM 安装包，然后在五台服务器上部署两个 DM-worker 实例和三个 DM-master 实例。对于 DM-master 的部署，可以使用命令行参数或配置文件两种方式。而对于 DM-worker 的部署，也可以使用命令行参数或配置文件两种方式。部署完成后，需要确保各组件间端口可正常连通。
+- [使用 DM 迁移数据](https://docs.pingcap.com/zh/tidb/stable/migrate-data-using-dm.md): 本文介绍如何使用 DM 工具迁移数据。首先部署 DM 集群，然后检查集群信息和创建数据源。配置任务后，启动任务并查询任务状态。最后，停止任务并监控任务与查看日志。
+- [使用 dmctl 运维 TiDB Data Migration 集群](https://docs.pingcap.com/zh/tidb/stable/dmctl-introduction.md): 了解如何使用 dmctl 运维 DM 集群。
+- [使用 Dumpling 和 TiDB Lightning 备份与恢复](https://docs.pingcap.com/zh/tidb/stable/backup-and-restore-using-dumpling-lightning.md): 了解如何使用 Dumpling 和 TiDB Lightning 备份与恢复集群数据。
+- [使用 Dumpling 导出数据](https://docs.pingcap.com/zh/tidb/stable/dumpling-overview.md): 使用 Dumpling 从 TiDB 导出数据。
+- [使用 EXPLAIN 解读执行计划](https://docs.pingcap.com/zh/tidb/stable/explain-walkthrough.md): 通过示例了解如何使用 EXPLAIN 分析执行计划。
+- [使用 FastScan 功能](https://docs.pingcap.com/zh/tidb/stable/use-fastscan.md): 介绍通过使用 FastScan 来加速 OLAP 场景的查询的方法。
+- [使用 Go-MySQL-Driver 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-golang-sql-driver.md): 了解如何使用 Go-MySQL-Driver 连接到 TiDB。本文提供了使用 Go-MySQL-Driver 与 TiDB 交互的 Golang 示例代码片段。
+- [使用 GORM 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-golang-gorm.md): 了解如何使用 GORM 连接到 TiDB。本文提供了使用 GORM 与 TiDB 交互的 Golang 示例代码片段。
+- [使用 Grafana 监控 TiDB 的最佳实践](https://docs.pingcap.com/zh/tidb/stable/grafana-monitor-best-practices.md): 了解高效利用 Grafana 监控 TiDB 的七个技巧。
+- [使用 Hibernate 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-java-hibernate.md): 了解如何使用 Hibernate 连接到 TiDB。本文提供了使用 Hibernate 与 TiDB 交互的 Java 示例代码片段。
+- [使用 JDBC 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-java-jdbc.md): 了解如何使用 JDBC 连接到 TiDB。本文提供了使用 JDBC 与 TiDB 交互的 Java 示例代码片段。
+- [使用 MPP 模式](https://docs.pingcap.com/zh/tidb/stable/use-tiflash-mpp-mode.md): 了解如何使用 MPP 模式。
+- [使用 MyBatis 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-java-mybatis.md): 了解如何使用 MyBatis 连接到 TiDB。本文提供了使用 MyBatis 与 TiDB 交互的 Java 示例代码片段。
+- [使用 MySQL Connector/Python 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-python-mysql-connector.md): 了解如何使用 MySQL Connector/Python 连接到 TiDB。本文提供了使用 MySQL Connector/Python 与 TiDB 交互的 Python 示例代码片段。
+- [使用 MySQL Workbench 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-gui-mysql-workbench.md): 了解如何使用 MySQL Workbench 连接到 TiDB。
+- [使用 mysql.js 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-nodejs-mysqljs.md): 本文描述了 TiDB 和 mysql.js 的连接步骤，并给出了简单示例代码片段。
+- [使用 mysql2 连接 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-ruby-mysql2.md): 本文描述了 TiDB 和 mysql2 的连接步骤，并给出了使用 mysql2 gem 连接 TiDB 的简单示例代码片段。
+- [使用 mysqlclient 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-python-mysqlclient.md): 了解如何使用 mysqlclient 连接到 TiDB。本文提供了使用 mysqlclient 与 TiDB 交互的 Python 示例代码片段。
+- [使用 Navicat 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-gui-navicat.md): 了解如何使用 Navicat 连接到 TiDB。
+- [使用 node-mysql2 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-nodejs-mysql2.md): 本文描述了 TiDB 和 node-mysql2 的连接步骤，并给出了简单示例代码片段。
+- [使用 OpenAPI 运维 TiDB Data Migration 集群](https://docs.pingcap.com/zh/tidb/stable/dm-open-api.md): 了解如何使用 OpenAPI 接口来管理 DM 集群状态和数据同步。
+- [使用 peewee 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-python-peewee.md): 了解如何使用 peewee 连接到 TiDB。本文提供了使用 peewee 与 TiDB 交互的 Python 示例代码片段。
+- [使用 PingCAP Clinic Diag 采集 SQL 查询计划信息](https://docs.pingcap.com/zh/tidb/stable/clinic-collect-sql-query-plan.md): 了解如何使用 PingCAP Clinic Diag 采集 TiUP 部署集群的 SQL 查询计划信息。
+- [使用 PingCAP Clinic 生成诊断报告](https://docs.pingcap.com/zh/tidb/stable/clinic-report.md): 介绍 PingCAP Clinic 诊断报告的使用场景、方法以及如何解读报告。
+- [使用 PingCAP Clinic 诊断集群](https://docs.pingcap.com/zh/tidb/stable/clinic-user-guide-for-tiup.md): 详细介绍在使用 TiUP 部署的 TiDB 集群或 DM 集群上如何通过 PingCAP Clinic 诊断服务远程定位集群问题和本地快速检查集群状态。
+- [使用 PLAN REPLAYER 保存和恢复集群现场信息](https://docs.pingcap.com/zh/tidb/stable/sql-plan-replayer.md): 了解如何使用 PLAN REPLAY 命令保存和恢复集群现场信息。
+- [使用 Prisma 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-nodejs-prisma.md): 本文描述了 TiDB 和 Prisma 的连接步骤，并给出了简单示例代码片段。
+- [使用 PyMySQL 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-python-pymysql.md): 了解如何使用 PyMySQL 连接到 TiDB。本文提供了使用 PyMySQL 与 TiDB 交互的 Python 示例代码片段。
+- [使用 Python 开始向量搜索](https://docs.pingcap.com/zh/tidb/stable/vector-search-get-started-using-python.md): 了解如何使用 Python 和 TiDB 向量搜索快速开发可执行语义搜索的人工智能应用程序。
+- [使用 Rails 框架和 ActiveRecord ORM 连接 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-ruby-rails.md): 本文描述了 TiDB 和 Rails 框架的连接步骤，并给出了使用 Rails 框架和 ActiveRecord ORM 连接 TiDB 的简单示例代码片段。
+- [使用 Sequelize 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-nodejs-sequelize.md): 本文描述了 TiDB 和 Sequelize 的连接步骤，并给出了简单示例代码片段。
+- [使用 Spring Boot 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-java-spring-boot.md): 了解如何使用 Spring Boot 连接到 TiDB。本文提供了使用 Spring Boot 与 TiDB 交互的 Java 示例代码片段。
+- [使用 SQL 开始向量搜索](https://docs.pingcap.com/zh/tidb/stable/vector-search-get-started-using-sql.md): 了解如何在 TiDB 中使用 SQL 语句快速开始向量搜索，从而为你的生成式 AI 应用提供支持。
+- [使用 SQLAlchemy 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-python-sqlalchemy.md): 了解如何使用 SQLAlchemy 连接到 TiDB。本文提供了使用 SQLAlchemy 与 TiDB 交互的 Python 示例代码片段。
+- [使用 TiDB Cloud Serverless 构建 TiDB 集群](https://docs.pingcap.com/zh/tidb/stable/dev-guide-build-cluster-in-cloud.md): 使用 TiDB Cloud Serverless 构建 TiDB 集群，并连接 TiDB Cloud Serverless 集群。
+- [使用 TiDB Dashboard 诊断报告定位问题](https://docs.pingcap.com/zh/tidb/stable/dashboard-diagnostics-usage.md): 本文介绍了使用 TiDB Dashboard 诊断报告定位问题的方法。通过对比两个时间段的监控项差异来帮助 DBA 定位问题。示例中展示了大查询/写入导致 QPS 抖动或延迟上升的诊断方法，以及如何用对比报告定位问题。对比报告可以帮助 DBA 更快速地定位问题，例如通过查看监控项的差异大小排序来发现异常。通过对比报告定位问题，可以更准确地诊断可能的慢查询和影响查询执行的负载。
+- [使用 TiDB Data Migration 处理出错的 DDL 语句](https://docs.pingcap.com/zh/tidb/stable/handle-failed-ddl-statements.md): 了解在使用 TiDB Data Migration 迁移数据时，如何处理出错的 DDL 语句。
+- [使用 TiDB 的增删改查 SQL](https://docs.pingcap.com/zh/tidb/stable/dev-guide-tidb-crud-sql.md): 简单介绍 TiDB 的增删改查 SQL。
+- [使用 TiDB 读取 TiFlash](https://docs.pingcap.com/zh/tidb/stable/use-tidb-to-read-tiflash.md): 了解如何使用 TiDB 读取 TiFlash 副本。
+- [使用 TiSpark 读取 TiFlash](https://docs.pingcap.com/zh/tidb/stable/use-tispark-to-read-tiflash.md): 了解如何使用 TiSpark 读取 TiFlash。
+- [使用 TiUP bench 组件压测 TiDB](https://docs.pingcap.com/zh/tidb/stable/tiup-bench.md): TiUP bench 组件集成了多种压测 workloads，包括 TPC-C、TPC-H、CH-benCHmark、YCSB 和自定义 SQL 文件。每种压测都有对应的命令和参数，可以通过 TiUP 运行。TPC-C 测试包括准备数据、运行测试、检查一致性和清理数据等步骤。TPC-H 测试也有类似的步骤，包括准备数据、运行测试和清理数据。YCSB 测试可以分别针对 TiDB 和 TiKV 节点进行，包括准备数据和运行测试。此外，还可以通过 RawSQL 文件进行测试，包括准备数据和执行查询。
+- [使用 TiUP no-sudo 模式部署运维 TiDB 线上集群](https://docs.pingcap.com/zh/tidb/stable/tiup-cluster-no-sudo-mode.md): 了解如何使用 TiUP no-sudo 模式部署运维 TiDB 线上集群。
+- [使用 TiUP 升级 TiDB](https://docs.pingcap.com/zh/tidb/stable/upgrade-tidb-using-tiup.md): TiUP 可用于 TiDB 升级。升级过程中需注意不支持 TiFlash 组件从 5.3 之前的老版本在线升级至 5.3 及之后的版本，只能采用停机升级。在升级过程中，不要执行 DDL 语句，避免出现行为未定义的问题。升级前需查看集群中是否有正在进行的 DDL Job，并等待其完成或取消后再进行升级。升级完成后，可使用 TiUP 安装对应版本的 `ctl` 组件来更新相关工具版本。
+- [使用 TiUP 命令管理组件](https://docs.pingcap.com/zh/tidb/stable/tiup-component-management.md): TiUP 是一个用于管理组件的命令行工具。它提供了一系列命令来查询组件列表、安装、升级、运行、查看状态、清理实例和卸载组件。此外，还可以使用实验性的 `link` 和 `unlink` 命令来将组件的二进制符号链接到可执行文件目录。
+- [使用 TiUP 扩容缩容 PD 微服务节点](https://docs.pingcap.com/zh/tidb/stable/scale-microservices-using-tiup.md): 介绍如何使用 TiUP 扩容缩容集群中的 PD 微服务节点，以及如何切换 PD 工作模式。
+- [使用 TiUP 扩容缩容 TiDB 集群](https://docs.pingcap.com/zh/tidb/stable/scale-tidb-using-tiup.md): TiUP 可以在不中断线上服务的情况下扩容和缩容 TiDB 集群。使用 `tiup cluster list` 查看当前集群名称列表。扩容 TiDB/PD/TiKV 节点需要编写扩容拓扑配置，并执行扩容命令。扩容后，使用 `tiup cluster display <cluster-name>` 检查集群状态。缩容 TiDB/PD/TiKV 节点需要查看节点 ID 信息，执行缩容操作，然后检查集群状态。缩容 TiFlash/TiCDC 节点也需要执行相似的操作。
+- [使用 TiUP 离线镜像部署 DM 集群](https://docs.pingcap.com/zh/tidb/stable/deploy-a-dm-cluster-using-tiup-offline.md): 学习如何使用 TiUP DM 组件来离线部署 TiDB Data Migration 工具。
+- [使用 TiUP 运维 DM 集群](https://docs.pingcap.com/zh/tidb/stable/maintain-dm-using-tiup.md): 学习如何使用 TiUP 运维 DM 集群。
+- [使用 TiUP 部署 DM 集群](https://docs.pingcap.com/zh/tidb/stable/deploy-a-dm-cluster-using-tiup.md): 学习如何使用 TiUP DM 组件来部署 TiDB Data Migration 工具。
+- [使用 TiUP 部署 TiDB 集群](https://docs.pingcap.com/zh/tidb/stable/production-deployment-using-tiup.md): 了解如何使用 TiUP 部署 TiDB 集群。
+- [使用 TiUP 部署运维 TiDB 线上集群](https://docs.pingcap.com/zh/tidb/stable/tiup-cluster.md): 使用 TiUP 的 cluster 组件可以快速部署生产集群，并提供强大的生产集群管理功能，包括升级、缩容、扩容、操作、审计等。部署集群的命令为 tiup cluster deploy，部署完成后可以通过 tiup cluster list 查看集群列表。启动集群的命令为 tiup cluster start，查看集群状态的命令为 tiup cluster display。可以使用 tiup cluster scale-in 进行集群缩容，tiup cluster scale-out 进行集群扩容。另外，还可以使用 tiup cluster upgrade 进行滚动升级，使用 tiup cluster edit-config 进行配置更新。最后，可以使用 tiup cluster exec 在集群节点机器上执行命令。
+- [使用 TTL (Time to Live) 定期删除过期数据](https://docs.pingcap.com/zh/tidb/stable/time-to-live.md): Time to Live (TTL) 提供了行级别的生命周期控制策略。本篇文档介绍如何通过 TTL (Time to Live) 来管理表数据的生命周期。
+- [使用 TypeORM 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-nodejs-typeorm.md): 本文描述了 TiDB 和 TypeORM 的连接步骤，并给出了简单示例代码片段。
+- [使用 WebUI 管理 DM 迁移任务](https://docs.pingcap.com/zh/tidb/stable/dm-webui-guide.md): 学习如何使用 WebUI 来方便的管理数据迁移任务。
+- [使用物理导入模式](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-physical-import-mode-usage.md): 了解如何使用 TiDB Lightning 的物理导入模式。
+- [使用资源管控 (Resource Control) 实现资源组限制和流控](https://docs.pingcap.com/zh/tidb/stable/tidb-resource-control-ru-groups.md): 介绍如何通过资源管控能力来实现对应用资源消耗的控制和有效调度。
+- [使用资源管控 (Resource Control) 管理后台任务](https://docs.pingcap.com/zh/tidb/stable/tidb-resource-control-background-tasks.md): 介绍如何通过资源管控 (Resource Control) 控制后台任务。
+- [使用逻辑导入模式](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-logical-import-mode-usage.md): 了解在 TiDB Lightning 的逻辑导入模式下，如何编写数据导入任务的配置文件，如何进行性能调优等。
+- [信息函数](https://docs.pingcap.com/zh/tidb/stable/information-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分信息函数。
+- [修改 JSON 值的 JSON 函数](https://docs.pingcap.com/zh/tidb/stable/json-functions-modify.md): 了解修改 JSON 值的 JSON 函数。
+- [停止 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/zh/tidb/stable/dm-stop-task.md): 了解 TiDB Data Migration 如何停止数据迁移任务。
+- [元数据锁](https://docs.pingcap.com/zh/tidb/stable/metadata-lock.md): 介绍 TiDB 中元数据锁的概念、原理、实现和影响。
+- [公共表表达式 (CTE)](https://docs.pingcap.com/zh/tidb/stable/dev-guide-use-common-table-expression.md): 介绍 TiDB 公共表表达式能力，用以简化 SQL。
+- [关联子查询去关联](https://docs.pingcap.com/zh/tidb/stable/correlated-subquery-optimization.md): 了解如何给关联子查询解除关联。
+- [关键字](https://docs.pingcap.com/zh/tidb/stable/keywords.md): 本文介绍 TiDB 的关键字。
+- [其他函数](https://docs.pingcap.com/zh/tidb/stable/miscellaneous-functions.md): TiDB 支持使用 MySQL 8.0 中提供的大部分其他函数。
+- [函数和操作符概述](https://docs.pingcap.com/zh/tidb/stable/functions-and-operators-overview.md): TiDB 中的函数和操作符使用方法与 MySQL 基本一致。在 SQL 语句中，表达式可用于诸如 SELECT 语句的 ORDER BY 或 HAVING 子句，SELECT/DELETE/UPDATE 语句的 WHERE 子句，或 SET 语句之类的地方。可使用字面值，列名，NULL，内置函数，操作符等来书写表达式。其中有些表达式下推到 TiKV 上执行，详见下推到 TiKV 的表达式列表。
+- [分享 TiDB Dashboard 会话](https://docs.pingcap.com/zh/tidb/stable/dashboard-session-share.md): 了解如何将当前的 TiDB Dashboard 会话分享给其他用户访问。
+- [分区表](https://docs.pingcap.com/zh/tidb/stable/partitioned-table.md): 了解如何使用 TiDB 的分区表。
+- [分区裁剪](https://docs.pingcap.com/zh/tidb/stable/partition-pruning.md): 了解 TiDB 分区裁剪的使用场景。
+- [分库分表合并迁移](https://docs.pingcap.com/zh/tidb/stable/feature-shard-merge.md): DM 提供了分库分表的合并迁移功能，可将上游 MySQL/MariaDB 实例中的表迁移到下游 TiDB 的同一个表中。支持悲观协调和乐观协调两种模式。悲观模式保证数据不出错，但可能会阻塞迁移；乐观模式处理 DDL 时不会阻塞数据迁移，但可能导致数据不一致。
+- [分库分表场景下的数据校验](https://docs.pingcap.com/zh/tidb/stable/shard-diff.md): sync-diff-inspector 支持对分库分表场景进行数据校验。使用 Datasource config 进行配置，设置对应 rules，配置上游表与下游表的映射关系。当上游分表较多且符合一定规则时，可以使用 table-rules 进行配置。注意事项：如果上游数据库有 test.table-0 也会被下游数据库匹配到。
+- [分析慢查询](https://docs.pingcap.com/zh/tidb/stable/analyze-slow-queries.md): 学习如何定位和分析慢查询。
+- [分表合并数据迁移最佳实践](https://docs.pingcap.com/zh/tidb/stable/shard-merge-best-practices.md): 使用 DM 对分库分表进行合并迁移时的最佳实践。
+- [分页查询](https://docs.pingcap.com/zh/tidb/stable/dev-guide-paginate-results.md): 介绍 TiDB 的分页查询功能。
+- [切换 DM-worker 与上游 MySQL 实例的连接](https://docs.pingcap.com/zh/tidb/stable/usage-scenario-master-slave-switch.md): 了解如何切换 DM-worker 与上游 MySQL 实例的连接。
+- [列裁剪](https://docs.pingcap.com/zh/tidb/stable/column-pruning.md): 列裁剪是优化器在优化过程中删除不需要的列的基本思想。这样可以减少 I/O 资源占用并为后续优化带来便利。TiDB 会在逻辑优化阶段进行列裁剪，减少资源浪费。该扫描过程称作“列裁剪”，对应逻辑优化规则中的 columnPruner。如果要关闭这个规则，可以参照优化规则及表达式下推的黑名单中的关闭方法。
+- [创建 JSON 值的 JSON 函数](https://docs.pingcap.com/zh/tidb/stable/json-functions-create.md): 了解创建 JSON 值的 JSON 函数。
+- [创建 TiDB Data Migration 数据源](https://docs.pingcap.com/zh/tidb/stable/quick-start-create-source.md): 了解如何为 DM 创建数据源。
+- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/zh/tidb/stable/dm-create-task.md): 了解 TiDB Data Migration 如何创建数据迁移任务。
+- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/zh/tidb/stable/quick-start-create-task.md): 了解在部署 DM 集群后，如何快速创建数据迁移任务。
+- [创建二级索引](https://docs.pingcap.com/zh/tidb/stable/dev-guide-create-secondary-indexes.md): 创建二级索引的方法、规范及例子。
+- [创建数据库](https://docs.pingcap.com/zh/tidb/stable/dev-guide-create-database.md): 创建数据库的方法、规范及例子。
+- [创建表](https://docs.pingcap.com/zh/tidb/stable/dev-guide-create-table.md): 创建表的方法、规范及例子。
+- [删除数据](https://docs.pingcap.com/zh/tidb/stable/dev-guide-delete-data.md): 删除数据、批量删除数据的方法、最佳实践及例子。
+- [加密和压缩函数](https://docs.pingcap.com/zh/tidb/stable/encryption-and-compression-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分加密和压缩函数。
+- [升级与升级后常见问题](https://docs.pingcap.com/zh/tidb/stable/upgrade-faq.md): TiDB 升级与升级后的常见问题与解决办法。
+- [升级集群监控组件](https://docs.pingcap.com/zh/tidb/stable/upgrade-monitoring-services.md): 介绍如何升级 TiDB 集群监控组件 Prometheus、Grafana 和 Alertmanager。
+- [单区域双 AZ 部署 TiDB](https://docs.pingcap.com/zh/tidb/stable/two-data-centers-in-one-city-deployment.md): 了解单个区域两个可用区自适应同步模式部署方式。
+- [单区域多 AZ 部署 TiDB](https://docs.pingcap.com/zh/tidb/stable/multi-data-centers-in-one-city-deployment.md): 本文档介绍单个区域多个可用区部署 TiDB 的方案。
+- [单表查询](https://docs.pingcap.com/zh/tidb/stable/dev-guide-get-data-from-single-table.md): 介绍 TiDB 中的单表查询功能。
+- [双区域多 AZ 部署 TiDB](https://docs.pingcap.com/zh/tidb/stable/three-data-centers-in-two-cities-deployment.md): 介绍在两个区域多个可用区部署 TiDB 的方式。
+- [只读存储节点最佳实践](https://docs.pingcap.com/zh/tidb/stable/readonly-nodes.md): 介绍如何通过使用只读存储节点，达到物理隔离部分流量的目的。
+- [同步数据到 Kafka](https://docs.pingcap.com/zh/tidb/stable/ticdc-sink-to-kafka.md): 了解如何使用 TiCDC 将数据同步到 Kafka。
+- [同步数据到 MySQL 兼容数据库](https://docs.pingcap.com/zh/tidb/stable/ticdc-sink-to-mysql.md): 了解如何使用 TiCDC 将数据同步到 TiDB 或 MySQL
+- [同步数据到 Pulsar](https://docs.pingcap.com/zh/tidb/stable/ticdc-sink-to-pulsar.md): 了解如何使用 TiCDC 将数据同步到 Pulsar。
+- [同步数据到存储服务](https://docs.pingcap.com/zh/tidb/stable/ticdc-sink-to-cloud-storage.md): 了解如何使用 TiCDC 将数据同步到存储服务，以及数据变更记录的存储路径。
+- [向量函数和操作符](https://docs.pingcap.com/zh/tidb/stable/vector-search-functions-and-operators.md): 本文介绍 TiDB 的向量相关函数和操作。
+- [向量搜索概述](https://docs.pingcap.com/zh/tidb/stable/vector-search-overview.md): 介绍 TiDB 向量搜索功能。TiDB 向量搜索可以对文档、图像、音频和视频等多种数据类型进行语义搜索。
+- [向量搜索索引](https://docs.pingcap.com/zh/tidb/stable/vector-search-index.md): 了解如何在 TiDB 中构建并使用向量搜索索引加速 K 近邻 (K-Nearest Neighbors, KNN) 查询。
+- [向量搜索限制](https://docs.pingcap.com/zh/tidb/stable/vector-search-limitations.md): 了解 TiDB 向量搜索功能的限制。
+- [向量搜索集成概览](https://docs.pingcap.com/zh/tidb/stable/vector-search-integration-overview.md): 介绍 TiDB 向量搜索支持的 AI 框架、嵌入模型和 ORM 库。
+- [向量数据类型](https://docs.pingcap.com/zh/tidb/stable/vector-search-data-types.md): 本文介绍 TiDB 的向量数据类型。
+- [唯一序列号生成方案](https://docs.pingcap.com/zh/tidb/stable/dev-guide-unique-serial-number-generation.md): 唯一序列号生成方案，为自行生成唯一 ID 的开发者提供帮助。
+- [在 AWS Lambda 函数中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-aws-lambda.md): 本文介绍如何在 AWS Lambda 函数中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
+- [在 Django ORM 中使用 TiDB 向量搜索](https://docs.pingcap.com/zh/tidb/stable/vector-search-integrate-with-django-orm.md): 了解如何在 Django ORM 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
+- [在 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/zh/tidb/stable/tidb-in-kubernetes.md): 你可以使用 TiDB Operator 在 Kubernetes 上部署 TiDB。TiDB Operator 是 Kubernetes 上的 TiDB 集群自动运维系统，提供部署、升级、扩缩容、备份恢复、配置变更的 TiDB 全生命周期管理。借助 TiDB Operator，TiDB 可以无缝运行在公有云或自托管的 Kubernetes 集群上。TiDB Operator 的文档目前独立于 TiDB 文档。要查看如何在 Kubernetes 上部署 TiDB 的详细步骤，请参阅对应版本的 TiDB Operator 文档。
+- [在 LangChain 中使用 TiDB 向量搜索](https://docs.pingcap.com/zh/tidb/stable/vector-search-integrate-with-langchain.md): 展示如何在 LangChain 中使用 TiDB 向量搜索
+- [在 LlamaIndex 中使用 TiDB 向量搜索](https://docs.pingcap.com/zh/tidb/stable/vector-search-integrate-with-llamaindex.md): 了解如何在 LlamaIndex 中使用 TiDB 向量搜索。
+- [在 Next.js 中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-sample-application-nextjs.md): 本文介绍了如何在 Next.js 中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
+- [在 peewee 中使用 TiDB 向量搜索](https://docs.pingcap.com/zh/tidb/stable/vector-search-integrate-with-peewee.md): 了解如何在 peewee 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
+- [在 SQLAlchemy 中使用 TiDB 向量搜索](https://docs.pingcap.com/zh/tidb/stable/vector-search-integrate-with-sqlalchemy.md): 了解如何在 SQLAlchemy 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
+- [在三数据中心下就近读取数据](https://docs.pingcap.com/zh/tidb/stable/three-dc-local-read.md): 了解通过 Stale Read 功能在三数据中心下就近读取数据，减少跨数据中心请求。
+- [在公有云上部署 TiDB 的最佳实践](https://docs.pingcap.com/zh/tidb/stable/best-practices-on-public-cloud.md): 了解在公有云上部署 TiDB 的最佳实践。
+- [在线修改集群配置](https://docs.pingcap.com/zh/tidb/stable/dynamic-config.md): 介绍在线修改集群配置的功能。
+- [在线应用 Hotfix 到 DM 集群](https://docs.pingcap.com/zh/tidb/stable/tiup-component-dm-patch.md): 了解如何应用 hotfix 补丁包到 DM 集群。
+- [基于 Avro 的 TiCDC 行数据 Checksum 校验](https://docs.pingcap.com/zh/tidb/stable/ticdc-avro-checksum-verification.md): 介绍 TiCDC 行数据 Checksum 校验的具体实现。
+- [基于 DM 同步场景下的数据校验](https://docs.pingcap.com/zh/tidb/stable/dm-diff.md): 了解如何使用 TiDB DM 拉取指定配置进行数据校验。
+- [基于主备集群的容灾方案](https://docs.pingcap.com/zh/tidb/stable/dr-secondary-cluster.md): 了解如何使用 TiCDC 构建主备集群进行容灾。
+- [基于备份与恢复的容灾方案](https://docs.pingcap.com/zh/tidb/stable/dr-backup-restore.md): 了解如何基于 TiDB 的备份与恢复功能实现容灾。
+- [基于多副本的单集群容灾方案](https://docs.pingcap.com/zh/tidb/stable/dr-multi-replica.md): 了解 TiDB 提供的基于多副本的单集群容灾方案。
+- [基于角色的访问控制](https://docs.pingcap.com/zh/tidb/stable/role-based-access-control.md): TiDB 的基于角色的访问控制 (RBAC) 系统类似于 MySQL 8.0 的 RBAC 系统。用户可以创建、删除和授予角色权限，也可以将角色授予其他用户。角色需要在用户启用后才能生效。用户可以通过 `SHOW GRANTS` 查看角色权限，也可以设置默认启用角色。角色授权具有原子性，失败会回滚。除了角色授权外，还有用户管理和权限管理相关操作。
+- [备份与恢复 RawKV 数据](https://docs.pingcap.com/zh/tidb/stable/rawkv-backup-and-restore.md): 了解如何使用 tikv-br 命令行工具备份和恢复 RawKV 数据。
+- [备份与恢复常见问题](https://docs.pingcap.com/zh/tidb/stable/backup-and-restore-faq.md): 了解备份恢复相关的常见问题以及解决方法。
+- [备份存储](https://docs.pingcap.com/zh/tidb/stable/backup-and-restore-storages.md): 了解 BR 支持的备份存储服务的 URI 格式、鉴权方案和使用方式。
+- [备份恢复监控告警](https://docs.pingcap.com/zh/tidb/stable/br-monitoring-and-alert.md): 了解备份恢复的监控告警。
+- [备份自动调节](https://docs.pingcap.com/zh/tidb/stable/br-auto-tune.md): 了解 TiDB 的自动调节备份功能，在集群资源占用率较高的情况下，BR 会自动限制备份使用的资源以求减少对集群的影响。
+- [外部存储服务的 URI 格式](https://docs.pingcap.com/zh/tidb/stable/external-storage-uri.md): 介绍了外部存储服务 Amazon S3、GCS、和 Azure Blob Storage 的 URI 格式。
+- [外键约束](https://docs.pingcap.com/zh/tidb/stable/foreign-key.md): TiDB 数据库中外键约束的使用概况。
+- [多表连接查询](https://docs.pingcap.com/zh/tidb/stable/dev-guide-join-tables.md): 介绍 TiDB 中的多表连接查询功能。
+- [如何对 TiDB 进行 CH-benCHmark 测试](https://docs.pingcap.com/zh/tidb/stable/benchmark-tidb-using-ch.md): 本文介绍如何对 TiDB 进行 CH-benCHmark 测试。
+- [如何对 TiDB 进行 TPC-C 测试](https://docs.pingcap.com/zh/tidb/stable/benchmark-tidb-using-tpcc.md): 本文介绍了如何对 TiDB 进行 TPC-C 测试。TPC-C 是一个对 OLTP 系统进行测试的规范，使用商品销售模型对系统进行测试，包含五类事务：NewOrder、Payment、OrderStatus、Delivery、StockLevel。测试使用 tpmC 值衡量系统最大有效吞吐量，以 NewOrder Transaction 为准。使用 go-tpc 进行测试实现，通过 TiUP 命令下载测试程序。测试包括数据导入、运行测试和清理测试数据。
+- [如何用 Sysbench 测试 TiDB](https://docs.pingcap.com/zh/tidb/stable/benchmark-tidb-using-sysbench.md): 使用 Sysbench 1.0 或更新版本测试 TiDB 性能。调整 TiDB 和 TiKV 的日志级别以提高性能。配置 RocksDB 的 block cache 以充分利用内存。调整 Sysbench 配置文件并导入数据。进行数据预热和统计信息收集。执行 Point select、Update index 和 Read-only 测试命令。解决可能出现的性能问题。
+- [如何过滤 binlog 事件](https://docs.pingcap.com/zh/tidb/stable/filter-binlog-event.md): 介绍如何过滤 binlog 事件。
+- [如何通过 SQL 表达式过滤 DML](https://docs.pingcap.com/zh/tidb/stable/filter-dml-event.md): 介绍如何通过 SQL 表达式过滤 DML 事件
+- [子查询](https://docs.pingcap.com/zh/tidb/stable/dev-guide-use-subqueries.md): 介绍 TiDB 子查询功能。
+- [子查询相关的优化](https://docs.pingcap.com/zh/tidb/stable/subquery-optimization.md): 了解子查询相关的优化。
+- [字符串函数](https://docs.pingcap.com/zh/tidb/stable/string-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分字符串函数以及 Oracle 21 中提供的部分函数。
+- [字符串类型](https://docs.pingcap.com/zh/tidb/stable/data-type-string.md): TiDB 支持 MySQL 所有字符串类型，包括 CHAR、VARCHAR、BINARY、VARBINARY、BLOB、TEXT、ENUM 和 SET。CHAR 是定长字符串，长度固定为创建表时声明的长度。VARCHAR 是变长字符串，空间占用大小不得超过 65535 字节。TEXT 是文本串，最大列长为 65535 字节。TINYTEXT 最大列长度为 255。MEDIUMTEXT 最大列长度为 16777215。LONGTEXT 最大列长度为 4294967295。BINARY 存储二进制字符串。VARBINARY 存储二进制字符串。BLOB 是二进制大文件，最大列长度为 65535 字节。TINYBLOB 最大列长度为 255。MEDIUMBLOB 最大列长度为 16777215。LONGBLOB 最大列长度为 4294967295。ENUM 是枚举类型，值必须从固定集合中选取。SET 是集合类型，包含零个或多个值的字符串。
+- [字符集和排序规则](https://docs.pingcap.com/zh/tidb/stable/character-set-and-collation.md): TiDB 支持的字符集包括 ascii、binary、gbk、latin1、utf8 和 utf8mb4。排序规则包括 ascii_bin、binary、gbk_bin、gbk_chinese_ci、latin1_bin、utf8_bin、utf8_general_ci、utf8_unicode_ci、utf8mb4_0900_ai_ci、utf8mb4_0900_bin、utf8mb4_bin、utf8mb4_general_ci 和 utf8mb4_unicode_ci。TiDB 强烈建议使用 utf8mb4 字符集，因为它支持更多字符。在 TiDB 中，默认的排序规则受到客户端的连接排序规则设置的影响。如果客户端使用 utf8mb4_0900_ai_ci 作为连接排序规则，TiDB 将遵循客户端的配置。TiDB 还支持新的排序规则框架，用于在语义上支持不同的排序规则。
+- [字面值](https://docs.pingcap.com/zh/tidb/stable/literal-values.md): 本文介绍了 TiDB SQL 语句的字面值。
+- [定位消耗系统资源多的查询](https://docs.pingcap.com/zh/tidb/stable/identify-expensive-queries.md): TiDB 会将执行时间超过 tidb_expensive_query_time_threshold 限制（默认值为 60s），或使用内存超过 tidb_mem_quota_query 限制（默认值为 1 GB）的语句输出到 tidb-server 日志文件中，用于定位消耗系统资源多的查询语句。expensive query 日志和慢查询日志的区别在于，expensive query 日志可以将正在执行的语句的相关信息打印出来。当一条语句在执行过程中达到资源使用阈值时，TiDB 会即时将这条语句的相关信息写入日志。
+- [对象命名规范](https://docs.pingcap.com/zh/tidb/stable/dev-guide-object-naming-guidelines.md): 介绍 TiDB 中的对象命名规范。
+- [将 Grafana 监控数据导出成快照](https://docs.pingcap.com/zh/tidb/stable/exporting-grafana-snapshots.md): 了解如何将 Grafana 监控数据导出为快照以及如何将快照文件可视化。
+- [已知的第三方工具兼容问题](https://docs.pingcap.com/zh/tidb/stable/dev-guide-third-party-tools-compatibility.md): 介绍在测试中发现的 TiDB 与第三方工具的兼容性问题。
+- [常规统计信息](https://docs.pingcap.com/zh/tidb/stable/statistics.md): 介绍 TiDB 中常规统计信息的收集和使用。
+- [平滑升级 TiDB](https://docs.pingcap.com/zh/tidb/stable/smooth-upgrade-tidb.md): 本文介绍支持无需手动取消 DDL 的平滑升级集群功能。
+- [序列函数](https://docs.pingcap.com/zh/tidb/stable/sequence-functions.md): 了解 TiDB 中的序列函数。
+- [延迟的拆解分析](https://docs.pingcap.com/zh/tidb/stable/latency-breakdown.md): 详细介绍 TiDB 运行各阶段中时间消耗带来的延迟，以及如何在真实场景中分析延迟。
+- [开发 Java 应用使用 TiDB 的最佳实践](https://docs.pingcap.com/zh/tidb/stable/java-app-best-practices.md): 本文介绍了开发 Java 应用程序使用 TiDB 的常见问题与解决办法。TiDB 是高度兼容 MySQL 协议的数据库，基于 MySQL 开发的 Java 应用的最佳实践也多适用于 TiDB。
+- [开发者手册概览](https://docs.pingcap.com/zh/tidb/stable/dev-guide-overview.md): 整体叙述了开发者手册，罗列了开发者手册的大致脉络。
+- [性能优化概述](https://docs.pingcap.com/zh/tidb/stable/performance-tuning-overview.md): 本文介绍性能优化的基本概念，比如用户响应时间、吞吐和数据库时间，以及性能优化的通用流程。
+- [性能调优最佳实践](https://docs.pingcap.com/zh/tidb/stable/dev-guide-optimize-sql-best-practices.md): 介绍使用 TiDB 的性能调优最佳实践。
+- [恢复 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/zh/tidb/stable/dm-resume-task.md): 了解 TiDB Data Migration 如何恢复数据迁移任务。
+- [悲观模式下分库分表合并迁移](https://docs.pingcap.com/zh/tidb/stable/feature-shard-merge-pessimistic.md): 介绍 DM 提供的悲观模式（默认模式）下分库分表的合并迁移功能。
+- [慢查询日志](https://docs.pingcap.com/zh/tidb/stable/identify-slow-queries.md): TiDB 会将执行时间超过 300 毫秒的语句输出到慢查询日志中，用于帮助用户定位慢查询语句。可以通过修改系统变量来启用或禁用慢查询日志。日志示例包括执行时间、用户信息、执行计划等字段。用户可通过查询 SLOW_QUERY 表来查询慢查询日志中的内容。还可以使用 pt-query-digest 工具分析 TiDB 慢日志。ADMIN SHOW SLOW 命令可以显示最近的慢查询记录或最慢的查询记录。
+- [手动处理 Sharding DDL Lock](https://docs.pingcap.com/zh/tidb/stable/manually-handling-sharding-ddl-locks.md): DM 使用 sharding DDL lock 来确保分库分表的 DDL 操作可以正确执行。在异常情况下，需要手动处理异常的 DDL lock。使用 shard-ddl-lock 命令查看 DDL lock 信息，使用 shard-ddl-lock unlock 命令请求 DM-master 解除指定的 DDL lock。支持处理部分 MySQL source 被移除和 unlock 过程中部分 DM-worker 异常停止或网络中断的情况。
+- [执行计划管理 (SPM)](https://docs.pingcap.com/zh/tidb/stable/sql-plan-management.md): 介绍 TiDB 的执行计划管理 (SQL Plan Management) 功能。
+- [扩展统计信息](https://docs.pingcap.com/zh/tidb/stable/extended-statistics.md): 了解如何使用扩展统计信息指导优化器。
+- [批量建表](https://docs.pingcap.com/zh/tidb/stable/br-batch-create-table.md): 了解如何使用批量建表功能。在恢复备份数据时，可以通过批量建表功能加快数据的恢复速度。
+- [控制执行计划](https://docs.pingcap.com/zh/tidb/stable/control-execution-plan.md): 本章节介绍了控制执行计划的方法，包括使用提示指导执行计划、执行计划管理、优化规则及表达式下推的黑名单。此外，还介绍了一些系统变量对执行计划的影响，以及引入的特殊变量 `tidb_opt_fix_control`，用于更细粒度地控制优化器的行为。
+- [控制流程函数](https://docs.pingcap.com/zh/tidb/stable/control-flow-functions.md): TiDB 支持 MySQL 8.0 中的控制流程函数，包括 CASE、IF()、IFNULL() 和 NULLIF()。这些函数可以用于构建 if/else 语句和处理 NULL 值。
+- [提升 TiDB 建表性能](https://docs.pingcap.com/zh/tidb/stable/accelerated-table-creation.md): 介绍 TiDB 加速建表中的概念、原理、实现和影响。
+- [提高 TiDB Dashboard 安全性](https://docs.pingcap.com/zh/tidb/stable/dashboard-ops-security.md): TiDB Dashboard 需要提高安全性。建议为 `root` 用户设置强密码或禁用 `root` 账户，并为 TiDB Dashboard 创建最小权限用户。使用防火墙阻止不可信访问，配置反向代理仅代理 TiDB Dashboard，并为反向代理开启 TLS。其他建议的安全措施包括为组件间通信和客户端服务端间通信开启加密传输。
+- [插入数据](https://docs.pingcap.com/zh/tidb/stable/dev-guide-insert-data.md): 插入数据、批量导入数据的方法、最佳实践及例子。
+- [搜索 JSON 值的 JSON 函数](https://docs.pingcap.com/zh/tidb/stable/json-functions-search.md): 了解搜索 JSON 值的 JSON 函数。
+- [搭建双集群主从复制](https://docs.pingcap.com/zh/tidb/stable/replicate-between-primary-and-secondary-clusters.md): 了解如何配置一个 TiDB 集群以及该集群的 TiDB 或 MySQL 从集群，并将增量数据实时从主集群同步到从集群，
+- [搭建私有镜像](https://docs.pingcap.com/zh/tidb/stable/tiup-mirror.md): TiUP 提供了构建私有镜像的方案，使用 mirror 指令来实现，可用于离线部署。执行 `tiup mirror clone` 命令，可构建本地地镜像。克隆完成后，可以通过 SCP、NFS、HTTP 或 HTTPS 共享仓库。使用 `TIUP_MIRRORS` 环境变量来使用镜像。重新运行 `tiup mirror clone` 命令会创建新的 manifest，并下载可用的最新版本的组件。可以创建自定义仓库，并使用自己构建的 TiDB 组件。
+- [操作符](https://docs.pingcap.com/zh/tidb/stable/operators.md): 操作符是用于在 MySQL 中执行各种操作的关键元素。它们包括逻辑操作符（如 AND、OR、NOT、XOR）、赋值操作符（如 =、:=）、比较操作符（如 =、<、>、LIKE、BETWEEN）、以及其他操作符（如 +、-、*、/）。操作符具有不同的优先级，可以用于执行各种复杂的操作。需要注意的是，MySQL 不支持 ILIKE 操作符。
+- [操作系统性能参数调优](https://docs.pingcap.com/zh/tidb/stable/tune-operating-system.md): 了解如何进行 CentOS 7 系统的性能调优。
+- [支持资源](https://docs.pingcap.com/zh/tidb/stable/support.md): 在使用 TiDB 时遇到问题，如何获取支持。
+- [数值函数与操作符](https://docs.pingcap.com/zh/tidb/stable/numeric-functions-and-operators.md): TiDB 支持 MySQL 8.0 中的所有数值函数和操作符。
+- [数值类型](https://docs.pingcap.com/zh/tidb/stable/data-type-numeric.md): TiDB 支持 MySQL 的所有数值类型，包括整数类型、浮点类型和定点类型。整数类型包括 BIT、BOOLEAN、TINYINT、SMALLINT、MEDIUMINT、INTEGER 和 BIGINT，存储空间和取值范围各不相同。浮点类型包括 FLOAT 和 DOUBLE，存储空间分别为 4 和 8 字节。定点类型包括 DECIMAL 和 NUMERIC，可设置小数位数和小数点后位数。建议使用 DECIMAL 类型存储精确值。
+- [数据批量处理](https://docs.pingcap.com/zh/tidb/stable/batch-processing.md): 介绍了 TiDB 为数据批量处理场景提供的功能，包括 Pipelined DML、非事务性 DML、IMPORT INTO 语句以及已被废弃的 batch-dml。
+- [数据类型概述](https://docs.pingcap.com/zh/tidb/stable/data-type-overview.md): TiDB 支持除了空间类型（SPATIAL）之外的所有 MySQL 数据类型，包括数值型类型、字符串类型、时间和日期类型、JSON 类型。数据类型定义一般为 T(M[, D])，其中 T 表示具体的类型，M 在整数类型中表示最大显示长度，在浮点数或者定点数中表示精度，在字符类型中表示最大长度，D 表示浮点数、定点数的小数位长度，fsp 在时间和日期类型里的 TIME、DATETIME 以及 TIMESTAMP 中表示秒的精度，其取值范围是 0 到 6，值为 0 表示没有小数部分，如果省略，则默认精度为 0。
+- [数据类型的默认值](https://docs.pingcap.com/zh/tidb/stable/data-type-default-values.md): 数据类型的默认值描述了列的默认值设置规则。默认值必须是常量，对于时间类型可以使用特定函数。从 v8.0.0 开始，BLOB、TEXT 和 JSON 可以设置表达式默认值。如果列没有设置 DEFAULT，TiDB 会根据规则添加隐式默认值。对于 NOT NULL 列，根据 SQL_MODE 进行不同行为。表达式默认值是实验特性，不建议在生产环境中使用。MySQL 8.0.13 开始支持在 DEFAULT 子句中指定表达式为默认值。TiDB 支持为 BLOB、TEXT 和 JSON 数据类型分配默认值，但仅支持通过表达式来设置。
+- [数据索引一致性错误](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-data-inconsistency-errors.md): TiDB 在执行事务或执行 ADMIN CHECK 命令时会检查数据索引的一致性。如果发现不一致，会报错并记录相关错误日志。报错处理可通过改写 SQL 或关闭错误检查来绕过。对于特定错误代码，可通过设置 @@tidb_enable_mutation_checker=0 或 @@tidb_txn_assertion_level=OFF 来跳过检查。需注意关闭开关会关闭所有 SQL 语句的对应检查。
+- [数据迁移工具概览](https://docs.pingcap.com/zh/tidb/stable/migration-tools.md): 介绍 TiDB 的数据迁移工具。
+- [数据迁移概述](https://docs.pingcap.com/zh/tidb/stable/migration-overview.md): 了解各种数据迁移场景和对应的数据迁移方案。
+- [数据集成概述](https://docs.pingcap.com/zh/tidb/stable/integration-overview.md): 了解使用 TiCDC 进行数据集成的具体场景。
+- [断点备份](https://docs.pingcap.com/zh/tidb/stable/br-checkpoint-backup.md): 了解断点备份功能，包括它的使用场景、实现原理以及使用方法。
+- [断点恢复](https://docs.pingcap.com/zh/tidb/stable/br-checkpoint-restore.md): 了解断点恢复功能，包括它的使用场景、实现原理以及使用方法。
+- [日常巡检](https://docs.pingcap.com/zh/tidb/stable/daily-check.md): 介绍 TiDB 集群需要常关注的性能指标。
+- [日志脱敏](https://docs.pingcap.com/zh/tidb/stable/log-redaction.md): 了解 TiDB 各组件中的日志脱敏。
+- [日期和时间函数](https://docs.pingcap.com/zh/tidb/stable/date-and-time-functions.md): TiDB 支持 MySQL 8.0 中的所有日期和时间函数。
+- [日期和时间类型](https://docs.pingcap.com/zh/tidb/stable/data-type-date-and-time.md): TiDB 支持 MySQL 的所有日期和时间类型，包括 DATE、TIME、DATETIME、TIMESTAMP 和 YEAR。每种类型都有有效值范围，值为 0 表示无效值。TIMESTAMP 和 DATETIME 类型能自动生成新的时间值。关于日期和时间值类型，需要注意日期部分必须是“年 - 月 - 日”的格式，如果日期的年份部分是 2 位数，TiDB 会根据具体规则进行转换。不同类型的零值如下表所示：DATE:0000-00-00, TIME:00:00:00, DATETIME:0000-00-00 00:00:00, TIMESTAMP:0000-00-00 00:00:00, YEAR:0000。如果 SQL 模式允许使用无效的 DATE、DATETIME、TIMESTAMP 值，无效值会自动转换为相应的零值。
+- [时区支持](https://docs.pingcap.com/zh/tidb/stable/configure-time-zone.md): TiDB 的时区设置由 `time_zone` 系统变量控制，可以在会话级别或全局级别进行设置。`TIMESTAMP` 数据类型的的显示值受时区设置影响，但 `DATETIME`、`DATE` 或 `TIME` 数据类型不受影响。在数据迁移时，需要特别注意主库和从库的时区设置是否一致。
+- [暂停 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/zh/tidb/stable/dm-pause-task.md): 了解 TiDB Data Migration 如何暂停数据迁移任务。
+- [更新数据](https://docs.pingcap.com/zh/tidb/stable/dev-guide-update-data.md): 更新数据、批量更新数据的方法、最佳实践及例子。
+- [最小拓扑架构](https://docs.pingcap.com/zh/tidb/stable/minimal-deployment-topology.md): 介绍 TiDB 集群的最小拓扑。
+- [服务器状态变量](https://docs.pingcap.com/zh/tidb/stable/status-variables.md): 使用状态变量查看系统和会话状态。
+- [本地快速部署 TiDB 集群](https://docs.pingcap.com/zh/tidb/stable/tiup-playground.md): TiDB 集群是分布式系统，由多个组件构成。想要快速体验 TiDB，可以使用 TiUP 中的 playground 组件快速搭建本地测试环境。通过命令行参数可以设置各组件的数量和配置，也可以启动多个组件实例。使用 `tiup client` 可以快速连接到本地启动的 TiDB 集群。还可以查看已启动集群的信息，扩容或缩容集群。
+- [术语表](https://docs.pingcap.com/zh/tidb/stable/glossary.md): 了解 TiDB 相关术语。
+- [权限管理](https://docs.pingcap.com/zh/tidb/stable/privilege-management.md): TiDB 支持 MySQL 5.7 和 MySQL 8.0 的权限管理系统。权限相关操作包括授予权限、收回权限、查看用户权限和动态权限。权限系统的实现包括授权表和连接验证。权限生效时机是在 TiDB 启动时加载到内存，并且可以手动刷新。
+- [构建 TiFlash 副本](https://docs.pingcap.com/zh/tidb/stable/create-tiflash-replicas.md): 了解如何构建 TiFlash 副本。
+- [概览](https://docs.pingcap.com/zh/tidb/stable/dev-guide-optimize-sql-overview.md): 介绍 TiDB 的 SQL 性能调优概览。
+- [概述](https://docs.pingcap.com/zh/tidb/stable/dev-guide-schema-design-overview.md): TiDB 数据库模式设计的概述。
+- [注释语法](https://docs.pingcap.com/zh/tidb/stable/comment-syntax.md): 本文介绍 TiDB 支持的注释语法。
+- [海量 Region 集群调优最佳实践](https://docs.pingcap.com/zh/tidb/stable/massive-regions-best-practices.md): 了解海量 Region 导致性能问题的原因和优化方法。
+- [混合部署拓扑](https://docs.pingcap.com/zh/tidb/stable/hybrid-deployment-topology.md): 介绍混合部署 TiDB 集群的拓扑结构。
+- [物理优化](https://docs.pingcap.com/zh/tidb/stable/sql-physical-optimization.md): 物理优化是基于代价的优化，为逻辑执行计划制定物理执行计划。优化器根据数据统计信息选择时间复杂度、资源消耗和物理属性最小的物理执行计划。TiDB 执行计划文档介绍了索引选择、统计信息、错误索引解决方案、Distinct 优化和代价模型。
+- [物理导入模式](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-physical-import-mode.md): 了解 TiDB Lightning 的物理导入模式。
+- [理解 TiKV 中的 Stale Read 和 safe-ts](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-stale-read.md): TiKV 中的 Stale Read 依赖于 safe-ts，保证读取历史数据版本的安全性。safe-ts 由每个 Region 中的 peer 维护，resolved-ts 则由 Region leader 维护。诊断 Stale Read 问题可通过 Grafana、tikv-ctl 和日志。常见原因包括事务提交时间过长、事务存在时间过长以及 CheckLeader 信息推送延迟。处理慢事务提交可通过识别锁所属的事务和检查应用程序逻辑。处理长事务可通过识别事务、检查应用程序逻辑和处理慢查询。解决 CheckLeader 问题可通过检查网络和监控面板指标。
+- [生成列](https://docs.pingcap.com/zh/tidb/stable/generated-columns.md): 生成列是由列定义中的表达式计算得到的值。它包括存储生成列和虚拟生成列，存储生成列会将计算得到的值存储起来，而虚拟生成列不会存储其值。生成列可以用于从 JSON 数据类型中解出数据，并为该数据建立索引。在 INSERT 和 UPDATE 语句中，会检查生成列计算得到的值是否满足生成列的定义。生成列的局限性包括不能增加存储生成列，不能转换存储生成列为普通列，不能修改存储生成列的生成列表达式，以及不支持所有的 JSON 函数。
+- [生成自签名证书](https://docs.pingcap.com/zh/tidb/stable/generate-self-signed-certificates.md): 本文介绍了使用 openssl 生成自签名证书的示例。用户可以根据需要生成符合要求的证书和密钥。首先安装 OpenSSL，然后生成 CA 证书和各个组件的证书，最后为客户端签发证书。证书的作用是为各个组件和客户端验证身份。
+- [用 EXPLAIN 查看 JOIN 查询的执行计划](https://docs.pingcap.com/zh/tidb/stable/explain-joins.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看 MPP 模式查询的执行计划](https://docs.pingcap.com/zh/tidb/stable/explain-mpp.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看分区查询的执行计划](https://docs.pingcap.com/zh/tidb/stable/explain-partitions.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看子查询的执行计划](https://docs.pingcap.com/zh/tidb/stable/explain-subqueries.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看带视图的 SQL 执行计划](https://docs.pingcap.com/zh/tidb/stable/explain-views.md): 了解 TiDB 中视图相关语句的执行计划。
+- [用 EXPLAIN 查看索引合并的 SQL 执行计划](https://docs.pingcap.com/zh/tidb/stable/explain-index-merge.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看索引查询的执行计划](https://docs.pingcap.com/zh/tidb/stable/explain-indexes.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看聚合查询的执行计划](https://docs.pingcap.com/zh/tidb/stable/explain-aggregation.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用户自定义变量](https://docs.pingcap.com/zh/tidb/stable/user-defined-variables.md): 本文介绍 TiDB 的用户自定义变量。
+- [窗口函数](https://docs.pingcap.com/zh/tidb/stable/window-functions.md): TiDB 中的窗口函数与 MySQL 8.0 基本一致。可以将 `tidb_enable_window_function` 设置为 `0` 来解决升级后无法解析语法的问题。TiDB 支持除 `GROUP_CONCAT()` 和 `APPROX_PERCENTILE()` 以外的所有 `GROUP BY` 聚合函数。其他支持的窗口函数包括 `CUME_DIST()`、`DENSE_RANK()`、`FIRST_VALUE()`、`LAG()`、`LAST_VALUE()`、`LEAD()`、`NTH_VALUE()`、`NTILE()`、`PERCENT_RANK()`、`RANK()` 和 `ROW_NUMBER()`。这些函数可以下推到 TiFlash。
+- [管理 Changefeed](https://docs.pingcap.com/zh/tidb/stable/ticdc-manage-changefeed.md): 了解 Changefeed 相关的各种管理手段。
+- [管理 TiDB Data Migration 上游数据源](https://docs.pingcap.com/zh/tidb/stable/dm-manage-source.md): 了解如何管理上游 MySQL 实例。
+- [管理 TiDB Data Migration 迁移表的表结构](https://docs.pingcap.com/zh/tidb/stable/dm-manage-schema.md): 了解如何管理待迁移表在 DM 内部的表结构。
+- [管理资源消耗超出预期的查询 (Runaway Queries)](https://docs.pingcap.com/zh/tidb/stable/tidb-resource-control-runaway-queries.md): 介绍如何通过资源管控能力来实现对资源消耗超出预期的语句 (Runaway Queries) 进行控制和降级。
+- [精度数学](https://docs.pingcap.com/zh/tidb/stable/precision-math.md): TiDB 中的精确数值运算与 MySQL 基本一致。精确数值运算包括整型和 DECIMAL 类型，以及精确值数字字面量。DECIMAL 数据类型是定点数类型，其运算是精确计算。在表达式计算中，TiDB 会尽可能不做任何修改的使用每个输入的数值。数值修约时，`round()` 函数将使用四舍五入的规则。向 DECIMAL 或整数类型列插入数据时，round 的规则将采用 round half away from zero 的方式。
+- [系统变量](https://docs.pingcap.com/zh/tidb/stable/system-variables.md): 使用 TiDB 系统变量来优化性能或修改运行行为。
+- [系统变量索引](https://docs.pingcap.com/zh/tidb/stable/system-variable-reference.md): 查看 TiDB 所有的系统变量，以及引用这些变量的文档。
+- [索引推荐 (Index Advisor)](https://docs.pingcap.com/zh/tidb/stable/index-advisor.md): 了解如何使用 TiDB 索引推荐 (Index Advisor) 功能优化查询性能。
+- [索引的最佳实践](https://docs.pingcap.com/zh/tidb/stable/dev-guide-index-best-practice.md): 介绍 TiDB 中索引的最佳实践。
+- [索引的选择](https://docs.pingcap.com/zh/tidb/stable/choose-index.md): 介绍 TiDB 如何选择索引去读入数据，以及相关的一些控制索引选择的方式。
+- [约束](https://docs.pingcap.com/zh/tidb/stable/constraints.md): TiDB 支持的约束与 MySQL 基本相同，包括非空约束和 CHECK 约束。非空约束规则与 MySQL 相同，而 CHECK 约束需要在 tidb_enable_check_constraint 设置为 ON 后才能开启。可以通过 CREATE TABLE 或 ALTER TABLE 语句添加 CHECK 约束。唯一约束和主键约束也与 MySQL 相似，但 TiDB 目前仅支持对 NONCLUSTERED 的主键进行添加和删除操作。外键约束从 v6.6.0 开始支持，可以使用 CREATE TABLE 和 ALTER TABLE 命令来添加和删除外键。
+- [结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索](https://docs.pingcap.com/zh/tidb/stable/vector-search-integrate-with-jinaai-embedding.md): 了解如何结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索，以存储向量嵌入信息并执行语义搜索。
+- [结果集不稳定](https://docs.pingcap.com/zh/tidb/stable/dev-guide-unstable-result-set.md): 结果集不稳定错误的处理办法。
+- [缓存表](https://docs.pingcap.com/zh/tidb/stable/cached-tables.md): 了解 TiDB 中的缓存表功能，用于很少被修改的热点小表，提升读性能。
+- [聚合 JSON 值的 JSON 函数](https://docs.pingcap.com/zh/tidb/stable/json-functions-aggregate.md): 了解聚合 JSON 值的 JSON 函数。
+- [聚簇索引](https://docs.pingcap.com/zh/tidb/stable/clustered-indexes.md): 本文档介绍了聚簇索引的概念、使用场景、使用方法、限制和兼容性。
+- [自定义监控组件的配置](https://docs.pingcap.com/zh/tidb/stable/customized-montior-in-tiup-environment.md): 了解如何自定义 TiUP 管理的监控组件的配置。
+- [表属性](https://docs.pingcap.com/zh/tidb/stable/table-attributes.md): 介绍 TiDB 的 `ATTRIBUTES` 使用方法。
+- [表库过滤](https://docs.pingcap.com/zh/tidb/stable/table-filter.md): 在 TiDB 数据迁移工具中使用表库过滤功能。
+- [表达式求值的类型转换](https://docs.pingcap.com/zh/tidb/stable/type-conversion-in-expression-evaluation.md): TiDB 中的表达式求值类型转换与 MySQL 基本一致。详情请参见 MySQL 表达式求值类型转换文档。
+- [表达式语法](https://docs.pingcap.com/zh/tidb/stable/expression-syntax.md): 本文列出 TiDB 的表达式语法。
+- [视图](https://docs.pingcap.com/zh/tidb/stable/dev-guide-use-views.md): 介绍 TiDB 中的视图功能。
+- [视图](https://docs.pingcap.com/zh/tidb/stable/views.md): TiDB 支持视图，视图是虚拟表，结构由创建时的 SELECT 语句定义。使用视图可保证数据安全，简化复杂查询。查询视图类似查询表，TiDB 执行查询时会展开视图。可通过 SHOW CREATE TABLE 或 SHOW CREATE VIEW 查看视图创建语句及相关信息。也可查询 INFORMATION_SCHEMA.VIEWS 表或访问 HTTP API 获取视图元信息。视图有局限性，不支持物化视图，且为只读视图，不支持写入操作。已创建的视图仅支持 DROP 操作。
+- [访问 TiDB Dashboard](https://docs.pingcap.com/zh/tidb/stable/dashboard-access.md): TiDB Dashboard 可通过浏览器访问，支持多 PD 实例访问。浏览器兼容性包括 Chrome、Firefox 和 Edge。登录界面可使用 root 用户或自定义 SQL 用户登录。支持简体中文和英文语言切换。可在用户页面登出当前用户。
+- [读写延迟增加](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-cpu-issues.md): 介绍读写延时增加、抖动时的排查思路，可能的原因和解决方法。
+- [谓词下推](https://docs.pingcap.com/zh/tidb/stable/predicate-push-down.md): TiDB 逻辑优化规则中的谓词下推旨在尽早完成数据过滤，减少数据传输或计算的开销。谓词下推适用于将过滤表达式计算下推到数据源，如示例 1、2、3。但对于存储层不支持的谓词、外连接中的谓词和包含用户变量的谓词则不能下推。
+- [资源管控 (Resource Control) 监控指标详解](https://docs.pingcap.com/zh/tidb/stable/grafana-resource-control-dashboard.md): 了解资源管控 (Resource Control) 的 Grafana Dashboard 中所展示的关键指标。
+- [跨数据中心部署拓扑](https://docs.pingcap.com/zh/tidb/stable/geo-distributed-deployment-topology.md): 介绍跨数据中心部署 TiDB 集群的拓扑结构。
+- [迁移使用 GH-ost/PT-osc 的源数据库](https://docs.pingcap.com/zh/tidb/stable/feature-online-ddl.md): 使用 GH-ost/PT-osc 进行在线 DDL 工具执行 DDL 时，会产生锁表操作，阻塞数据库读写。为降低影响，可选择在线 DDL 工具 gh-ost 和 pt-osc。在 DM 迁移 MySQL 到 TiDB 时，可开启 `online-ddl` 配置，实现 DM 工具与 gh-ost 或 pt-osc 的协同。 DM 与 online DDL 工具协作细节包括 gh-ost 和 pt-osc 的实现过程，以及自定义规则配置。
+- [迁移升级 TiDB 集群](https://docs.pingcap.com/zh/tidb/stable/tidb-upgrade-migration-guide.md): 本文介绍如何使用 BR 全量备份恢复与 TiCDC 增量数据同步实现 TiDB 集群的迁移升级。
+- [迁移常见问题](https://docs.pingcap.com/zh/tidb/stable/migration-tidb-faq.md): 介绍 TiDB 迁移中的常见问题。
+- [返回 JSON 值的 JSON 函数](https://docs.pingcap.com/zh/tidb/stable/json-functions-return.md): 了解返回 JSON 值的 JSON 函数。
+- [连接到 TiDB](https://docs.pingcap.com/zh/tidb/stable/dev-guide-connect-to-tidb.md): 介绍连接到 TiDB 的方法。
+- [连接池与连接参数](https://docs.pingcap.com/zh/tidb/stable/dev-guide-connection-parameters.md): 针对开发者的 TiDB 连接池与连接参数的说明。
+- [选择驱动或 ORM 框架](https://docs.pingcap.com/zh/tidb/stable/dev-guide-choose-driver-or-orm.md): 选择驱动或 ORM 框架连接 TiDB。
+- [通过 SQL 表达式过滤 DML](https://docs.pingcap.com/zh/tidb/stable/feature-expression-filter.md): 增量数据迁移时可通过 SQL 表达式过滤 binlog event，例如不向下游迁移 `DELETE` 事件。从 v2.0.5 起，DM 支持使用 `binlog value filter` 过滤迁移数据。在 `ROW` 格式的 binlog 中，可以基于列的值配置 SQL 表达式。如果表达式结果为 `TRUE`，DM 就不会向下游迁移该条行变更。具体操作步骤和实现细节，请参考如何通过 SQL 表达式过滤 DML。
+- [通过 TiUP 部署 DM 集群的拓扑文件配置](https://docs.pingcap.com/zh/tidb/stable/tiup-dm-topology-reference.md): TiUP 部署 DM 集群的拓扑文件配置包括全局配置、组件配置、master 服务器配置、worker 服务器配置、监控服务器配置、Grafana 服务器配置和 Alertmanager 服务器配置。每个配置包含不同字段，如部署目录、数据目录、日志目录等。部署完成后部分字段不能再修改。
+- [通过 TiUP 部署 TiDB 集群的拓扑文件配置](https://docs.pingcap.com/zh/tidb/stable/tiup-cluster-topology-reference.md): 介绍通过 TiUP 部署或扩容 TiDB 集群时提供的拓扑文件配置和示例。
+- [通过反向代理使用 TiDB Dashboard](https://docs.pingcap.com/zh/tidb/stable/dashboard-ops-reverse-proxy.md): TiDB Dashboard 可通过反向代理安全提供给外部网络。首先获取实际地址，然后配置反向代理，最后修改路径前缀。详细步骤可参考官方文档。
+- [通过拓扑 label 进行副本调度](https://docs.pingcap.com/zh/tidb/stable/schedule-replicas-by-topology-labels.md): TiDB v5.3.0 引入了通过拓扑 label 进行副本调度的功能。为了提升集群的高可用性和数据容灾能力，推荐让 TiKV 节点在物理层面上尽可能分散。通过设置 TiKV 和 TiFlash 的 labels，可以标识它们的地理位置。同时，需要配置 PD 的 location-labels 和 isolation-level 来使 PD 理解 TiKV 节点拓扑并加强拓扑隔离要求。PD 在副本调度时会保证同一份数据的不同副本尽可能分散，以提高集群容灾能力。
+- [通过系统变量 `tidb_external_ts` 读取历史数据](https://docs.pingcap.com/zh/tidb/stable/tidb-external-ts.md): 了解如何通过系统变量 `tidb_external_ts` 读取历史数据。
+- [通过系统变量 `tidb_read_staleness` 读取历史数据](https://docs.pingcap.com/zh/tidb/stable/tidb-read-staleness.md): 了解如何通过系统变量 `tidb_read_staleness` 读取历史数据。
+- [通过系统变量 tidb_snapshot 读取历史数据](https://docs.pingcap.com/zh/tidb/stable/read-historical-data.md): 本文介绍了通过系统变量 `tidb_snapshot` 读取历史数据的操作流程和历史数据的保留策略。TiDB 实现了通过标准 SQL 接口读取历史数据功能，无需特殊的 client 或者 driver。当数据被更新、删除后，依然可以通过 SQL 接口将更新 / 删除前的数据读取出来。历史数据保留策略使用 MVCC 管理版本，超过一定时间的历史数据会被彻底删除，以减小空间占用以及避免历史版本过多引入的性能开销。
+- [逻辑优化](https://docs.pingcap.com/zh/tidb/stable/sql-logical-optimization.md): 本章节介绍了 TiDB 查询计划的关键逻辑改写，包括子查询优化、列裁剪、关联子查询去关联、Max/Min 消除、谓词下推、分区裁剪、TopN 和 Limit 下推以及 Join 重排序。这些改写帮助 TiDB 生成最终的查询计划，提高查询效率。
+- [逻辑导入模式简介](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-logical-import-mode.md): 了解 TiDB Lightning 的逻辑导入模式 (Logical Import Mode)。
+- [遥测](https://docs.pingcap.com/zh/tidb/stable/telemetry.md): 介绍遥测的场景，如何禁用功能和查看遥测状态。
+- [避免隐式类型转换](https://docs.pingcap.com/zh/tidb/stable/dev-guide-implicit-type-conversion.md): 介绍 TiDB 中隐式类型转换可能会带来的后果和避免方法。
+- [部署 TiDB Dashboard](https://docs.pingcap.com/zh/tidb/stable/dashboard-ops-deploy.md): TiDB Dashboard 是内置于 TiDB 4.0 或更高版本的 PD 组件中的界面，无需额外部署。对于 TiDB v6.5.0 及 TiDB Operator v1.4.0 之后的版本，在 Kubernetes 上支持将 TiDB Dashboard 作为独立的 Pod 部署。部署标准 TiDB 集群的文档可参考快速试用 TiDB 集群、生产环境部署和 Kubernetes 环境部署。当集群中部署了多个 PD 实例时，仅有一个 PD 实例会提供 TiDB Dashboard 服务。可通过 TiUP 查看实际运行 TiDB Dashboard 服务的 PD 实例，并切换其他 PD 实例提供 TiDB Dashboard 服务。也可以禁用和重新启用 TiDB Dashboard。
+- [部署 TiDB Lightning](https://docs.pingcap.com/zh/tidb/stable/deploy-tidb-lightning.md): 了解如何部署 TiDB Lightning，包括在线部署和离线部署。
+- [配置 TiDB Dashboard 使用 SSO 登录](https://docs.pingcap.com/zh/tidb/stable/dashboard-session-sso.md): 了解如何配置 TiDB Dashboard 启用 SSO 登录。
+- [锁函数](https://docs.pingcap.com/zh/tidb/stable/locking-functions.md): 了解 TiDB 中的用户级锁函数。
+- [错误码与故障诊断](https://docs.pingcap.com/zh/tidb/stable/error-codes.md): TiDB 错误码包括 MySQL 兼容的错误码和 TiDB 特有的错误码。如果遇到错误码，请参考官方文档或社区获取支持。常见错误码包括内存使用超限、写入冲突、表数据损坏、事务过大、写入冲突等。另外，TiDB 还提供了故障诊断文档供参考。
+- [错误索引的解决方案](https://docs.pingcap.com/zh/tidb/stable/wrong-index-solution.md): 了解如何处理错误索引问题。
+- [集合运算](https://docs.pingcap.com/zh/tidb/stable/set-operators.md): 了解 TiDB 支持的集合运算。
+- [集群监控部署](https://docs.pingcap.com/zh/tidb/stable/deploy-monitoring-services.md): 本文适用于手动部署 TiDB 监控报警系统的用户。假设 TiDB 的拓扑结构如下：Node1 主机 IP 为 192.168.199.113，服务包括 PD1、TiDB、node_export、Prometheus、Grafana；Node2 主机 IP 为 192.168.199.114，服务包括 PD2、node_export；Node3 主机 IP 为 192.168.199.115，服务包括 PD3、node_export；Node4 主机 IP 为 192.168.199.116，服务包括 TiKV1、node_export；Node5 主机 IP 为 192.168.199.117，服务包括 TiKV2、node_export；Node6 主机 IP 为 192.168.199.118，服务包括 TiKV3、node_export。具体部署步骤包括下载二进制包、启动 node_exporter 服务、启动 Prometheus 服务、启动 Grafana 服务、配置 Grafana 数据源和导入 Grafana 面板。可查看 TiDB Server、PD Server 和 TiKV Server 的监控信息。
+- [静态加密](https://docs.pingcap.com/zh/tidb/stable/encryption-at-rest.md): 了解如何启用静态加密功能保护敏感数据。
+- [非 Prepare 语句执行计划缓存](https://docs.pingcap.com/zh/tidb/stable/sql-non-prepared-plan-cache.md): 介绍 TiDB 中非 Prepare 语句执行计划缓存的原理、使用方法及示例。
+- [非事务 DML 语句](https://docs.pingcap.com/zh/tidb/stable/non-transactional-dml.md): 以事务的原子性和隔离性为代价，将 DML 语句拆成多个语句依次执行，用以提升批量数据处理场景的稳定性和易用性。
+- [预处理语句](https://docs.pingcap.com/zh/tidb/stable/dev-guide-prepared-statement.md): 介绍 TiDB 的预处理语句功能。
+- [验证 JSON 文档的函数](https://docs.pingcap.com/zh/tidb/stable/json-functions-validate.md): 了解验证 JSON 文档的函数。
+- [验证集群运行状态](https://docs.pingcap.com/zh/tidb/stable/post-installation-check.md): 介绍如何验证集群运行状态。
+- [高可用常见问题](https://docs.pingcap.com/zh/tidb/stable/high-availability-faq.md): 介绍高可用相关的常见问题。
+- [高可靠常见问题](https://docs.pingcap.com/zh/tidb/stable/high-reliability-faq.md): 介绍高可靠相关的常见问题。
 
 ## TiDB on Kubernetes 文档（使用 TiDB Operator 部署）
 
 - [TiDB on Kubernetes 文档](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable.md): 使用 PingCAP 提供的 TiDB Operator，你可以在公有云或自托管的 Kubernetes 集群上自动运维 TiDB 集群，实现 TiDB 在 Kubernetes 上的无缝运行。
 - [API 文档](https://github.com/pingcap/tidb-operator/blob/v1.6.1/docs/api-references/docs.md)
-- [Kubernetes 上的 TiDB Binlog Drainer 配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-tidb-binlog-drainer.md): 了解 Kubernetes 上的 TiDB Binlog Drainer 配置参数。
-- [Kubernetes 上的 TiDB 工具指南](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-toolkit.md): 详细介绍 Kubernetes 上的 TiDB 相关的工具及其使用方法。
-- [Kubernetes 上的 TiDB 常见部署错误](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-failures.md): 介绍 Kubernetes 上 TiDB 部署的常见错误以及处理办法。
-- [Kubernetes 上的 TiDB 集群常见异常](https://docs.pingcap.com/tidb-in-kubernetes/stable/exceptions.md): 介绍 TiDB 集群运行过程中常见异常以及处理办法。
-- [Kubernetes 上的 TiDB 集群常见网络问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/network-issues.md): 介绍 Kubernetes 上 TiDB 集群的常见网络问题以及诊断解决方案。
-- [Kubernetes 上的 TiDB 集群常见问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/faq.md): 介绍 Kubernetes 上的 TiDB 集群常见问题以及解决方案。
-- [Kubernetes 上的 TiDB 集群故障自动转移](https://docs.pingcap.com/tidb-in-kubernetes/stable/use-auto-failover.md): 介绍 Kubernetes 上的 TiDB 集群故障自动转移的功能。
-- [Kubernetes 上的 TiDB 集群环境需求](https://docs.pingcap.com/tidb-in-kubernetes/stable/prerequisites.md): 介绍在 Kubernetes 上部署 TiDB 集群的软硬件环境需求。
-- [Kubernetes 上的 TiDB 集群管理常用使用技巧](https://docs.pingcap.com/tidb-in-kubernetes/stable/tips.md): 介绍 Kubernetes 上 TiDB 集群管理常用使用技巧。
-- [Kubernetes 上的持久化存储类型配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-storage-class.md): 介绍 Kubernetes 上的数据持久化存储类型配置。
-- [Kubernetes 上的集群初始化配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/initialize-a-cluster.md): 介绍如何初始化配置 Kubernetes 上的 TiDB 集群。
-- [Kubernetes 的监控与告警](https://docs.pingcap.com/tidb-in-kubernetes/stable/monitor-kubernetes.md): 介绍如何监控 Kubernetes。
-- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/tidb-in-kubernetes/stable/clinic-data-collection.md): 详细说明 PingCAP Clinic 诊断服务在使用 Operator 部署的 TiDB 集群中能够采集的诊断数据类型、输出文件及采集参数。
-- [TiDB on Kubernetes Sysbench 性能测试](https://docs.pingcap.com/tidb-in-kubernetes/stable/benchmark-sysbench.md): TiDB Operator GA 发布后，我们在 GKE 平台进行了全面的性能测试。测试结果显示，在 Host 网络模式下，TiDB 性能略优于 Pod 网络模式（约 7%）。此外，使用 Ubuntu 系统的 Host 网络模式下，TiDB 性能也略优于 COS 系统（约 9%）。在集群外访问时，使用 Load Balancer 会略损失性能（约 5%）。多可用区下节点之间的延迟增加，会对 TiDB 性能产生一定影响（30% ~ 6%）。计算型机型相对普通型机器带来了很大 QPS 提升（50% ~ 60%）。
-- [TiDB Operator 0.1.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.1.0.md): TiDB Operator 0.1.0 was released on August 22, 2018. Notable changes include the ability to bootstrap multiple TiDB clusters, support for monitoring deployment and Helm charts, basic Network PV/Local PV support, safe scaling of the TiDB cluster, orderly cluster upgrades, and stopping the TiDB process without terminating the Pod. Additionally, cluster meta info can be synchronized to POD/PV/PVC labels, and basic unit tests & E2E tests are available. Tutorials for GKE and local DinD are also provided.
-- [TiDB Operator 0.2.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.2.0.md): TiDB Operator 0.2.0 was released on September 11, 2018. Notable changes include experimental support for auto-failover, unification of Tiller and TiDB Operator managed resources labels, managing TiDB service via Tiller, adding toleration for TiDB cluster components, and refactoring upgrade functions as interface. Additionally, a script for easy setup of DinD environment was added, and code was linted and formatted in CI.
-- [TiDB Operator 0.2.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.2.1.md): TiDB Operator 0.2.1 was released on September 20, 2018. This version includes bug fixes for retry on conflict logic, TiDB timezone configuration, failover, and repeated updating of pod and pd/tidb StatefulSet.
-- [TiDB Operator 0.3.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.3.0.md): TiDB Operator 0.3.0 was released on October 12, 2018. Notable changes include the addition of full backup support, TiDB Binlog support, graceful upgrade feature, and the ability to persist monitor data.
-- [TiDB Operator 0.3.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.3.1.md): TiDB Operator 0.3.1 was released on October 31, 2018. The release includes minor changes such as parameterizing the serviceAccount, bumping TiDB to v2.0.7, and allowing user-specified config files. Bug fixes include addressing issues with parallel upgrades, wrong parameters, and recovery after a failed upgrade.
-- [TiDB Operator 0.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.4.0.md): TiDB Operator 0.4.0 was released on November 9, 2018. Notable changes include extending Kubernetes scheduler for TiDB data awareness, restoring backup data from GCS bucket, and setting password for TiDB when first deployed. Minor changes and bug fixes include updating roadmap, adding unit tests, E2E tests, adding TiDB failover limit, synchronizing PV reclaim policy early, using helm release name as instance label, and fixing local PV setup script.
-- [TiDB Operator 1.0 Beta.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.0.md): TiDB Operator 1.0 Beta.0 was released on November 26, 2018. Notable changes include the introduction of basic chaos testing, improved unit test coverage, default log-level values for PD/TiKV/TiDB, and various bug fixes and enhancements. The release also includes a user guide and migration to Go 1.11 module.
-- [TiDB Operator 1.0 Beta.1 P1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p1.md): TiDB Operator 1.0 Beta.1 P1 was released on January 7, 2019. The bug fixes include resolving scheduler policy issues for Kubernetes v1.10, v1.11, and v1.12. The documentation updates include a proposal to add multiple statefulsets support to TiDB Operator and an updated roadmap.
-- [TiDB Operator 1.0 Beta.1 P2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p2.md): TiDB Operator 1.0 Beta.1 P2 was released on February 21, 2019. Notable changes include a new algorithm for scheduler HA predicate, addition of TiDB discovery service, serial scheduling, change in tolerations type to an array, direct start when there is a join file, addition of code coverage icon, omission of just the empty leaves in `values.yml`, backup to ceph object storage in charts, and addition of `ClusterIDLabelKey` label to TidbCluster.
-- [TiDB Operator 1.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1.md): TiDB Operator 1.0 Beta.1 was released on December 27, 2018. The release includes bug fixes such as pd_control bug, orphan pod cleaner, scheduler configuration fix, Grafana configuration fix, and more. Minor improvements include adding Kubernetes 1.12 local DinD scripts, bumping default TiDB to v2.1.0, releasing tidb-operator/tidb-cluster charts, and adding connection timeout for TiDB password setter job. Other improvements involve separating ad-hoc backup and restore to another chart, adding compiler version info to tidb-operator binary, allowing specifying TiDB service LoadBalancer IP, and exposing TiKV cpu/memory related configuration to values.yaml.
-- [TiDB Operator 1.0 Beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.2.md): TiDB Operator 1.0 Beta.2 has been released on May 10, 2019. The new version includes enhanced stability, improved ease of use, bug fixes, and other improvements. Some of the key changes include refactored e2e test, one-command deployment for AWS and Aliyun, and support for slow log of TiDB. Numerous bug fixes and detailed changes have also been made to improve the overall performance and user experience.
-- [TiDB Operator 1.0 Beta.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.3.md): TiDB Operator 1.0 Beta.3 was released on June 6, 2019. The new version includes the removal of `nodeSelectorRequired` from values.yaml and the addition of stability cases, new features, documentation improvements, and bug fixes. Some notable new features include ConfigMap rollout management, stable scheduling for pods, and support for adding additional pod annotations. The default TiDB version has been upgraded to v3.0.0-rc.1, and various bug fixes and changes have been implemented.
-- [TiDB Operator 1.0 GA Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0-ga.md): TiDB Operator 1.0.0 has been released on July 30, 2019. The new version requires action to be taken for configuration changes in `values.yaml`. Stability test cases have been added, along with improvements such as GKE SSD setup simplification and AWS Terraform script modularization. Bug fixes include sysbench installation and TiKV metrics monitoring. Detailed bug fixes and changes include upgrading TiDB monitor, specifying TiKV status address, and enabling nlb cross zone load balancing by default. Multiple TiDB clusters management is now supported in Alibaba Cloud. The default TiDB version has been upgraded to v3.0.1. The release also includes various other bug fixes and improvements.
-- [TiDB Operator 1.0 RC.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-rc.1.md): TiDB Operator 1.0 RC.1 was released on July 12, 2019. The new version includes stability test cases, improvements such as increasing TiKV GC life time, and bug fixes like fixing unbound variables in the backup script and scheduled backup bugs. It also supports force upgrade when PD cluster is unavailable and adds Amazon S3 support for backup/restore features. Multiple clusters management in EKS and local SSD provision for COS on GKE are also included. The release notes contain detailed bug fixes and changes, including various pull requests for bug fixes and improvements.
-- [TiDB Operator 1.0.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.1.md): TiDB Operator version 1.0.1 was released on September 17, 2019. The release includes important bug fixes and improvements. Users of version 1.0.0 or prior must upgrade to avoid potential service outage. The backup tool image has been updated to fix a serious bug. Other improvements include modularizing GCP Terraform, adding support for various configurations, and reducing e2e run time. Bug fixes address issues such as TiKV scale-in failure, orphan pods cleaner bugs, and incorrect condition judgment. The release also includes detailed bug fixes and changes.
-- [TiDB Operator 1.0.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.2.md): TiDB Operator version 1.0.2 was released on November 1, 2019. The new version includes improvements such as suspending the ReplaceUnhealthy process for AWS TiKV auto-scaling-group, adding a new VM manager 'qm' in stability test, and setting default externalTrafficPolicy to 'Local' for TiDB service in AWS/GCP/Aliyun. Bug fixes include issues with tkctl version, create_tidb_cluster_release variable in AWS Terraform script, and compatibility issues with Kubernetes 1.16 and above versions. Other fixes and changes are also included in this release.
-- [TiDB Operator 1.0.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.3.md): TiDB Operator version 1.0.3 was released on November 13, 2019. The new version requires an upgrade to TiDB v3.0.5 and adds timezone support for all charts. Existing TiDB clusters with customized timezones will trigger a rolling update. Improvements include timezone support and configuring resource requests and limits for all containers of the TiDB cluster. Bug fixes include upgrading default TiDB version to v3.0.5 and adding timezone support for all containers of the TiDB cluster.
-- [TiDB Operator 1.0.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.4.md): TiDB Operator version 1.0.4 was released on November 23, 2019. The new version introduces HostNetwork support for better performance, podSecurityContext support, and new Helm charts for TiDB Lightning and TiDB Binlog. It also includes bug fixes and changes. Users of the v1.1.0.alpha branch are advised to upgrade to v1.0.4, as it includes all fixes from the alpha branch and introduces additional improvements.
-- [TiDB Operator 1.0.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.5.md): TiDB Operator version 1.0.5 was released on December 11, 2019. The new features include fixing backup failure issue, recommending deployment of TiDB and Pump on the same node, fixing RBAC permission, and resolving e2e nil point dereference. No action is required for upgrading from v1.0.4.
-- [TiDB Operator 1.0.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.6.md): TiDB Operator 1.0.6 was released on December 27, 2019. Users need to migrate configs from the old `values.yaml` to the new one to avoid monitor pod failures. The new release includes improvements in monitor, TiDB Scheduler, compatibility, TiKV Importer, E2E, and CI. Notable changes include enabling alert rule persistence, adding node & pod info in TiDB Grafana, refining scheduler error messages, fixing compatibility issues in Kubernetes v1.17, and adjusting the release CI script.
-- [TiDB Operator 1.0.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.7.md): TiDB Operator 1.0.7 was released on June 16, 2020. Notable changes include fixing alert rules lost after rolling upgrade, upgrading local volume provisioner to 2.3.4, fixing operator failover config invalid, removing unnecessary duplicated docs, updating doc links and image in readme, emitting events when PD failover, fixing some broken urls, and removing some not very useful update events.
-- [TiDB Operator 1.1 Beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-beta.1.md): 支持配置时区，备份到 S3，基础默认设置，增强型 StatefulSet 扩缩容，自定义资源初始化 TiDB 集群，优化配置结构，支持临时存储，发布 Terraform Aliyun ACK 版本，优化报错信息，支持 TLS 加密连接，支持动态扩展云存储 PV，支持自动生成证书，支持暂停备份计划，升级 TiDB 版本。
-- [TiDB Operator 1.1 Beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-beta.2.md): 默认存储类和备份存储类已废弃，现在使用 Kubernetes 默认存储类。用户可设置备份和恢复的亲和性和容忍度。解决了 AdvancedStatefulSet 和 Admission Webhook 一起使用的问题。支持基于 CPU 平均负载的集群自动扩容。支持用户自定义证书。修复了一些问题并优化了日志。
-- [TiDB Operator 1.1 GA Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1-ga.md): TiDB Operator 1.1 GA 发布日期 2020 年 5 月 28 日。将 TiDB Pod 的 readiness 探针从 HTTPGet 更改为 TCPSocket 4000 端口。这将触发 tidb-server 组件滚动升级。你可以在升级 TiDB Operator 之前将 spec.paused 设置为 true 以避免滚动升级，并在准备升级 tidb-server 时将其重新设置为 false。
-- [TiDB Operator 1.1 RC.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.1.md): 此版本包括对 tidb-server 的配置选项的更新，备份和恢复规范的修改，以及对 TiDB 组件的一些修复和改进。还支持通过 Terraform 在 AWS 和 ACK 上部署 TiDB 集群，并添加了一些新的功能和文档。
-- [TiDB Operator 1.1 RC.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.2.md): TiDB Operator 1.1 RC.2 was released on April 15, 2020. Action required includes changing TiDB pod readiness probe and setting spec.paused to true before upgrading. Notable changes include adding status field for TidbAutoScaler CR, emitting more events for TidbCluster and TidbClusterAutoScaler, and adding TLS support for TiKV metrics API. Other changes involve adding a switch to skip PD Dashboard TLS configuration, supporting TiFlash in TidbCluster CR, and fixing errors related to alertmanager in TidbMonitor.
-- [TiDB Operator 1.1 RC.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.3.md): TiDB Operator 1.1 RC.3 was released on April 30, 2020. Notable changes include support for TiFlash metrics in TidbMonitor, fixing bugs related to failover pods and statefulsets, and adding new features like configuring Ingress in TidbMonitor and supporting failover for TiFlash. Other changes include updates to terraform scripts and adding new fields in TiKVConfig.
-- [TiDB Operator 1.1 RC.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.4.md): TiDB Operator 1.1 RC.4 发布于 2020 年 5 月 15 日。每个组件可以使用单独的 TiDB 客户端证书。用户应该将 `Backup` 和 `Restore` CR 中的旧的 TLS 配置迁移到新的配置。
-- [TiDB Operator 1.1.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.1.md): TiDB Operator 1.1.1 版本发布，重大变化包括添加 `additionalContainers` 和 `additionalVolumes` 字段，修复了多个问题，并更新了配置版本到 v4.0.1。
-- [TiDB Operator 1.1.10 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.10.md): TiDB Operator 1.1.10 版本发布，包含兼容性改动、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性改动包括 `apiVersion` 更改，滚动升级改动导致 TidbMonitor Pod 删除重建。新功能包括灰度升级、TidbMonitor 支持 `remotewrite`、配置 init containers 等。优化提升包括自定义存储、增加 label 支持多集群监控等。Bug 修复包括备份或者恢复失败、Pod 在升级过程中不会进行迁移 leader 等问题。
-- [TiDB Operator 1.1.11 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.11.md): TiDB Operator 1.1.11 版本发布，新增优化 LeaderElection 和自定义 Store 标签功能。优化 TiFlash 滚动更新机制，改进获取 region leader 数量方式。支持打印 RocksDB 和 Raft 日志到 stdout。
-- [TiDB Operator 1.1.12 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.12.md): TiDB Operator 1.1.12 版本发布日期为 2021 年 4 月 15 日。新功能包括支持为备份和恢复 Job 设置自定义环境变量，支持备份恢复 CR 设置 affinity 和 tolerations，以及支持 tidb-operator chart 使用新的 service account。优化提升包括 TiDBInitializer 中增加重试机制，增加多 PVC 支持，以及优化 `PodsAreChanged` 函数。Bug 修复包括修复挂载多 PVC 时容量设置错误的问题，修复创建 `.spec.tidb` 为空并开启 TLS 的 TidbCluster 导致 tidb-controller-manager panic 的问题，以及修复 `UnjoinedMembers` 中 PVC 状态异常的问题。
-- [TiDB Operator 1.1.13 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.13.md): TiDB Operator 1.1.13 版本发布，优化了 TiCDC 配置 TLS 证书、BR 工具镜像 tag、扩缩容 TiDB 过程中协调 PVC、备份日志中隐藏数据库密码。修复了部署异构集群时可能 panic 的问题和 TiDB 实例缩容后在 TiDB Dashboard 中仍然存在的问题。
-- [TiDB Operator 1.1.14 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.14.md): TiDB Operator 1.1.14 版本发布日期为 2021 年 10 月 21 日。此版本修复了 `tidb-backup-manager` 和 `tidb-operator` 镜像中的安全漏洞。
-- [TiDB Operator 1.1.15 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.15.md): TiDB Operator 1.1.15 发布日期为 2022 年 2 月 17 日。此版本修复了 TiDB Operator 计算 TiKV Region leader 数量时可能会造成 goroutine 泄露的问题。
-- [TiDB Operator 1.1.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.2.md): TiDB Operator 1.1.2 版本修复了与 PD 4.0.2 不兼容的问题。需要将 TiDB Operator 升级到 v1.1.2 后再部署 TiDB 4.0.2 及更高版本。其他变更包括抓取监控指标和更新配置为 v4.0.2，修复缩容后 PD 成员可能仍然存在的错误，同步信息到 `TidbCluster` `Status` 字段，以及支持在 TiDB 参数中配置容器生命周期 hook 和 `terminationGracePeriodSeconds`。
-- [TiDB Operator 1.1.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.3.md): TiDB Operator 1.1.3 版本发布，需要采取的行动包括在 `BackupSpec` 中添加 `cleanPolicy` 字段，将 `mydumper` 替换为 `dumpling` 进行备份。其他变更包括更新 backup manager 工具、为 TiCDC 添加 TLS 支持、在 Drainer 和下游数据库服务器之间添加 TLS 支持等。
-- [TiDB Operator 1.1.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.4.md): TiDB Operator 1.1.4 版本发布，重大变化包括添加 TableFilter 到 BackupSpec 和 RestoreSpec，更新 TiDB 和配套工具版本为 v4.0.4，支持自定义环境变量，增加存储请求，为备份恢复添加 TLS 支持，支持 TiFlash 中的 cert-allowed-cn 配置项，修复了启用 TLS 时的内存泄漏问题，为 TiFlash 添加 TLS 支持，配置 TZ 环境。
-- [TiDB Operator 1.1.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.5.md): TiDB Operator 1.1.5 版本发布日期为 2020 年 9 月 18 日。此版本兼容性变化需要注意 TiFlash 版本低于 `v4.0.5` 的设置。新功能包括支持为 TiDB/Pump/PD 配置 `serviceAccount`，以及配置 `spec.tikv.config.log-format` 和 `spec.tikv.config.server.max-grpc-send-msg-len`。优化提升方面支持 TiDB/PD/TiKV 的 v4.0.6 配置，挂载集群客户端证书到 PD Pod，以及对于 TiFlash/PD/TiDB 的伸缩实例优先于升级。同时修复了 TidbMonitor CR 中的 Grafana container 忽略 `Env` 配置的问题。
-- [TiDB Operator 1.1.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.6.md): TiDB Operator 1.1.6 版本发布日期为 2020 年 10 月 16 日。此版本包含兼容性变化、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性变化包括 `spec.pd.config` 参数的自动转换和需要手动编辑 TidbCluster CR 的配置。滚动升级改动包括 TiDB 或 TiKV 集群的滚动升级以及 TiFlash 集群的滚动升级。新功能包括支持 Backup 和 Restore CR 自定义 BR 命令行参数、配置 TiKV evict leader 超时时间等。优化提升包括透传 TiFlash/TiKV/PD/Pump 的 TOML 格式配置、定时备份到 GCS 时目录名称添加备份时间等。Bug 修复包括修复 Discovery 可能导致启动多个 PD 集群的错误。
-- [TiDB Operator 1.1.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.7.md): TiDB Operator 1.1.7 版本发布日期为 2020 年 11 月 13 日。此版本中兼容性变化包括配置项 `prometheus.spec.config.commandOptions` 的行为变化。新增功能包括对 `Backup` 和 `Restore` CR 的配置项 `spec.toolImage` 的新增，以及对 `spec.pd.storageVolumes`、`spec.tidb.storageVolumes` 和 `spec.tikv.storageVolumes` 的支持。优化提升方面包括禁止缩容 TiKV 实例和新增 `BackupStatus` 和 `RestoreStatus` 中的 `phase` 状态。此外还修复了当前 `TidbCluster` 之外存在 PD member 时无法把 PD scale 到 0 的 bug。
-- [TiDB Operator 1.1.8 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.8.md): TiDB Operator 1.1.8 版本新增了对备份和恢复任务的支持，用户可以利用该功能实现基于 NFS 或者任意 Kubernetes 支持的 Volume 类型的任务。此外，还优化了 TiDB 组件和客户端开启 TLS 的功能，支持为 TiDB service 指定额外的端口，以及在连接 TiDB server 时不使用 TLS。修复了一系列 Bug，包括部署 TiDB 集群问题、编码错误问题、Pods 误认为问题等。
-- [TiDB Operator 1.1.9 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.9.md): TiDB Operator 1.1.9 版本发布日期为 2020 年 12 月 28 日。此版本优化了支持使用 `spec.toolImage` 来为 `Backup` 和 `Restore` 指定 Dumpling/TiDB Lightning 的二进制可执行文件。同时修复了 Prometheus 不能拉取 TiKV Importer 的 metrics 以及用 BR 和 GCS 进行备份与恢复时的兼容性问题。
-- [TiDB Operator 1.2.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0.md): TiDB Operator 1.2.0 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级改动包括升级 TiDB Operator 会导致 TidbMonitor Pod 删除重建。新功能包括支持为 `TiDBMonitor` 的 `Prometheus` 设置更细粒度的 `retentionTime` 和通过 `priorityClassName` 设置备份 Job 优先级。优化提升包括调整升级过程中驱逐 TiKV 的 Region Leader 超时的默认值。Bug 修复包括修复解析 `TiDBMonitor` 定义中 `Prometheus.RemoteWrite` 的 URL 可能失败的问题。
-- [TiDB Operator 1.2.0-alpha.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-alpha.1.md): TiDB Operator 1.2.0-alpha.1 版本发布。滚动升级改动包括 TidbMonitor Pod 重建。新增功能包括跨多个 Kubernetes 集群部署 TiDB 集群、管理 DM 2.0、PD API 弹性伸缩、灰度升级 TiDB Operator。优化提升包括 TiDB Lightning chart 支持 local backend、TLS、持久化 checkpoint，TidbMonitor 支持配置 Thanos sidecar，管理资源从 Deployment 变为 StatefulSet。其他改进包括优化队列 rate limiter 间隔，修改 TidbMonitor 自定义告警规则存储目录。
-- [TiDB Operator 1.2.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-beta.1.md): TiDB Operator 1.2.0-beta.1 发布日期为 2021 年 4 月 7 日。此版本包含兼容性改动和滚动升级改动。新增功能包括为备份和恢复 Job 设置自定义环境变量，支持配置额外的 volume 和 volumeMount，以及支持设置自定义 Store 标签。优化提升方面包括增加重试机制解决 DNS 查询异常处理问题，优化 Thanos 的 example yaml，以及在 PD 的扩缩容和容灾过程中增加多 PVC 支持。Bug 修复方面包括修复挂载多 PVC 时容量设置错误的问题，修复 TidbMonitor 外部标签包含无法识别的环境变量的问题，以及修复备份或恢复 Pod 状态没有正常更新为 Failed 的问题。
-- [TiDB Operator 1.2.0-beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-beta.2.md): TiDB Operator 1.2.0-beta.2 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。新功能包括 TidbMonitor 支持监控多个启用了 TLS 的 TidbCluster，以及为所有 TiDB 组件设置安全上下文和拓扑约束。优化提升包括为 TidbMonitor Pod 增加 readiness 探测器和支持不生成 Prometheus 的告警规则。 Bug 修复包括修复 TiDB 实例缩容后仍在 TiDB Dashboard 中展示的问题和解决 TidbCluster CR 同步问题。
-- [TiDB Operator 1.2.0-rc.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-rc.1.md): TiDB Operator 1.2.0-rc.1 发布，滚动升级改动会导致 Pump Pod 删除重建。新增支持为 TidbCluster 中的 Pod 与 service 设置自定义的 label，以及对 Pump 的完整生命周期管理。优化提升包括隐藏数据库密码的展示、支持为 Grafana 配置额外的 volumeMount、为 TidbMonitor 增加额外的信息展示列，以及 TidbMonitor 支持将配置信息直接写入到 PD 的 etcd 中。Bug 修复包括对启用了 TLS 的 DmCluster 进行监控的问题、PD 在扩容过程中 member 数量统计不正确的问题、DM-master 可能无法成功重启的问题、`configUpdateStrategy` 从 `InPlace` 修改为 `RollingUpdate` 后可能造成的 TidbCluster 组件滚动更新的问题，以及使用 Dumpling 备份数据时可能失败的问题。
-- [TiDB Operator 1.2.0-rc.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-rc.2.md): TiDB Operator 1.2.0-rc.2 发布，新增支持透传 TiCDC 的 TOML 格式配置、为 TiCDC 设置存储卷和挂载、自定义 Discovery、TidbMonitor 和 TidbInitializer 的标签和注释、修改 Grafana 仪表盘。优化支持未指定 BR toolImage tag 时将 TiKV 版本作为 tag、扩缩容 TiDB 过程中协调 PVC、增加 liveness 与 readiness 探测器。修复部署异构集群时可能 panic 的问题、TidbCluster spec 未更改时 TiDB service 与 TidbCluster 状态持续更新的问题。
-- [TiDB Operator 1.2.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.1.md): TiDB Operator 1.2.1 版本发布日期为 2021 年 8 月 18 日。滚动升级改动，如果部署 TiCDC 时配置了 hostNetwork 为 true，升级 TiDB Operator 后会导致 TiCDC Pod 删除重建。优化提升包括支持为 TidbCluster 的所有组件配置 hostNetwork，使所有组件都可以使用宿主机网络。
-- [TiDB Operator 1.2.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.2.md): TiDB Operator 1.2.2 版本发布日期为 2021 年 9 月 3 日。滚动升级改动包括升级 TiDB Operator 会导致 TiDBMonitor Pod 和 TiFlash Pod 删除重建。新功能包括 TiDBMonitor 支持动态重新加载配置。Bug 修复包括修复 TiCDC 无法从低版本升级到 v5.2.0 的问题。
-- [TiDB Operator 1.2.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.3.md): TiDB Operator 1.2.3 版本发布日期为 2021 年 9 月 7 日。此版本修复了升级到 TiDB Operator v1.2.2 时导致 TiFlash Pod 滚动重启的问题。
-- [TiDB Operator 1.2.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.4.md): TiDB Operator 1.2.4 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级会导致 TidbMonitor Pod 删除重建。新增 TidbMonitor 支持用户自定义 Prometheus 告警规则和动态重新加载告警规则，以及支持批量删除备份数据。优化了 TiFlash 滚动升级流程，修复了镜像中的安全漏洞和备份数据残留的问题。
-- [TiDB Operator 1.2.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.5.md): TiDB Operator 1.2.5 版本发布，优化了 DM 配置、TiFlash init container 资源配置和 TiDB TLS 客户端认证参数配置。修复了组件启动脚本更新后的滚动更新问题、启用 TLS 后 TidbCluster spec 自动更新问题、TiKV Region leader 数量计算可能导致 goroutine 泄露的问题和一些高级别的安全问题。
-- [TiDB Operator 1.2.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.6.md): TiDB Operator 1.2.6 发布日期 2022 年 1 月 4 日。优化更新 Restore 和 Backup 状态时的重试逻辑。
-- [TiDB Operator 1.2.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.7.md): TiDB Operator 1.2.7 发布，新增 `spec.pd.startUpScriptVersion` 字段，支持在 PD 启动脚本中使用 `dig` 命令解析域名。优化部署或更新组件的 StatefulSet，预先检查配置的 VolumeMount 是否存在，防止集群进行失败的滚动更新。
-- [TiDB Operator 1.3.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.0.md): TiDB Operator 1.3.0 版本发布，包括兼容性改动、新功能、优化提升和 Bug 修复。兼容性改动包括跨集群部署 TiDB 集群升级操作，TiFlash 升级操作需注意。新增功能包括支持内部组件访问 TiDB 时跳过服务端证书验证、设置所有组件 Pod 的 DNS 配置等。优化提升包括部署或更新组件的 StatefulSet 预先检查配置的 VolumeMount 是否存在，跨集群部署 TiDB 集群功能增强。Bug 修复包括修复 Kubernetes v1.23 及之后版本无法部署 tidb scheduler 的问题。
-- [TiDB Operator 1.3.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.0-beta.1.md): TiDB Operator 1.3.0-beta.1 发布日期为 2022 年 1 月 12 日。此版本的兼容性改动包括删除 Pod `ValidatingWebhook` 和 `MutatingWebhook`，升级后不会影响 TiDB 集群管理。升级到 1.3.0-beta.1 版本后，需要按照操作来升级 TiDB Operator。此版本还支持新功能和优化提升，包括支持 TiFlash 的 init container 配置资源使用量，支持持续性能分析，以及优化 TidbMonitor 部署示例等。
-- [TiDB Operator 1.3.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.1.md): TiDB Operator 1.3.1 版本发布日期为 2022 年 2 月 24 日。此版本修复了 TiFlash 丢失元数据的问题，并添加了新的 `spec.dnsPolicy` 字段以支持配置 Pod 的 DNSPolicy。另外，`tidb-lightning` Helm chart 默认后端改为使用 `local`。还修复了 TiFlash 配置中缺少 `tmp_path` 字段时无法使用 TiFlash v5.4.0 及以后版本的问题，以及 Discovery 服务错误导致 TiDB 集群 PD 组件启动失败的问题。
-- [TiDB Operator 1.3.10 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.10.md): TiDB Operator 1.3.10 发布，优化提升包括升级 Golang 版本到 1.19 以修复安全漏洞。
-- [TiDB Operator 1.3.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.2.md): TiDB Operator 1.3.2 版本发布，优化支持在启用 Istio 的 Kubernetes 集群上部署与运行 TiDB，支持多架构 Docker 镜像包括 ARM 系统。
-- [TiDB Operator 1.3.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.3.md): TiDB Operator 1.3.3 发布，新增了 `spec.tidb.service.port` 字段，修复了集群升级过程中可能泄漏的问题，更新了 `tidb-backup-manager` 镜像的基础镜像，修复了不兼容 ARM 架构的问题，修复了当 tidb Service 没有 Endpoint 时可能会 panic 的问题，修复了 Kubernetes 集群访问失败并重试后组件 Pod 的 Labels 和 Annotations 可能丢失的问题。
-- [TiDB Operator 1.3.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.4.md): TiDB Operator 1.3.4 发布，优化提升包括在各个组件的状态信息中添加了 `volumes` 字段，以展示存储卷状态。
-- [TiDB Operator 1.3.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.5.md): TiDB Operator 1.3.5 发布，新增功能支持使用 Azure Blob Storage 备份与恢复 TiDB 集群数据。
-- [TiDB Operator 1.3.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.6.md): TiDB Operator 1.3.6 版本发布日期为 2022 年 7 月 5 日。此版本优化了扩容 PVC 对集群性能的影响，现在扩容 PVC 时按照 Pod 一个个扩容，并且在扩容 TiKV 的 PVC 前会先驱逐该 TiKV 上的 leader。
-- [TiDB Operator 1.3.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.7.md): TiDB Operator 1.3.7 版本发布，新增了暂停组件功能，优化了扩容完成后重建 StatefulSet 的流程，修复了本地存储升级 TiKV 和清理备份文件后残留的问题。
-- [TiDB Operator 1.3.8 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.8.md): TiDB Operator 1.3.8 版本发布，新增了为 `TidbCluster` 添加特殊 Annotation 的功能，支持配置 TiDB、TiKV 和 TiFlash 的 Pod 的最小等待时间。此外，还优化了支持优雅升级版本大于或等于 6.3.0 的 TiCDC pod。
-- [TiDB Operator 1.3.9 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.9.md): TiDB Operator 1.3.9 发布，修复了在已设置 `acrossK8s` 字段但未设置 `clusterDomain` 的情况下，PD 升级流程会卡住的问题。
-- [TiDB Operator 1.4. Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.7.md): TiDB Operator 1.4.7 发布，修复了 BackupSchedule CR 字段中的 `logBackupTemplate` 字段变成可选值的问题。
-- [TiDB Operator 1.4.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0.md): TiDB Operator 1.4.0 版本发布，新增支持独立管理 TiDB Dashboard，配置 TiKV 和 PD 的 Readiness Probe，以及基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复。优化支持 IPv6 网络环境，修复了基于 EBS 快照备份无法恢复到不同 namespace 的问题和日志备份停止占用 Complete 状态的 bug。
-- [TiDB Operator 1.4.0-alpha.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-alpha.1.md): TiDB Operator 1.4.0-alpha.1 发布，包含兼容性改动、滚动升级改动、新功能、优化提升和错误修复。新增自动设置 TiDB 的 location labels、新字段 `spec.tikv.scalePolicy` 与 `spec.tiflash.scalePolicy`、`startScriptVersion` 字段、BR 恢复集群到备份时间点、feature gate `VolumeModifying`、修改存储参数、配置 BR 的 `--check-requirements` 参数、使用字段 `additionalContainers` 自定义 Pod 容器配置。优化了 `TidbMonitor` 使用的 Prometheus 的 remoteWrite 配置和 TiFlash `Service` 添加 metric 端口。修复了集群扩缩容时的问题和 PD spec 为空导致 TiDB Operator 崩溃的问题。
-- [TiDB Operator 1.4.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.1.md): TiDB Operator 1.4.0-beta.1 发布，新增支持基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复（实验特性），修复了日志备份的 checkpoint ts 无法更新的问题。
-- [TiDB Operator 1.4.0-beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.2.md): TiDB Operator 1.4.0-beta.2 发布日期为 2022 年 11 月 11 日。此版本修复了使用 Azure Blob Storage 时未设置前缀的问题，并升级了 AWS SDK 到 v1.44.72 以支持使用 AWS 的 Asia Pacific (Jakarta) 区域 (`ap-southeast-3`)。
-- [TiDB Operator 1.4.0-beta.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.3.md): TiDB Operator 1.4.0-beta.3 发布，新增 TiProxy 实验性支持和基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复 GA。修复了拼写错误和清理卷快照备份失败的问题，以及大规模 TiKV 节点下备份 TiDB 集群失败的问题。
-- [TiDB Operator 1.4.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.1.md): TiDB Operator 1.4.1 版本发布，新增故障自动转移功能，优化了 TiDB Controller Manager 中 Kubernetes 客户端的配置，修复了未配置 PV 权限时 TiDB Controller Manager panic 的问题。
-- [TiDB Operator 1.4.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.2.md): TiDB Operator 1.4.2 发布，修复了开启 `preferIPv6` 时 TiFlash 没有监听 IPv6 地址的问题。
-- [TiDB Operator 1.4.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.3.md): TiDB Operator 1.4.3 发布，修复了开启 `preferIPv6` 时 TiFlash 的 metric server 未监听正确 IPv6 地址的问题，以及在 AWS 环境中打开了 feature gate `VolumeModifying` 且 `StorageClass` 缺少 EBS 相关参数时 TiDB Operator 会一直尝试修改 EBS 参数的问题。
-- [TiDB Operator 1.4.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.4.md): TiDB Operator 1.4.4 发布，新增支持在已部署 TiFlash 的集群上使用卷快照备份和恢复，准确显示备份大小，支持重试快照备份，集成管理日志备份和快照备份。修复了使用非语义版本格式的 TiDB 镜像同步失败的问题，使用卷快照备份一个已缩容的集群后无法恢复数据的问题，卷快照备份可能崩溃的问题，卷快照恢复可能在最后阶段失败的问题。
-- [TiDB Operator 1.4.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.5.md): TiDB Operator 1.4.5 版本发布，优化了 TidbCluster 的错误处理相关 metrics 和 worker 队列相关 metrics，增加了 DM master 组件的 `startUpScriptVersion` 字段，以及跨 Kubernetes 集群滚动重启或缩容 TiCDC 集群的能力。同时修复了定时备份中取消 GC、Backup CR 字段可选值、TiDB Operator 未配置权限时的 panic 问题，以及 TidbCluster 中设置 `AdditionalVolumeMounts` 时可能的 panic 问题。
-- [TiDB Operator 1.4.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.6.md): TiDB Operator 1.4.6 发布，优化默认启用 volume resize 支持，修复备份恢复时报错问题，修复 TiCDC image tag 不符合语义化版本时无法 Graceful Drain TiCDC 的问题。
-- [TiDB Operator 1.5.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.0.md): 了解 TiDB Operator 1.5.0 版本的新功能、优化提升，以及 Bug 修复。
-- [TiDB Operator 1.5.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.0-beta.1.md): TiDB Operator 1.5.0-beta.1 发布，新增支持优雅重启 PD 和 TiDB Pod，使用 Advanced StatefulSet 管理 TiCDC 和 TiProxy，新增 TiDB Spec 字段，允许用户定义策略重启失败备份任务，升级 Kubernetes 依赖库至 v1.20 版本，添加与 reconciler 和 worker queue 相关的 Metric，优化滚动升级 TiKV 节点性能，允许用户自定义 Prometheus Scraping 相关配置，TiProxy 支持共享部分 TiDB 证书，配置 `spec.preferIPv6` 为 `true` 时，Service 的 `ipFamilyPolicy` 将配置为 `PreferDualStack`，添加统计协调流程失败计数的 Metric，修复了因为 metric 接口冲突而导致 pprof 接口无法访问的问题。
-- [TiDB Operator 1.5.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.1.md): TiDB Operator 1.5.1 发布，新增支持替换 PD、TiKV 和 TiDB 所使用的 volume。修复了多个 Bug，包括手动触发 TiKV eviction 时 PVC Modifier 报错的问题，替换 TiKV volume 过程中再触发 TiKV eviction 时可能造成 TiDB Operator reconcile 死锁的问题，TidbCluster 在 Upgrade 过程中可能无法回滚的问题，以及 MaxReservedTime 选项没有被 backup schedule gc 使用的问题。
-- [TiDB Operator 1.5.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.2.md): TiDB Operator 1.5.2 版本新增了对 AWS EBS 快照的备份能力的跨多个 K8S 集群的支持。优化了重启 PD、TiKV 时的启动流程，修复了替换 volume 时可能出现的问题。
-- [TiDB Operator 1.5.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.3.md): 了解 TiDB Operator 1.5.3 版本的新功能和 Bug 修复。
-- [TiDB Operator 1.5.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.4.md): 了解 TiDB Operator 1.5.4 版本的优化提升和 Bug 修复。
-- [TiDB Operator 1.5.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.5.md): 了解 TiDB Operator 1.5.5 版本的新功能和优化提升。
-- [TiDB Operator 1.6.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.0.md): 了解 TiDB Operator 1.6.0 版本的新功能、优化提升，以及 Bug 修复。
-- [TiDB Operator 1.6.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.0-beta.1.md): 了解 TiDB Operator 1.6.0-beta.1 版本的新功能、优化提升，以及 Bug 修复。
-- [TiDB Operator 1.6.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.1.md): 了解 TiDB Operator 1.6.1 版本的新功能、优化提升，以及 Bug 修复。
-- [TiDB Operator RBAC 规则](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-operator-rbac.md): 介绍 TiDB Operator 需要的 RBAC 规则。
-- [TiDB Operator v1.6 新特性](https://docs.pingcap.com/tidb-in-kubernetes/stable/whats-new-in-v1.6.md): 了解 TiDB Operator 1.6.0 版本引入的新特性。
-- [TiDB Operator 架构](https://docs.pingcap.com/tidb-in-kubernetes/stable/architecture.md): 了解 TiDB Operator 架构及其工作原理。
-- [TiDB Operator 简介](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-operator-overview.md): 介绍 TiDB Operator 的整体架构及使用方式。
-- [TiDB Scheduler 扩展调度器](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-scheduler.md): 了解 TiDB Scheduler 扩展调度器及其工作原理。
-- [TiDB 集群的监控与告警](https://docs.pingcap.com/tidb-in-kubernetes/stable/monitor-a-tidb-cluster.md): 介绍如何监控 TiDB 集群。
-- [TidbMonitor 分片功能](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-monitor-shards.md): 如何使用 TidbMonitor 分片功能
-- [TidbMonitor 开启动态配置功能](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-monitor-dynamic-configuration.md): 动态更新 TidbMonitor 配置
-- [为 DM 开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-dm.md): 在 Kubernetes 上如何为 DM 开启 TLS。
-- [为 MySQL 客户端开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-mysql-client.md): 在 Kubernetes 上如何为 TiDB 集群的 MySQL 客户端开启 TLS。
-- [为 TiDB 组件间开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-between-components.md): 在 Kubernetes 上如何为 TiDB 集群组件间开启 TLS。
-- [为使用云存储的 TiDB 集群更换节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/replace-nodes-for-cloud-disk.md): 介绍如何为使用云存储的 TiDB 集群更换节点。
-- [为使用本地存储的 TiDB 集群更换节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/replace-nodes-for-local-disk.md): 介绍如何为使用本地存储的 TiDB 集群更换节点。
-- [为已有 TiDB 集群部署 HTAP 存储引擎 TiFlash](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tiflash.md): 了解如何在 Kubernetes 上为已有 TiDB 集群部署 TiDB HTAP 存储引擎 TiFlash。
-- [为已有 TiDB 集群部署异构集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-heterogeneous-tidb-cluster.md): 本文档介绍如何为已有的 TiDB 集群部署一个异构集群。
-- [为已有 TiDB 集群部署负载均衡 TiProxy](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tiproxy.md): 了解如何在 Kubernetes 上为已有 TiDB 集群部署负载均衡 TiProxy。
-- [从 Helm 2 迁移到 Helm 3](https://docs.pingcap.com/tidb-in-kubernetes/stable/migrate-to-helm3.md): 介绍如何将由 Helm 2 管理的组件迁移到由 Helm 3 管理。
-- [以非 root 用户运行容器](https://docs.pingcap.com/tidb-in-kubernetes/stable/containers-run-as-non-root-user.md): 了解如何以非 root 用户运行容器。
-- [使用 BR 备份 TiDB 集群到 GCS](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs-using-br.md): 介绍如何使用 BR 备份 TiDB 集群到 Google Cloud Storage (GCS)。
-- [使用 BR 备份 TiDB 集群数据到 Azure Blob Storage](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-azblob-using-br.md): 介绍如何使用 BR 备份 TiDB 集群数据到 Azure Blob Storage 上。
-- [使用 BR 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-aws-s3-using-br.md): 介绍如何使用 BR 备份 TiDB 集群数据到兼容 Amazon S3 的存储。
-- [使用 BR 恢复 Azure Blob Storage 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-azblob-using-br.md): 介绍如何使用 BR 恢复 Azure Blob Storage 上的备份数据。
-- [使用 BR 恢复 GCS 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-gcs-using-br.md): 介绍如何使用 BR 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
-- [使用 BR 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-aws-s3-using-br.md): 介绍如何使用 BR 恢复 Amazon S3 兼容存储上的备份数据。
-- [使用 Dumpling 备份 TiDB 集群数据到 GCS](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs.md): 介绍如何使用 Dumpling 将 TiDB 集群数据备份到 Google Cloud Storage (GCS)。
-- [使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-s3.md): 介绍如何使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储。
-- [使用 PD Recover 恢复 PD 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/pd-recover.md): 了解如何使用 PD Recover 恢复 PD 集群。
-- [使用 PingCAP Clinic 诊断 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/clinic-user-guide.md): 详细介绍在使用 TiDB Operator 部署的集群上如何安装、使用 PingCAP Clinic 诊断服务进行数据采集和快速检查。
-- [使用 TiDB Lightning 恢复 GCS 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-gcs.md): 介绍如何使用 TiDB Lightning 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
-- [使用 TiDB Lightning 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-s3.md): 了解如何使用 TiDB Lightning 将兼容 S3 存储上的备份数据恢复到 TiDB 集群。
-- [使用多套 TiDB Operator 单独管理不同的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-multiple-tidb-operator.md): 介绍如何部署多套 TiDB Operator 分别管理不同的 TiDB 集群。
-- [修改 TiDB 集群配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/modify-tidb-configuration.md): 了解如何修改部署在 Kubernetes 上的 TiDB 的集群配置。
-- [升级 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster.md): 介绍如何升级 Kubernetes 上的 TiDB 集群。
-- [升级 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/upgrade-tidb-operator.md): 介绍如何升级 TiDB Operator。
-- [同步数据到开启 TLS 的下游服务](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-ticdc-sink.md): 了解在 Kubernetes 上如何同步数据到开启 TLS 的下游服务。
-- [在 ARM64 机器上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-cluster-on-arm64.md): 本文档介绍如何在 ARM64 机器上部署 TiDB 集群
-- [在 AWS EKS 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-aws-eks.md): 介绍如何在 AWS EKS (Elastic Kubernetes Service) 上部署 TiDB 集群。
-- [在 Azure AKS 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-azure-aks.md): 介绍如何在 Azure AKS (Azure Kubernetes Service) 上部署 TiDB 集群。
-- [在 Google Cloud GKE 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-gcp-gke.md): 了解如何在 Google Cloud GKE 上部署 TiDB 集群。
-- [在 Kubernetes 上使用 DM](https://docs.pingcap.com/tidb-in-kubernetes/stable/use-tidb-dm.md): 了解如何在 Kubernetes 上使用 TiDB DM 迁移数据。
-- [在 Kubernetes 上快速上手 TiDB](https://docs.pingcap.com/tidb-in-kubernetes/stable/get-started.md): 介绍如何快速地在 Kubernetes 上使用 TiDB Operator 部署 TiDB 集群
-- [在 Kubernetes 上部署 DM](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-dm.md): 了解如何在 Kubernetes 上部署 TiDB DM 集群。
-- [在 Kubernetes 上部署 TiCDC](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-ticdc.md): 了解如何在 Kubernetes 上部署 TiCDC。
-- [在 Kubernetes 上部署 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-operator.md): 了解如何在 Kubernetes 上部署 TiDB Operator。
-- [在标准 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-general-kubernetes.md): 介绍如何在标准 Kubernetes 集群上通过 TiDB Operator 部署 TiDB 集群。
-- [基于 AWS EBS 卷快照的备份](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-aws-s3-by-snapshot.md): 介绍如何基于 EBS 卷快照使用 TiDB Operator 备份 TiDB 集群数据到 S3。
-- [基于 AWS EBS 卷快照的恢复](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-aws-s3-by-snapshot.md): 介绍如何将存储在 S3 上的备份元数据以及 EBS 卷快照恢复到 TiDB 集群。
-- [基于 EBS 卷快照备份恢复的性能介绍](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-snapshot-perf.md): 了解 EBS 卷快照备份恢复的性能基线。
-- [基于 EBS 卷快照的备份恢复功能架构](https://docs.pingcap.com/tidb-in-kubernetes/stable/volume-snapshot-backup-restore.md): 了解 TiDB EBS 卷快照的备份恢复架构设计。
-- [基于 EBS 快照备份恢复的常见问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-faq.md): 介绍卷快照备份恢复中的常见问题以及解决方案。
-- [增强型 StatefulSet 控制器](https://docs.pingcap.com/tidb-in-kubernetes/stable/advanced-statefulset.md): 介绍如何开启、使用增强型 StatefulSet 控制器
-- [备份 TiDB 集群到持久卷](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-pv-using-br.md): 介绍如何使用 BR 备份 TiDB 集群数据到持久卷。
-- [备份与恢复 CR 介绍](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-cr.md): 介绍用于备份与恢复的 Custom Resource (CR) 资源的各字段。
-- [备份与恢复简介](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-overview.md): 介绍如何使用 BR、Dumpling、TiDB Lightning 工具对 Kubernetes 上的 TiDB 集群进行数据备份和数据恢复。
-- [导入集群数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-data-using-tidb-lightning.md): 使用 TiDB Lightning 导入集群数据。
-- [将 TiDB 迁移至 Kubernetes](https://docs.pingcap.com/tidb-in-kubernetes/stable/migrate-tidb-to-kubernetes.md): 介绍如何将部署在物理机或虚拟机中的 TiDB 迁移至 Kubernetes 集群中
-- [开启 TiDB Operator 准入控制器](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-admission-webhook.md): 介绍如何开启 TiDB Operator 准入控制器以及它的作用。
-- [恢复持久卷上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-pv-using-br.md): 介绍如何将存储在持久卷上的备份数据恢复到 TiDB 集群。
-- [恢复误删的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/recover-deleted-cluster.md): 介绍如何恢复误删的 TiDB 集群。
-- [手动扩缩容 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/scale-a-tidb-cluster.md): 了解如何在 Kubernetes 上对 TiDB 集群手动扩缩容。
-- [挂起 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/suspend-tidb-cluster.md): 了解如何通过配置挂起 Kubernetes 上的 TiDB 集群。
-- [日志收集](https://docs.pingcap.com/tidb-in-kubernetes/stable/logs-collection.md): 介绍收集 TiDB 及相关组件日志的方法。
-- [暂停同步 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/pause-sync-of-tidb-cluster.md): 介绍如何暂停同步 Kubernetes 上的 TiDB 集群
-- [更新和替换 TLS 证书](https://docs.pingcap.com/tidb-in-kubernetes/stable/renew-tls-certificate.md): 介绍如何更新和替换 TiDB 组件间的 TLS 证书。
-- [构建多个网络互通的 AWS EKS 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/build-multi-aws-eks.md): 介绍如何构建多个 AWS EKS 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
-- [构建多个网络互通的 Google Cloud GKE 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/build-multi-gcp-gke.md): 介绍如何构建多个 Google Cloud GKE 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
-- [查看日志](https://docs.pingcap.com/tidb-in-kubernetes/stable/view-logs.md): 介绍如何查看 TiDB 集群各组件日志以及 TiDB 慢查询日志。
-- [灰度升级 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/canary-upgrade-tidb-operator.md): 介绍如何灰度升级 TiDB Operator，避免 TiDB Operator 升级对整个 Kubernetes 集群中的所有 TiDB 集群产生不可预知的影响。
-- [管理 TiDB 集群的 Command Cheat Sheet](https://docs.pingcap.com/tidb-in-kubernetes/stable/cheat-sheet.md): 介绍管理 TiDB 集群的 Command Cheat Sheet。
-- [维护 TiDB 集群所在的 Kubernetes 节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/maintain-a-kubernetes-node.md): 介绍如何维护 TiDB 集群所在的 Kubernetes 节点。
-- [聚合多个 TiDB 集群的监控数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/aggregate-multiple-cluster-monitor-data.md): 通过 Thanos 框架聚合多个 TiDB 集群的监控数据
-- [访问 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/access-tidb.md): 介绍如何访问 Kubernetes 上的 TiDB 集群。
-- [访问 TiDB Dashboard](https://docs.pingcap.com/tidb-in-kubernetes/stable/access-dashboard.md): 介绍如何在 Kubernetes 环境下访问 TiDB Dashboard
-- [跨多个 Kubernetes 集群监控 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-monitor-across-multiple-kubernetes.md): 介绍如何对跨多个 Kubernetes 集群的 TiDB 集群进行监控，并集成到常见 Prometheus 多集群监控体系中
-- [跨多个 Kubernetes 集群部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-cluster-across-multiple-kubernetes.md): 本文档介绍如何实现跨多个 Kubernetes 集群部署 TiDB 集群
-- [远程存储访问授权](https://docs.pingcap.com/tidb-in-kubernetes/stable/grant-permissions-to-remote-storage.md): 介绍如何授权访问远程存储。
-- [部署 TiDB Binlog](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-binlog.md): 了解如何在 Kubernetes 上部署 TiDB 集群的 TiDB Binlog。
-- [配置 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-a-tidb-cluster.md): 了解如何在 Kubernetes 中配置 TiDB 集群。
-- [重启 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/restart-a-tidb-cluster.md): 了解如何重启 Kubernetes 集群上的 TiDB 集群。
-- [销毁 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/destroy-a-tidb-cluster.md): 介绍如何销毁 Kubernetes 集群上的 TiDB 集群。
+- [Kubernetes 上的 TiDB Binlog Drainer 配置](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/configure-tidb-binlog-drainer.md): 了解 Kubernetes 上的 TiDB Binlog Drainer 配置参数。
+- [Kubernetes 上的 TiDB 工具指南](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/tidb-toolkit.md): 详细介绍 Kubernetes 上的 TiDB 相关的工具及其使用方法。
+- [Kubernetes 上的 TiDB 常见部署错误](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-failures.md): 介绍 Kubernetes 上 TiDB 部署的常见错误以及处理办法。
+- [Kubernetes 上的 TiDB 集群常见异常](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/exceptions.md): 介绍 TiDB 集群运行过程中常见异常以及处理办法。
+- [Kubernetes 上的 TiDB 集群常见网络问题](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/network-issues.md): 介绍 Kubernetes 上 TiDB 集群的常见网络问题以及诊断解决方案。
+- [Kubernetes 上的 TiDB 集群常见问题](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/faq.md): 介绍 Kubernetes 上的 TiDB 集群常见问题以及解决方案。
+- [Kubernetes 上的 TiDB 集群故障自动转移](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/use-auto-failover.md): 介绍 Kubernetes 上的 TiDB 集群故障自动转移的功能。
+- [Kubernetes 上的 TiDB 集群环境需求](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/prerequisites.md): 介绍在 Kubernetes 上部署 TiDB 集群的软硬件环境需求。
+- [Kubernetes 上的 TiDB 集群管理常用使用技巧](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/tips.md): 介绍 Kubernetes 上 TiDB 集群管理常用使用技巧。
+- [Kubernetes 上的持久化存储类型配置](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/configure-storage-class.md): 介绍 Kubernetes 上的数据持久化存储类型配置。
+- [Kubernetes 上的集群初始化配置](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/initialize-a-cluster.md): 介绍如何初始化配置 Kubernetes 上的 TiDB 集群。
+- [Kubernetes 的监控与告警](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/monitor-kubernetes.md): 介绍如何监控 Kubernetes。
+- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/clinic-data-collection.md): 详细说明 PingCAP Clinic 诊断服务在使用 Operator 部署的 TiDB 集群中能够采集的诊断数据类型、输出文件及采集参数。
+- [TiDB on Kubernetes Sysbench 性能测试](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/benchmark-sysbench.md): TiDB Operator GA 发布后，我们在 GKE 平台进行了全面的性能测试。测试结果显示，在 Host 网络模式下，TiDB 性能略优于 Pod 网络模式（约 7%）。此外，使用 Ubuntu 系统的 Host 网络模式下，TiDB 性能也略优于 COS 系统（约 9%）。在集群外访问时，使用 Load Balancer 会略损失性能（约 5%）。多可用区下节点之间的延迟增加，会对 TiDB 性能产生一定影响（30% ~ 6%）。计算型机型相对普通型机器带来了很大 QPS 提升（50% ~ 60%）。
+- [TiDB Operator 0.1.0 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-0.1.0.md): TiDB Operator 0.1.0 was released on August 22, 2018. Notable changes include the ability to bootstrap multiple TiDB clusters, support for monitoring deployment and Helm charts, basic Network PV/Local PV support, safe scaling of the TiDB cluster, orderly cluster upgrades, and stopping the TiDB process without terminating the Pod. Additionally, cluster meta info can be synchronized to POD/PV/PVC labels, and basic unit tests & E2E tests are available. Tutorials for GKE and local DinD are also provided.
+- [TiDB Operator 0.2.0 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-0.2.0.md): TiDB Operator 0.2.0 was released on September 11, 2018. Notable changes include experimental support for auto-failover, unification of Tiller and TiDB Operator managed resources labels, managing TiDB service via Tiller, adding toleration for TiDB cluster components, and refactoring upgrade functions as interface. Additionally, a script for easy setup of DinD environment was added, and code was linted and formatted in CI.
+- [TiDB Operator 0.2.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-0.2.1.md): TiDB Operator 0.2.1 was released on September 20, 2018. This version includes bug fixes for retry on conflict logic, TiDB timezone configuration, failover, and repeated updating of pod and pd/tidb StatefulSet.
+- [TiDB Operator 0.3.0 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-0.3.0.md): TiDB Operator 0.3.0 was released on October 12, 2018. Notable changes include the addition of full backup support, TiDB Binlog support, graceful upgrade feature, and the ability to persist monitor data.
+- [TiDB Operator 0.3.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-0.3.1.md): TiDB Operator 0.3.1 was released on October 31, 2018. The release includes minor changes such as parameterizing the serviceAccount, bumping TiDB to v2.0.7, and allowing user-specified config files. Bug fixes include addressing issues with parallel upgrades, wrong parameters, and recovery after a failed upgrade.
+- [TiDB Operator 0.4 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-0.4.0.md): TiDB Operator 0.4.0 was released on November 9, 2018. Notable changes include extending Kubernetes scheduler for TiDB data awareness, restoring backup data from GCS bucket, and setting password for TiDB when first deployed. Minor changes and bug fixes include updating roadmap, adding unit tests, E2E tests, adding TiDB failover limit, synchronizing PV reclaim policy early, using helm release name as instance label, and fixing local PV setup script.
+- [TiDB Operator 1.0 Beta.0 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.0-beta.0.md): TiDB Operator 1.0 Beta.0 was released on November 26, 2018. Notable changes include the introduction of basic chaos testing, improved unit test coverage, default log-level values for PD/TiKV/TiDB, and various bug fixes and enhancements. The release also includes a user guide and migration to Go 1.11 module.
+- [TiDB Operator 1.0 Beta.1 P1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p1.md): TiDB Operator 1.0 Beta.1 P1 was released on January 7, 2019. The bug fixes include resolving scheduler policy issues for Kubernetes v1.10, v1.11, and v1.12. The documentation updates include a proposal to add multiple statefulsets support to TiDB Operator and an updated roadmap.
+- [TiDB Operator 1.0 Beta.1 P2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p2.md): TiDB Operator 1.0 Beta.1 P2 was released on February 21, 2019. Notable changes include a new algorithm for scheduler HA predicate, addition of TiDB discovery service, serial scheduling, change in tolerations type to an array, direct start when there is a join file, addition of code coverage icon, omission of just the empty leaves in `values.yml`, backup to ceph object storage in charts, and addition of `ClusterIDLabelKey` label to TidbCluster.
+- [TiDB Operator 1.0 Beta.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.0-beta.1.md): TiDB Operator 1.0 Beta.1 was released on December 27, 2018. The release includes bug fixes such as pd_control bug, orphan pod cleaner, scheduler configuration fix, Grafana configuration fix, and more. Minor improvements include adding Kubernetes 1.12 local DinD scripts, bumping default TiDB to v2.1.0, releasing tidb-operator/tidb-cluster charts, and adding connection timeout for TiDB password setter job. Other improvements involve separating ad-hoc backup and restore to another chart, adding compiler version info to tidb-operator binary, allowing specifying TiDB service LoadBalancer IP, and exposing TiKV cpu/memory related configuration to values.yaml.
+- [TiDB Operator 1.0 Beta.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.0-beta.2.md): TiDB Operator 1.0 Beta.2 has been released on May 10, 2019. The new version includes enhanced stability, improved ease of use, bug fixes, and other improvements. Some of the key changes include refactored e2e test, one-command deployment for AWS and Aliyun, and support for slow log of TiDB. Numerous bug fixes and detailed changes have also been made to improve the overall performance and user experience.
+- [TiDB Operator 1.0 Beta.3 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.0-beta.3.md): TiDB Operator 1.0 Beta.3 was released on June 6, 2019. The new version includes the removal of `nodeSelectorRequired` from values.yaml and the addition of stability cases, new features, documentation improvements, and bug fixes. Some notable new features include ConfigMap rollout management, stable scheduling for pods, and support for adding additional pod annotations. The default TiDB version has been upgraded to v3.0.0-rc.1, and various bug fixes and changes have been implemented.
+- [TiDB Operator 1.0 GA Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0-ga.md): TiDB Operator 1.0.0 has been released on July 30, 2019. The new version requires action to be taken for configuration changes in `values.yaml`. Stability test cases have been added, along with improvements such as GKE SSD setup simplification and AWS Terraform script modularization. Bug fixes include sysbench installation and TiKV metrics monitoring. Detailed bug fixes and changes include upgrading TiDB monitor, specifying TiKV status address, and enabling nlb cross zone load balancing by default. Multiple TiDB clusters management is now supported in Alibaba Cloud. The default TiDB version has been upgraded to v3.0.1. The release also includes various other bug fixes and improvements.
+- [TiDB Operator 1.0 RC.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.0-rc.1.md): TiDB Operator 1.0 RC.1 was released on July 12, 2019. The new version includes stability test cases, improvements such as increasing TiKV GC life time, and bug fixes like fixing unbound variables in the backup script and scheduled backup bugs. It also supports force upgrade when PD cluster is unavailable and adds Amazon S3 support for backup/restore features. Multiple clusters management in EKS and local SSD provision for COS on GKE are also included. The release notes contain detailed bug fixes and changes, including various pull requests for bug fixes and improvements.
+- [TiDB Operator 1.0.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.1.md): TiDB Operator version 1.0.1 was released on September 17, 2019. The release includes important bug fixes and improvements. Users of version 1.0.0 or prior must upgrade to avoid potential service outage. The backup tool image has been updated to fix a serious bug. Other improvements include modularizing GCP Terraform, adding support for various configurations, and reducing e2e run time. Bug fixes address issues such as TiKV scale-in failure, orphan pods cleaner bugs, and incorrect condition judgment. The release also includes detailed bug fixes and changes.
+- [TiDB Operator 1.0.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.2.md): TiDB Operator version 1.0.2 was released on November 1, 2019. The new version includes improvements such as suspending the ReplaceUnhealthy process for AWS TiKV auto-scaling-group, adding a new VM manager 'qm' in stability test, and setting default externalTrafficPolicy to 'Local' for TiDB service in AWS/GCP/Aliyun. Bug fixes include issues with tkctl version, create_tidb_cluster_release variable in AWS Terraform script, and compatibility issues with Kubernetes 1.16 and above versions. Other fixes and changes are also included in this release.
+- [TiDB Operator 1.0.3 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.3.md): TiDB Operator version 1.0.3 was released on November 13, 2019. The new version requires an upgrade to TiDB v3.0.5 and adds timezone support for all charts. Existing TiDB clusters with customized timezones will trigger a rolling update. Improvements include timezone support and configuring resource requests and limits for all containers of the TiDB cluster. Bug fixes include upgrading default TiDB version to v3.0.5 and adding timezone support for all containers of the TiDB cluster.
+- [TiDB Operator 1.0.4 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.4.md): TiDB Operator version 1.0.4 was released on November 23, 2019. The new version introduces HostNetwork support for better performance, podSecurityContext support, and new Helm charts for TiDB Lightning and TiDB Binlog. It also includes bug fixes and changes. Users of the v1.1.0.alpha branch are advised to upgrade to v1.0.4, as it includes all fixes from the alpha branch and introduces additional improvements.
+- [TiDB Operator 1.0.5 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.5.md): TiDB Operator version 1.0.5 was released on December 11, 2019. The new features include fixing backup failure issue, recommending deployment of TiDB and Pump on the same node, fixing RBAC permission, and resolving e2e nil point dereference. No action is required for upgrading from v1.0.4.
+- [TiDB Operator 1.0.6 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.6.md): TiDB Operator 1.0.6 was released on December 27, 2019. Users need to migrate configs from the old `values.yaml` to the new one to avoid monitor pod failures. The new release includes improvements in monitor, TiDB Scheduler, compatibility, TiKV Importer, E2E, and CI. Notable changes include enabling alert rule persistence, adding node & pod info in TiDB Grafana, refining scheduler error messages, fixing compatibility issues in Kubernetes v1.17, and adjusting the release CI script.
+- [TiDB Operator 1.0.7 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.0.7.md): TiDB Operator 1.0.7 was released on June 16, 2020. Notable changes include fixing alert rules lost after rolling upgrade, upgrading local volume provisioner to 2.3.4, fixing operator failover config invalid, removing unnecessary duplicated docs, updating doc links and image in readme, emitting events when PD failover, fixing some broken urls, and removing some not very useful update events.
+- [TiDB Operator 1.1 Beta.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.0-beta.1.md): 支持配置时区，备份到 S3，基础默认设置，增强型 StatefulSet 扩缩容，自定义资源初始化 TiDB 集群，优化配置结构，支持临时存储，发布 Terraform Aliyun ACK 版本，优化报错信息，支持 TLS 加密连接，支持动态扩展云存储 PV，支持自动生成证书，支持暂停备份计划，升级 TiDB 版本。
+- [TiDB Operator 1.1 Beta.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.0-beta.2.md): 默认存储类和备份存储类已废弃，现在使用 Kubernetes 默认存储类。用户可设置备份和恢复的亲和性和容忍度。解决了 AdvancedStatefulSet 和 Admission Webhook 一起使用的问题。支持基于 CPU 平均负载的集群自动扩容。支持用户自定义证书。修复了一些问题并优化了日志。
+- [TiDB Operator 1.1 GA Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1-ga.md): TiDB Operator 1.1 GA 发布日期 2020 年 5 月 28 日。将 TiDB Pod 的 readiness 探针从 HTTPGet 更改为 TCPSocket 4000 端口。这将触发 tidb-server 组件滚动升级。你可以在升级 TiDB Operator 之前将 spec.paused 设置为 true 以避免滚动升级，并在准备升级 tidb-server 时将其重新设置为 false。
+- [TiDB Operator 1.1 RC.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.0-rc.1.md): 此版本包括对 tidb-server 的配置选项的更新，备份和恢复规范的修改，以及对 TiDB 组件的一些修复和改进。还支持通过 Terraform 在 AWS 和 ACK 上部署 TiDB 集群，并添加了一些新的功能和文档。
+- [TiDB Operator 1.1 RC.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.0-rc.2.md): TiDB Operator 1.1 RC.2 was released on April 15, 2020. Action required includes changing TiDB pod readiness probe and setting spec.paused to true before upgrading. Notable changes include adding status field for TidbAutoScaler CR, emitting more events for TidbCluster and TidbClusterAutoScaler, and adding TLS support for TiKV metrics API. Other changes involve adding a switch to skip PD Dashboard TLS configuration, supporting TiFlash in TidbCluster CR, and fixing errors related to alertmanager in TidbMonitor.
+- [TiDB Operator 1.1 RC.3 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.0-rc.3.md): TiDB Operator 1.1 RC.3 was released on April 30, 2020. Notable changes include support for TiFlash metrics in TidbMonitor, fixing bugs related to failover pods and statefulsets, and adding new features like configuring Ingress in TidbMonitor and supporting failover for TiFlash. Other changes include updates to terraform scripts and adding new fields in TiKVConfig.
+- [TiDB Operator 1.1 RC.4 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.0-rc.4.md): TiDB Operator 1.1 RC.4 发布于 2020 年 5 月 15 日。每个组件可以使用单独的 TiDB 客户端证书。用户应该将 `Backup` 和 `Restore` CR 中的旧的 TLS 配置迁移到新的配置。
+- [TiDB Operator 1.1.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.1.md): TiDB Operator 1.1.1 版本发布，重大变化包括添加 `additionalContainers` 和 `additionalVolumes` 字段，修复了多个问题，并更新了配置版本到 v4.0.1。
+- [TiDB Operator 1.1.10 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.10.md): TiDB Operator 1.1.10 版本发布，包含兼容性改动、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性改动包括 `apiVersion` 更改，滚动升级改动导致 TidbMonitor Pod 删除重建。新功能包括灰度升级、TidbMonitor 支持 `remotewrite`、配置 init containers 等。优化提升包括自定义存储、增加 label 支持多集群监控等。Bug 修复包括备份或者恢复失败、Pod 在升级过程中不会进行迁移 leader 等问题。
+- [TiDB Operator 1.1.11 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.11.md): TiDB Operator 1.1.11 版本发布，新增优化 LeaderElection 和自定义 Store 标签功能。优化 TiFlash 滚动更新机制，改进获取 region leader 数量方式。支持打印 RocksDB 和 Raft 日志到 stdout。
+- [TiDB Operator 1.1.12 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.12.md): TiDB Operator 1.1.12 版本发布日期为 2021 年 4 月 15 日。新功能包括支持为备份和恢复 Job 设置自定义环境变量，支持备份恢复 CR 设置 affinity 和 tolerations，以及支持 tidb-operator chart 使用新的 service account。优化提升包括 TiDBInitializer 中增加重试机制，增加多 PVC 支持，以及优化 `PodsAreChanged` 函数。Bug 修复包括修复挂载多 PVC 时容量设置错误的问题，修复创建 `.spec.tidb` 为空并开启 TLS 的 TidbCluster 导致 tidb-controller-manager panic 的问题，以及修复 `UnjoinedMembers` 中 PVC 状态异常的问题。
+- [TiDB Operator 1.1.13 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.13.md): TiDB Operator 1.1.13 版本发布，优化了 TiCDC 配置 TLS 证书、BR 工具镜像 tag、扩缩容 TiDB 过程中协调 PVC、备份日志中隐藏数据库密码。修复了部署异构集群时可能 panic 的问题和 TiDB 实例缩容后在 TiDB Dashboard 中仍然存在的问题。
+- [TiDB Operator 1.1.14 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.14.md): TiDB Operator 1.1.14 版本发布日期为 2021 年 10 月 21 日。此版本修复了 `tidb-backup-manager` 和 `tidb-operator` 镜像中的安全漏洞。
+- [TiDB Operator 1.1.15 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.15.md): TiDB Operator 1.1.15 发布日期为 2022 年 2 月 17 日。此版本修复了 TiDB Operator 计算 TiKV Region leader 数量时可能会造成 goroutine 泄露的问题。
+- [TiDB Operator 1.1.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.2.md): TiDB Operator 1.1.2 版本修复了与 PD 4.0.2 不兼容的问题。需要将 TiDB Operator 升级到 v1.1.2 后再部署 TiDB 4.0.2 及更高版本。其他变更包括抓取监控指标和更新配置为 v4.0.2，修复缩容后 PD 成员可能仍然存在的错误，同步信息到 `TidbCluster` `Status` 字段，以及支持在 TiDB 参数中配置容器生命周期 hook 和 `terminationGracePeriodSeconds`。
+- [TiDB Operator 1.1.3 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.3.md): TiDB Operator 1.1.3 版本发布，需要采取的行动包括在 `BackupSpec` 中添加 `cleanPolicy` 字段，将 `mydumper` 替换为 `dumpling` 进行备份。其他变更包括更新 backup manager 工具、为 TiCDC 添加 TLS 支持、在 Drainer 和下游数据库服务器之间添加 TLS 支持等。
+- [TiDB Operator 1.1.4 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.4.md): TiDB Operator 1.1.4 版本发布，重大变化包括添加 TableFilter 到 BackupSpec 和 RestoreSpec，更新 TiDB 和配套工具版本为 v4.0.4，支持自定义环境变量，增加存储请求，为备份恢复添加 TLS 支持，支持 TiFlash 中的 cert-allowed-cn 配置项，修复了启用 TLS 时的内存泄漏问题，为 TiFlash 添加 TLS 支持，配置 TZ 环境。
+- [TiDB Operator 1.1.5 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.5.md): TiDB Operator 1.1.5 版本发布日期为 2020 年 9 月 18 日。此版本兼容性变化需要注意 TiFlash 版本低于 `v4.0.5` 的设置。新功能包括支持为 TiDB/Pump/PD 配置 `serviceAccount`，以及配置 `spec.tikv.config.log-format` 和 `spec.tikv.config.server.max-grpc-send-msg-len`。优化提升方面支持 TiDB/PD/TiKV 的 v4.0.6 配置，挂载集群客户端证书到 PD Pod，以及对于 TiFlash/PD/TiDB 的伸缩实例优先于升级。同时修复了 TidbMonitor CR 中的 Grafana container 忽略 `Env` 配置的问题。
+- [TiDB Operator 1.1.6 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.6.md): TiDB Operator 1.1.6 版本发布日期为 2020 年 10 月 16 日。此版本包含兼容性变化、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性变化包括 `spec.pd.config` 参数的自动转换和需要手动编辑 TidbCluster CR 的配置。滚动升级改动包括 TiDB 或 TiKV 集群的滚动升级以及 TiFlash 集群的滚动升级。新功能包括支持 Backup 和 Restore CR 自定义 BR 命令行参数、配置 TiKV evict leader 超时时间等。优化提升包括透传 TiFlash/TiKV/PD/Pump 的 TOML 格式配置、定时备份到 GCS 时目录名称添加备份时间等。Bug 修复包括修复 Discovery 可能导致启动多个 PD 集群的错误。
+- [TiDB Operator 1.1.7 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.7.md): TiDB Operator 1.1.7 版本发布日期为 2020 年 11 月 13 日。此版本中兼容性变化包括配置项 `prometheus.spec.config.commandOptions` 的行为变化。新增功能包括对 `Backup` 和 `Restore` CR 的配置项 `spec.toolImage` 的新增，以及对 `spec.pd.storageVolumes`、`spec.tidb.storageVolumes` 和 `spec.tikv.storageVolumes` 的支持。优化提升方面包括禁止缩容 TiKV 实例和新增 `BackupStatus` 和 `RestoreStatus` 中的 `phase` 状态。此外还修复了当前 `TidbCluster` 之外存在 PD member 时无法把 PD scale 到 0 的 bug。
+- [TiDB Operator 1.1.8 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.8.md): TiDB Operator 1.1.8 版本新增了对备份和恢复任务的支持，用户可以利用该功能实现基于 NFS 或者任意 Kubernetes 支持的 Volume 类型的任务。此外，还优化了 TiDB 组件和客户端开启 TLS 的功能，支持为 TiDB service 指定额外的端口，以及在连接 TiDB server 时不使用 TLS。修复了一系列 Bug，包括部署 TiDB 集群问题、编码错误问题、Pods 误认为问题等。
+- [TiDB Operator 1.1.9 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.1.9.md): TiDB Operator 1.1.9 版本发布日期为 2020 年 12 月 28 日。此版本优化了支持使用 `spec.toolImage` 来为 `Backup` 和 `Restore` 指定 Dumpling/TiDB Lightning 的二进制可执行文件。同时修复了 Prometheus 不能拉取 TiKV Importer 的 metrics 以及用 BR 和 GCS 进行备份与恢复时的兼容性问题。
+- [TiDB Operator 1.2.0 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.0.md): TiDB Operator 1.2.0 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级改动包括升级 TiDB Operator 会导致 TidbMonitor Pod 删除重建。新功能包括支持为 `TiDBMonitor` 的 `Prometheus` 设置更细粒度的 `retentionTime` 和通过 `priorityClassName` 设置备份 Job 优先级。优化提升包括调整升级过程中驱逐 TiKV 的 Region Leader 超时的默认值。Bug 修复包括修复解析 `TiDBMonitor` 定义中 `Prometheus.RemoteWrite` 的 URL 可能失败的问题。
+- [TiDB Operator 1.2.0-alpha.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.0-alpha.1.md): TiDB Operator 1.2.0-alpha.1 版本发布。滚动升级改动包括 TidbMonitor Pod 重建。新增功能包括跨多个 Kubernetes 集群部署 TiDB 集群、管理 DM 2.0、PD API 弹性伸缩、灰度升级 TiDB Operator。优化提升包括 TiDB Lightning chart 支持 local backend、TLS、持久化 checkpoint，TidbMonitor 支持配置 Thanos sidecar，管理资源从 Deployment 变为 StatefulSet。其他改进包括优化队列 rate limiter 间隔，修改 TidbMonitor 自定义告警规则存储目录。
+- [TiDB Operator 1.2.0-beta.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.0-beta.1.md): TiDB Operator 1.2.0-beta.1 发布日期为 2021 年 4 月 7 日。此版本包含兼容性改动和滚动升级改动。新增功能包括为备份和恢复 Job 设置自定义环境变量，支持配置额外的 volume 和 volumeMount，以及支持设置自定义 Store 标签。优化提升方面包括增加重试机制解决 DNS 查询异常处理问题，优化 Thanos 的 example yaml，以及在 PD 的扩缩容和容灾过程中增加多 PVC 支持。Bug 修复方面包括修复挂载多 PVC 时容量设置错误的问题，修复 TidbMonitor 外部标签包含无法识别的环境变量的问题，以及修复备份或恢复 Pod 状态没有正常更新为 Failed 的问题。
+- [TiDB Operator 1.2.0-beta.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.0-beta.2.md): TiDB Operator 1.2.0-beta.2 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。新功能包括 TidbMonitor 支持监控多个启用了 TLS 的 TidbCluster，以及为所有 TiDB 组件设置安全上下文和拓扑约束。优化提升包括为 TidbMonitor Pod 增加 readiness 探测器和支持不生成 Prometheus 的告警规则。 Bug 修复包括修复 TiDB 实例缩容后仍在 TiDB Dashboard 中展示的问题和解决 TidbCluster CR 同步问题。
+- [TiDB Operator 1.2.0-rc.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.0-rc.1.md): TiDB Operator 1.2.0-rc.1 发布，滚动升级改动会导致 Pump Pod 删除重建。新增支持为 TidbCluster 中的 Pod 与 service 设置自定义的 label，以及对 Pump 的完整生命周期管理。优化提升包括隐藏数据库密码的展示、支持为 Grafana 配置额外的 volumeMount、为 TidbMonitor 增加额外的信息展示列，以及 TidbMonitor 支持将配置信息直接写入到 PD 的 etcd 中。Bug 修复包括对启用了 TLS 的 DmCluster 进行监控的问题、PD 在扩容过程中 member 数量统计不正确的问题、DM-master 可能无法成功重启的问题、`configUpdateStrategy` 从 `InPlace` 修改为 `RollingUpdate` 后可能造成的 TidbCluster 组件滚动更新的问题，以及使用 Dumpling 备份数据时可能失败的问题。
+- [TiDB Operator 1.2.0-rc.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.0-rc.2.md): TiDB Operator 1.2.0-rc.2 发布，新增支持透传 TiCDC 的 TOML 格式配置、为 TiCDC 设置存储卷和挂载、自定义 Discovery、TidbMonitor 和 TidbInitializer 的标签和注释、修改 Grafana 仪表盘。优化支持未指定 BR toolImage tag 时将 TiKV 版本作为 tag、扩缩容 TiDB 过程中协调 PVC、增加 liveness 与 readiness 探测器。修复部署异构集群时可能 panic 的问题、TidbCluster spec 未更改时 TiDB service 与 TidbCluster 状态持续更新的问题。
+- [TiDB Operator 1.2.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.1.md): TiDB Operator 1.2.1 版本发布日期为 2021 年 8 月 18 日。滚动升级改动，如果部署 TiCDC 时配置了 hostNetwork 为 true，升级 TiDB Operator 后会导致 TiCDC Pod 删除重建。优化提升包括支持为 TidbCluster 的所有组件配置 hostNetwork，使所有组件都可以使用宿主机网络。
+- [TiDB Operator 1.2.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.2.md): TiDB Operator 1.2.2 版本发布日期为 2021 年 9 月 3 日。滚动升级改动包括升级 TiDB Operator 会导致 TiDBMonitor Pod 和 TiFlash Pod 删除重建。新功能包括 TiDBMonitor 支持动态重新加载配置。Bug 修复包括修复 TiCDC 无法从低版本升级到 v5.2.0 的问题。
+- [TiDB Operator 1.2.3 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.3.md): TiDB Operator 1.2.3 版本发布日期为 2021 年 9 月 7 日。此版本修复了升级到 TiDB Operator v1.2.2 时导致 TiFlash Pod 滚动重启的问题。
+- [TiDB Operator 1.2.4 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.4.md): TiDB Operator 1.2.4 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级会导致 TidbMonitor Pod 删除重建。新增 TidbMonitor 支持用户自定义 Prometheus 告警规则和动态重新加载告警规则，以及支持批量删除备份数据。优化了 TiFlash 滚动升级流程，修复了镜像中的安全漏洞和备份数据残留的问题。
+- [TiDB Operator 1.2.5 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.5.md): TiDB Operator 1.2.5 版本发布，优化了 DM 配置、TiFlash init container 资源配置和 TiDB TLS 客户端认证参数配置。修复了组件启动脚本更新后的滚动更新问题、启用 TLS 后 TidbCluster spec 自动更新问题、TiKV Region leader 数量计算可能导致 goroutine 泄露的问题和一些高级别的安全问题。
+- [TiDB Operator 1.2.6 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.6.md): TiDB Operator 1.2.6 发布日期 2022 年 1 月 4 日。优化更新 Restore 和 Backup 状态时的重试逻辑。
+- [TiDB Operator 1.2.7 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.2.7.md): TiDB Operator 1.2.7 发布，新增 `spec.pd.startUpScriptVersion` 字段，支持在 PD 启动脚本中使用 `dig` 命令解析域名。优化部署或更新组件的 StatefulSet，预先检查配置的 VolumeMount 是否存在，防止集群进行失败的滚动更新。
+- [TiDB Operator 1.3.0 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.0.md): TiDB Operator 1.3.0 版本发布，包括兼容性改动、新功能、优化提升和 Bug 修复。兼容性改动包括跨集群部署 TiDB 集群升级操作，TiFlash 升级操作需注意。新增功能包括支持内部组件访问 TiDB 时跳过服务端证书验证、设置所有组件 Pod 的 DNS 配置等。优化提升包括部署或更新组件的 StatefulSet 预先检查配置的 VolumeMount 是否存在，跨集群部署 TiDB 集群功能增强。Bug 修复包括修复 Kubernetes v1.23 及之后版本无法部署 tidb scheduler 的问题。
+- [TiDB Operator 1.3.0-beta.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.0-beta.1.md): TiDB Operator 1.3.0-beta.1 发布日期为 2022 年 1 月 12 日。此版本的兼容性改动包括删除 Pod `ValidatingWebhook` 和 `MutatingWebhook`，升级后不会影响 TiDB 集群管理。升级到 1.3.0-beta.1 版本后，需要按照操作来升级 TiDB Operator。此版本还支持新功能和优化提升，包括支持 TiFlash 的 init container 配置资源使用量，支持持续性能分析，以及优化 TidbMonitor 部署示例等。
+- [TiDB Operator 1.3.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.1.md): TiDB Operator 1.3.1 版本发布日期为 2022 年 2 月 24 日。此版本修复了 TiFlash 丢失元数据的问题，并添加了新的 `spec.dnsPolicy` 字段以支持配置 Pod 的 DNSPolicy。另外，`tidb-lightning` Helm chart 默认后端改为使用 `local`。还修复了 TiFlash 配置中缺少 `tmp_path` 字段时无法使用 TiFlash v5.4.0 及以后版本的问题，以及 Discovery 服务错误导致 TiDB 集群 PD 组件启动失败的问题。
+- [TiDB Operator 1.3.10 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.10.md): TiDB Operator 1.3.10 发布，优化提升包括升级 Golang 版本到 1.19 以修复安全漏洞。
+- [TiDB Operator 1.3.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.2.md): TiDB Operator 1.3.2 版本发布，优化支持在启用 Istio 的 Kubernetes 集群上部署与运行 TiDB，支持多架构 Docker 镜像包括 ARM 系统。
+- [TiDB Operator 1.3.3 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.3.md): TiDB Operator 1.3.3 发布，新增了 `spec.tidb.service.port` 字段，修复了集群升级过程中可能泄漏的问题，更新了 `tidb-backup-manager` 镜像的基础镜像，修复了不兼容 ARM 架构的问题，修复了当 tidb Service 没有 Endpoint 时可能会 panic 的问题，修复了 Kubernetes 集群访问失败并重试后组件 Pod 的 Labels 和 Annotations 可能丢失的问题。
+- [TiDB Operator 1.3.4 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.4.md): TiDB Operator 1.3.4 发布，优化提升包括在各个组件的状态信息中添加了 `volumes` 字段，以展示存储卷状态。
+- [TiDB Operator 1.3.5 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.5.md): TiDB Operator 1.3.5 发布，新增功能支持使用 Azure Blob Storage 备份与恢复 TiDB 集群数据。
+- [TiDB Operator 1.3.6 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.6.md): TiDB Operator 1.3.6 版本发布日期为 2022 年 7 月 5 日。此版本优化了扩容 PVC 对集群性能的影响，现在扩容 PVC 时按照 Pod 一个个扩容，并且在扩容 TiKV 的 PVC 前会先驱逐该 TiKV 上的 leader。
+- [TiDB Operator 1.3.7 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.7.md): TiDB Operator 1.3.7 版本发布，新增了暂停组件功能，优化了扩容完成后重建 StatefulSet 的流程，修复了本地存储升级 TiKV 和清理备份文件后残留的问题。
+- [TiDB Operator 1.3.8 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.8.md): TiDB Operator 1.3.8 版本发布，新增了为 `TidbCluster` 添加特殊 Annotation 的功能，支持配置 TiDB、TiKV 和 TiFlash 的 Pod 的最小等待时间。此外，还优化了支持优雅升级版本大于或等于 6.3.0 的 TiCDC pod。
+- [TiDB Operator 1.3.9 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.3.9.md): TiDB Operator 1.3.9 发布，修复了在已设置 `acrossK8s` 字段但未设置 `clusterDomain` 的情况下，PD 升级流程会卡住的问题。
+- [TiDB Operator 1.4. Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.7.md): TiDB Operator 1.4.7 发布，修复了 BackupSchedule CR 字段中的 `logBackupTemplate` 字段变成可选值的问题。
+- [TiDB Operator 1.4.0 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.0.md): TiDB Operator 1.4.0 版本发布，新增支持独立管理 TiDB Dashboard，配置 TiKV 和 PD 的 Readiness Probe，以及基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复。优化支持 IPv6 网络环境，修复了基于 EBS 快照备份无法恢复到不同 namespace 的问题和日志备份停止占用 Complete 状态的 bug。
+- [TiDB Operator 1.4.0-alpha.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.0-alpha.1.md): TiDB Operator 1.4.0-alpha.1 发布，包含兼容性改动、滚动升级改动、新功能、优化提升和错误修复。新增自动设置 TiDB 的 location labels、新字段 `spec.tikv.scalePolicy` 与 `spec.tiflash.scalePolicy`、`startScriptVersion` 字段、BR 恢复集群到备份时间点、feature gate `VolumeModifying`、修改存储参数、配置 BR 的 `--check-requirements` 参数、使用字段 `additionalContainers` 自定义 Pod 容器配置。优化了 `TidbMonitor` 使用的 Prometheus 的 remoteWrite 配置和 TiFlash `Service` 添加 metric 端口。修复了集群扩缩容时的问题和 PD spec 为空导致 TiDB Operator 崩溃的问题。
+- [TiDB Operator 1.4.0-beta.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.0-beta.1.md): TiDB Operator 1.4.0-beta.1 发布，新增支持基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复（实验特性），修复了日志备份的 checkpoint ts 无法更新的问题。
+- [TiDB Operator 1.4.0-beta.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.0-beta.2.md): TiDB Operator 1.4.0-beta.2 发布日期为 2022 年 11 月 11 日。此版本修复了使用 Azure Blob Storage 时未设置前缀的问题，并升级了 AWS SDK 到 v1.44.72 以支持使用 AWS 的 Asia Pacific (Jakarta) 区域 (`ap-southeast-3`)。
+- [TiDB Operator 1.4.0-beta.3 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.0-beta.3.md): TiDB Operator 1.4.0-beta.3 发布，新增 TiProxy 实验性支持和基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复 GA。修复了拼写错误和清理卷快照备份失败的问题，以及大规模 TiKV 节点下备份 TiDB 集群失败的问题。
+- [TiDB Operator 1.4.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.1.md): TiDB Operator 1.4.1 版本发布，新增故障自动转移功能，优化了 TiDB Controller Manager 中 Kubernetes 客户端的配置，修复了未配置 PV 权限时 TiDB Controller Manager panic 的问题。
+- [TiDB Operator 1.4.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.2.md): TiDB Operator 1.4.2 发布，修复了开启 `preferIPv6` 时 TiFlash 没有监听 IPv6 地址的问题。
+- [TiDB Operator 1.4.3 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.3.md): TiDB Operator 1.4.3 发布，修复了开启 `preferIPv6` 时 TiFlash 的 metric server 未监听正确 IPv6 地址的问题，以及在 AWS 环境中打开了 feature gate `VolumeModifying` 且 `StorageClass` 缺少 EBS 相关参数时 TiDB Operator 会一直尝试修改 EBS 参数的问题。
+- [TiDB Operator 1.4.4 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.4.md): TiDB Operator 1.4.4 发布，新增支持在已部署 TiFlash 的集群上使用卷快照备份和恢复，准确显示备份大小，支持重试快照备份，集成管理日志备份和快照备份。修复了使用非语义版本格式的 TiDB 镜像同步失败的问题，使用卷快照备份一个已缩容的集群后无法恢复数据的问题，卷快照备份可能崩溃的问题，卷快照恢复可能在最后阶段失败的问题。
+- [TiDB Operator 1.4.5 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.5.md): TiDB Operator 1.4.5 版本发布，优化了 TidbCluster 的错误处理相关 metrics 和 worker 队列相关 metrics，增加了 DM master 组件的 `startUpScriptVersion` 字段，以及跨 Kubernetes 集群滚动重启或缩容 TiCDC 集群的能力。同时修复了定时备份中取消 GC、Backup CR 字段可选值、TiDB Operator 未配置权限时的 panic 问题，以及 TidbCluster 中设置 `AdditionalVolumeMounts` 时可能的 panic 问题。
+- [TiDB Operator 1.4.6 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.4.6.md): TiDB Operator 1.4.6 发布，优化默认启用 volume resize 支持，修复备份恢复时报错问题，修复 TiCDC image tag 不符合语义化版本时无法 Graceful Drain TiCDC 的问题。
+- [TiDB Operator 1.5.0 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.5.0.md): 了解 TiDB Operator 1.5.0 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator 1.5.0-beta.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.5.0-beta.1.md): TiDB Operator 1.5.0-beta.1 发布，新增支持优雅重启 PD 和 TiDB Pod，使用 Advanced StatefulSet 管理 TiCDC 和 TiProxy，新增 TiDB Spec 字段，允许用户定义策略重启失败备份任务，升级 Kubernetes 依赖库至 v1.20 版本，添加与 reconciler 和 worker queue 相关的 Metric，优化滚动升级 TiKV 节点性能，允许用户自定义 Prometheus Scraping 相关配置，TiProxy 支持共享部分 TiDB 证书，配置 `spec.preferIPv6` 为 `true` 时，Service 的 `ipFamilyPolicy` 将配置为 `PreferDualStack`，添加统计协调流程失败计数的 Metric，修复了因为 metric 接口冲突而导致 pprof 接口无法访问的问题。
+- [TiDB Operator 1.5.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.5.1.md): TiDB Operator 1.5.1 发布，新增支持替换 PD、TiKV 和 TiDB 所使用的 volume。修复了多个 Bug，包括手动触发 TiKV eviction 时 PVC Modifier 报错的问题，替换 TiKV volume 过程中再触发 TiKV eviction 时可能造成 TiDB Operator reconcile 死锁的问题，TidbCluster 在 Upgrade 过程中可能无法回滚的问题，以及 MaxReservedTime 选项没有被 backup schedule gc 使用的问题。
+- [TiDB Operator 1.5.2 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.5.2.md): TiDB Operator 1.5.2 版本新增了对 AWS EBS 快照的备份能力的跨多个 K8S 集群的支持。优化了重启 PD、TiKV 时的启动流程，修复了替换 volume 时可能出现的问题。
+- [TiDB Operator 1.5.3 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.5.3.md): 了解 TiDB Operator 1.5.3 版本的新功能和 Bug 修复。
+- [TiDB Operator 1.5.4 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.5.4.md): 了解 TiDB Operator 1.5.4 版本的优化提升和 Bug 修复。
+- [TiDB Operator 1.5.5 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.5.5.md): 了解 TiDB Operator 1.5.5 版本的新功能和优化提升。
+- [TiDB Operator 1.6.0 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.6.0.md): 了解 TiDB Operator 1.6.0 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator 1.6.0-beta.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.6.0-beta.1.md): 了解 TiDB Operator 1.6.0-beta.1 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator 1.6.1 Release Notes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/release-1.6.1.md): 了解 TiDB Operator 1.6.1 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator RBAC 规则](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/tidb-operator-rbac.md): 介绍 TiDB Operator 需要的 RBAC 规则。
+- [TiDB Operator v1.6 新特性](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/whats-new-in-v1.6.md): 了解 TiDB Operator 1.6.0 版本引入的新特性。
+- [TiDB Operator 架构](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/architecture.md): 了解 TiDB Operator 架构及其工作原理。
+- [TiDB Operator 简介](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/tidb-operator-overview.md): 介绍 TiDB Operator 的整体架构及使用方式。
+- [TiDB Scheduler 扩展调度器](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/tidb-scheduler.md): 了解 TiDB Scheduler 扩展调度器及其工作原理。
+- [TiDB 集群的监控与告警](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/monitor-a-tidb-cluster.md): 介绍如何监控 TiDB 集群。
+- [TidbMonitor 分片功能](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/enable-monitor-shards.md): 如何使用 TidbMonitor 分片功能
+- [TidbMonitor 开启动态配置功能](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/enable-monitor-dynamic-configuration.md): 动态更新 TidbMonitor 配置
+- [为 DM 开启 TLS](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/enable-tls-for-dm.md): 在 Kubernetes 上如何为 DM 开启 TLS。
+- [为 MySQL 客户端开启 TLS](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/enable-tls-for-mysql-client.md): 在 Kubernetes 上如何为 TiDB 集群的 MySQL 客户端开启 TLS。
+- [为 TiDB 组件间开启 TLS](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/enable-tls-between-components.md): 在 Kubernetes 上如何为 TiDB 集群组件间开启 TLS。
+- [为使用云存储的 TiDB 集群更换节点](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/replace-nodes-for-cloud-disk.md): 介绍如何为使用云存储的 TiDB 集群更换节点。
+- [为使用本地存储的 TiDB 集群更换节点](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/replace-nodes-for-local-disk.md): 介绍如何为使用本地存储的 TiDB 集群更换节点。
+- [为已有 TiDB 集群部署 HTAP 存储引擎 TiFlash](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tiflash.md): 了解如何在 Kubernetes 上为已有 TiDB 集群部署 TiDB HTAP 存储引擎 TiFlash。
+- [为已有 TiDB 集群部署异构集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-heterogeneous-tidb-cluster.md): 本文档介绍如何为已有的 TiDB 集群部署一个异构集群。
+- [为已有 TiDB 集群部署负载均衡 TiProxy](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tiproxy.md): 了解如何在 Kubernetes 上为已有 TiDB 集群部署负载均衡 TiProxy。
+- [从 Helm 2 迁移到 Helm 3](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/migrate-to-helm3.md): 介绍如何将由 Helm 2 管理的组件迁移到由 Helm 3 管理。
+- [以非 root 用户运行容器](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/containers-run-as-non-root-user.md): 了解如何以非 root 用户运行容器。
+- [使用 BR 备份 TiDB 集群到 GCS](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-to-gcs-using-br.md): 介绍如何使用 BR 备份 TiDB 集群到 Google Cloud Storage (GCS)。
+- [使用 BR 备份 TiDB 集群数据到 Azure Blob Storage](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-to-azblob-using-br.md): 介绍如何使用 BR 备份 TiDB 集群数据到 Azure Blob Storage 上。
+- [使用 BR 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-to-aws-s3-using-br.md): 介绍如何使用 BR 备份 TiDB 集群数据到兼容 Amazon S3 的存储。
+- [使用 BR 恢复 Azure Blob Storage 上的备份数据](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/restore-from-azblob-using-br.md): 介绍如何使用 BR 恢复 Azure Blob Storage 上的备份数据。
+- [使用 BR 恢复 GCS 上的备份数据](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/restore-from-gcs-using-br.md): 介绍如何使用 BR 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
+- [使用 BR 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/restore-from-aws-s3-using-br.md): 介绍如何使用 BR 恢复 Amazon S3 兼容存储上的备份数据。
+- [使用 Dumpling 备份 TiDB 集群数据到 GCS](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-to-gcs.md): 介绍如何使用 Dumpling 将 TiDB 集群数据备份到 Google Cloud Storage (GCS)。
+- [使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-to-s3.md): 介绍如何使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储。
+- [使用 PD Recover 恢复 PD 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/pd-recover.md): 了解如何使用 PD Recover 恢复 PD 集群。
+- [使用 PingCAP Clinic 诊断 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/clinic-user-guide.md): 详细介绍在使用 TiDB Operator 部署的集群上如何安装、使用 PingCAP Clinic 诊断服务进行数据采集和快速检查。
+- [使用 TiDB Lightning 恢复 GCS 上的备份数据](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/restore-from-gcs.md): 介绍如何使用 TiDB Lightning 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
+- [使用 TiDB Lightning 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/restore-from-s3.md): 了解如何使用 TiDB Lightning 将兼容 S3 存储上的备份数据恢复到 TiDB 集群。
+- [使用多套 TiDB Operator 单独管理不同的 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-multiple-tidb-operator.md): 介绍如何部署多套 TiDB Operator 分别管理不同的 TiDB 集群。
+- [修改 TiDB 集群配置](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/modify-tidb-configuration.md): 了解如何修改部署在 Kubernetes 上的 TiDB 的集群配置。
+- [升级 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster.md): 介绍如何升级 Kubernetes 上的 TiDB 集群。
+- [升级 TiDB Operator](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/upgrade-tidb-operator.md): 介绍如何升级 TiDB Operator。
+- [同步数据到开启 TLS 的下游服务](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/enable-tls-for-ticdc-sink.md): 了解在 Kubernetes 上如何同步数据到开启 TLS 的下游服务。
+- [在 ARM64 机器上部署 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-cluster-on-arm64.md): 本文档介绍如何在 ARM64 机器上部署 TiDB 集群
+- [在 AWS EKS 上部署 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-on-aws-eks.md): 介绍如何在 AWS EKS (Elastic Kubernetes Service) 上部署 TiDB 集群。
+- [在 Azure AKS 上部署 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-on-azure-aks.md): 介绍如何在 Azure AKS (Azure Kubernetes Service) 上部署 TiDB 集群。
+- [在 Google Cloud GKE 上部署 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-on-gcp-gke.md): 了解如何在 Google Cloud GKE 上部署 TiDB 集群。
+- [在 Kubernetes 上使用 DM](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/use-tidb-dm.md): 了解如何在 Kubernetes 上使用 TiDB DM 迁移数据。
+- [在 Kubernetes 上快速上手 TiDB](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/get-started.md): 介绍如何快速地在 Kubernetes 上使用 TiDB Operator 部署 TiDB 集群
+- [在 Kubernetes 上部署 DM](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tidb-dm.md): 了解如何在 Kubernetes 上部署 TiDB DM 集群。
+- [在 Kubernetes 上部署 TiCDC](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-ticdc.md): 了解如何在 Kubernetes 上部署 TiCDC。
+- [在 Kubernetes 上部署 TiDB Operator](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tidb-operator.md): 了解如何在 Kubernetes 上部署 TiDB Operator。
+- [在标准 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-on-general-kubernetes.md): 介绍如何在标准 Kubernetes 集群上通过 TiDB Operator 部署 TiDB 集群。
+- [基于 AWS EBS 卷快照的备份](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-to-aws-s3-by-snapshot.md): 介绍如何基于 EBS 卷快照使用 TiDB Operator 备份 TiDB 集群数据到 S3。
+- [基于 AWS EBS 卷快照的恢复](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/restore-from-aws-s3-by-snapshot.md): 介绍如何将存储在 S3 上的备份元数据以及 EBS 卷快照恢复到 TiDB 集群。
+- [基于 EBS 卷快照备份恢复的性能介绍](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-restore-snapshot-perf.md): 了解 EBS 卷快照备份恢复的性能基线。
+- [基于 EBS 卷快照的备份恢复功能架构](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/volume-snapshot-backup-restore.md): 了解 TiDB EBS 卷快照的备份恢复架构设计。
+- [基于 EBS 快照备份恢复的常见问题](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-restore-faq.md): 介绍卷快照备份恢复中的常见问题以及解决方案。
+- [增强型 StatefulSet 控制器](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/advanced-statefulset.md): 介绍如何开启、使用增强型 StatefulSet 控制器
+- [备份 TiDB 集群到持久卷](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-to-pv-using-br.md): 介绍如何使用 BR 备份 TiDB 集群数据到持久卷。
+- [备份与恢复 CR 介绍](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-restore-cr.md): 介绍用于备份与恢复的 Custom Resource (CR) 资源的各字段。
+- [备份与恢复简介](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-restore-overview.md): 介绍如何使用 BR、Dumpling、TiDB Lightning 工具对 Kubernetes 上的 TiDB 集群进行数据备份和数据恢复。
+- [导入集群数据](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/restore-data-using-tidb-lightning.md): 使用 TiDB Lightning 导入集群数据。
+- [将 TiDB 迁移至 Kubernetes](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/migrate-tidb-to-kubernetes.md): 介绍如何将部署在物理机或虚拟机中的 TiDB 迁移至 Kubernetes 集群中
+- [开启 TiDB Operator 准入控制器](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/enable-admission-webhook.md): 介绍如何开启 TiDB Operator 准入控制器以及它的作用。
+- [恢复持久卷上的备份数据](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/restore-from-pv-using-br.md): 介绍如何将存储在持久卷上的备份数据恢复到 TiDB 集群。
+- [恢复误删的 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/recover-deleted-cluster.md): 介绍如何恢复误删的 TiDB 集群。
+- [手动扩缩容 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/scale-a-tidb-cluster.md): 了解如何在 Kubernetes 上对 TiDB 集群手动扩缩容。
+- [挂起 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/suspend-tidb-cluster.md): 了解如何通过配置挂起 Kubernetes 上的 TiDB 集群。
+- [日志收集](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/logs-collection.md): 介绍收集 TiDB 及相关组件日志的方法。
+- [暂停同步 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/pause-sync-of-tidb-cluster.md): 介绍如何暂停同步 Kubernetes 上的 TiDB 集群
+- [更新和替换 TLS 证书](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/renew-tls-certificate.md): 介绍如何更新和替换 TiDB 组件间的 TLS 证书。
+- [构建多个网络互通的 AWS EKS 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/build-multi-aws-eks.md): 介绍如何构建多个 AWS EKS 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
+- [构建多个网络互通的 Google Cloud GKE 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/build-multi-gcp-gke.md): 介绍如何构建多个 Google Cloud GKE 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
+- [查看日志](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/view-logs.md): 介绍如何查看 TiDB 集群各组件日志以及 TiDB 慢查询日志。
+- [灰度升级 TiDB Operator](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/canary-upgrade-tidb-operator.md): 介绍如何灰度升级 TiDB Operator，避免 TiDB Operator 升级对整个 Kubernetes 集群中的所有 TiDB 集群产生不可预知的影响。
+- [管理 TiDB 集群的 Command Cheat Sheet](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/cheat-sheet.md): 介绍管理 TiDB 集群的 Command Cheat Sheet。
+- [维护 TiDB 集群所在的 Kubernetes 节点](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/maintain-a-kubernetes-node.md): 介绍如何维护 TiDB 集群所在的 Kubernetes 节点。
+- [聚合多个 TiDB 集群的监控数据](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/aggregate-multiple-cluster-monitor-data.md): 通过 Thanos 框架聚合多个 TiDB 集群的监控数据
+- [访问 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/access-tidb.md): 介绍如何访问 Kubernetes 上的 TiDB 集群。
+- [访问 TiDB Dashboard](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/access-dashboard.md): 介绍如何在 Kubernetes 环境下访问 TiDB Dashboard
+- [跨多个 Kubernetes 集群监控 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tidb-monitor-across-multiple-kubernetes.md): 介绍如何对跨多个 Kubernetes 集群的 TiDB 集群进行监控，并集成到常见 Prometheus 多集群监控体系中
+- [跨多个 Kubernetes 集群部署 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tidb-cluster-across-multiple-kubernetes.md): 本文档介绍如何实现跨多个 Kubernetes 集群部署 TiDB 集群
+- [远程存储访问授权](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/grant-permissions-to-remote-storage.md): 介绍如何授权访问远程存储。
+- [部署 TiDB Binlog](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tidb-binlog.md): 了解如何在 Kubernetes 上部署 TiDB 集群的 TiDB Binlog。
+- [配置 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/configure-a-tidb-cluster.md): 了解如何在 Kubernetes 中配置 TiDB 集群。
+- [重启 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/restart-a-tidb-cluster.md): 了解如何重启 Kubernetes 集群上的 TiDB 集群。
+- [销毁 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/destroy-a-tidb-cluster.md): 介绍如何销毁 Kubernetes 集群上的 TiDB 集群。

--- a/static/zh/llms.txt
+++ b/static/zh/llms.txt
@@ -1,1305 +1,1305 @@
 # TiDB 文档中心
 
-- [TiDB 文档中心](https://docs.pingcap.com/zh/): 欢迎来到 TiDB 文档中心！我们为您提供了丰富的操作指南和详实的参考资料，助您轻松上手 TiDB 产品，顺利完成数据迁移和基于数据库的应用开发等操作。
+- [TiDB 文档中心](https://docs.pingcap.com/zh.md): 欢迎来到 TiDB 文档中心！我们为您提供了丰富的操作指南和详实的参考资料，助您轻松上手 TiDB 产品，顺利完成数据迁移和基于数据库的应用开发等操作。
 
 ## TiDB Self-Managed 文档（使用 TiUP 部署）
 
-- [TiDB 版本周期支持策略](https://cn.pingcap.com/tidb-release-support-policy/): 阐述了 PingCAP 就 TiDB 版本提供支持服务的标准和规则。
-- [50 TiB 数据导入最佳实践](https://docs.pingcap.com/tidb/stable/data-import-best-practices/): 了解将大规模数据导入 TiDB 的最佳实践。
-- [ADD COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-add-column/): TiDB 数据库中 ADD COLUMN 的使用概况。
-- [ADD INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-add-index/): TiDB 数据库中 ADD INDEX 的使用概况。
-- [ADMIN](https://docs.pingcap.com/tidb/stable/sql-statement-admin/): TiDB的 `ADMIN` 语句是用于查看TiDB状态和对表数据进行校验的扩展语法。其中包括 `ADMIN RELOAD`、`ADMIN PLUGIN`、`ADMIN ... BINDINGS`、`ADMIN REPAIR TABLE` 和 `ADMIN SHOW NEXT_ROW_ID` 等扩展语句。这些语句可以用于重新加载表达式下推的黑名单、启用或禁用插件、持久化 SQL Plan 绑定信息、修复表的元信息以及查看表中特殊列的详情。这些功能对于管理和维护 TiDB 数据库非常有用。
-- [ADMIN [SET|SHOW|UNSET] BDR ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-admin-bdr-role/): TiDB 数据库中 ADMIN [SET|SHOW|UNSET] BDR ROLE 的使用概况。
-- [ADMIN ALTER DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-alter-ddl/): TiDB 数据库中 `ADMIN ALTER DDL JOBS` 的使用概况。
-- [ADMIN CANCEL DDL](https://docs.pingcap.com/tidb/stable/sql-statement-admin-cancel-ddl/): TiDB 数据库中 ADMIN CANCEL DDL 的使用概况。
-- [ADMIN CHECK [TABLE|INDEX]](https://docs.pingcap.com/tidb/stable/sql-statement-admin-check-table-index/): TiDB 数据库中 ADMIN CHECK [TABLE|INDEX] 的使用概况。
-- [ADMIN CHECKSUM TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-admin-checksum-table/): TiDB 数据库中 ADMIN CHECKSUM TABLE 的使用概况。
-- [ADMIN CLEANUP INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-admin-cleanup/): TiDB 数据库中 ADMIN CLEANUP 的使用概况。
-- [ADMIN PAUSE DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-pause-ddl/): TiDB 数据库中 ADMIN PAUSE DDL JOBS 的使用概况。
-- [ADMIN RECOVER INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-admin-recover/): TiDB 数据库中 ADMIN RECOVER INDEX 的使用概况。
-- [ADMIN RESUME DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-resume-ddl/): TiDB 数据库中 ADMIN RESUME DDL 的使用概况。
-- [ADMIN SHOW DDL [JOBS|JOB QUERIES]](https://docs.pingcap.com/tidb/stable/sql-statement-admin-show-ddl/): TiDB 数据库中 ADMIN SHOW DDL [JOBS|JOB QUERIES] 的使用概况。
-- [ALTER DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-database/): TiDB 数据库中 ALTER DATABASE 的使用概况。
-- [ALTER INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-alter-index/): TiDB 数据库中 ALTER INDEX 的使用概况。
-- [ALTER INSTANCE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-instance/): TiDB 数据库中 ALTER INSTANCE 的使用概况。
-- [ALTER PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-alter-placement-policy/): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
-- [ALTER RANGE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-range/): TiDB 数据库中 ALTER RANGE 的使用概况。
-- [ALTER RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-alter-resource-group/): TiDB 数据库中 ALTER RESOURCE GROUP 的使用概况。
-- [ALTER SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-sequence/): 介绍 ALTER SEQUENCE 在 TiDB 中的使用概况。
-- [ALTER TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-table/): TiDB 数据库中 ALTER TABLE 的使用概况。
-- [ALTER TABLE ... COMPACT](https://docs.pingcap.com/tidb/stable/sql-statement-alter-table-compact/): TiDB 数据库中 ALTER TABLE ... COMPACT 语句的使用概况。
-- [ALTER USER](https://docs.pingcap.com/tidb/stable/sql-statement-alter-user/): TiDB 数据库中 ALTER USER 的使用概况。
-- [ANALYZE](https://docs.pingcap.com/tidb/stable/sql-statement-analyze-table/): TiDB 数据库中 ANALYZE 的使用概况。
-- [ANALYZE_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-analyze-status/): 了解 information_schema 表 `ANALYZE_STATUS`。
-- [AUTO_INCREMENT](https://docs.pingcap.com/tidb/stable/auto-increment/): 介绍 TiDB 的 `AUTO_INCREMENT` 列属性。
-- [AUTO_RANDOM](https://docs.pingcap.com/tidb/stable/auto-random/): 本文介绍了 TiDB 的 `AUTO_RANDOM` 列属性。
-- [BACKUP](https://docs.pingcap.com/tidb/stable/sql-statement-backup/): TiDB 数据库中 BACKUP 的使用概况。
-- [BATCH](https://docs.pingcap.com/tidb/stable/sql-statement-batch/): TiDB 数据库中 BATCH 的使用概况。
-- [BEGIN](https://docs.pingcap.com/tidb/stable/sql-statement-begin/): TiDB 数据库中 BEGIN 的使用概况。
-- [Bookshop 应用](https://docs.pingcap.com/tidb/stable/dev-guide-bookshop-schema-design/): Bookshop 应用设计、数据导入、连接数据库等操作。
-- [br 命令行手册](https://docs.pingcap.com/tidb/stable/use-br-command-line-tool/): 了解 br 命令行的定义、组成与使用。
-- [CALIBRATE RESOURCE](https://docs.pingcap.com/tidb/stable/sql-statement-calibrate-resource/): TiDB 数据库中 CALIBRATE RESOURCE 的使用概况。
-- [CANCEL IMPORT](https://docs.pingcap.com/tidb/stable/sql-statement-cancel-import-job/): TiDB 数据库中 CANCEL IMPORT 的使用概况。
-- [Cast 函数和操作符](https://docs.pingcap.com/tidb/stable/cast-functions-and-operators/): Cast 函数和操作符用于将某种数据类型的值转换为另一种数据类型。TiDB 支持使用 MySQL 8.0 中提供的所有 Cast 函数和操作符。
-- [CHANGE COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-change-column/): TiDB 数据库中 CHANGE COLUMN 的使用概况。
-- [Changefeed DDL 同步](https://docs.pingcap.com/tidb/stable/ticdc-ddl/): 了解 TiCDC 支持同步的 DDL 和一些特殊情况
-- [Changefeed 日志过滤器](https://docs.pingcap.com/tidb/stable/ticdc-filter/): 了解 TiCDC 的表过滤器和事件过滤器使用方法。
-- [Changefeed 概述](https://docs.pingcap.com/tidb/stable/ticdc-changefeed-overview/): 了解 Changefeed 的基本概念和 Changefeed 状态的定义与流转
-- [CHARACTER_SETS](https://docs.pingcap.com/tidb/stable/information-schema-character-sets/): 了解 INFORMATION_SCHEMA 表 `CHARACTER_SETS`。
-- [CHECK_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-check-constraints/): 了解 INFORMATION_SCHEMA 表 `CHECK_CONSTRAINTS`。
-- [CLIENT_ERRORS_SUMMARY_BY_HOST](https://docs.pingcap.com/tidb/stable/client-errors-summary-by-host/): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_HOST`。
-- [CLIENT_ERRORS_SUMMARY_BY_USER](https://docs.pingcap.com/tidb/stable/client-errors-summary-by-user/): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_USER`。
-- [CLIENT_ERRORS_SUMMARY_GLOBAL](https://docs.pingcap.com/tidb/stable/client-errors-summary-global/): 了解 information_schema 表 `CLIENT_ERRORS_SUMMARY_GLOBAL`。
-- [CLUSTER_CONFIG](https://docs.pingcap.com/tidb/stable/information-schema-cluster-config/): 了解 information_schema 表 `CLUSTER_CONFIG`。
-- [CLUSTER_HARDWARE](https://docs.pingcap.com/tidb/stable/information-schema-cluster-hardware/): 了解 TiDB 集群硬件表 `CLUSTER_HARDWARE`。
-- [CLUSTER_INFO](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info/): 了解 TiDB 集群拓扑表 `CLUSTER_INFO`。
-- [CLUSTER_LOAD](https://docs.pingcap.com/tidb/stable/information-schema-cluster-load/): 了解 information_schema 表 `CLUSTER_LOAD`。
-- [CLUSTER_LOG](https://docs.pingcap.com/tidb/stable/information-schema-cluster-log/): 了解 information_schema 表 `CLUSTER_LOG`。
-- [CLUSTER_SYSTEMINFO](https://docs.pingcap.com/tidb/stable/information-schema-cluster-systeminfo/): 了解 TiDB 集群负载表 `CLUSTER_SYSTEMINFO`。
-- [COLLATION_CHARACTER_SET_APPLICABILITY](https://docs.pingcap.com/tidb/stable/information-schema-collation-character-set-applicability/): 了解 INFORMATION_SCHEMA 表 `COLLATION_CHARACTER_SET_APPLICABILITY`。
-- [COLLATIONS](https://docs.pingcap.com/tidb/stable/information-schema-collations/): 了解 information_schema 表 `COLLATIONS`。
-- [COLUMNS](https://docs.pingcap.com/tidb/stable/information-schema-columns/): 了解 INFORMATION_SCHEMA 表 `COLUMNS`。
-- [COMMIT](https://docs.pingcap.com/tidb/stable/sql-statement-commit/): TiDB 数据库中 COMMIT 的使用概况。
-- [CREATE [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/tidb/stable/sql-statement-create-binding/): TiDB 数据库中 CREATE [GLOBAL|SESSION] BINDING 的使用概况。
-- [CREATE DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-create-database/): TiDB 数据库中 CREATE DATABASE 的使用概况。
-- [CREATE INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-create-index/): CREATE INDEX 在 TiDB 中的使用概况
-- [CREATE PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-create-placement-policy/): TiDB 数据库中 CREATE PLACEMENT POLICY 的使用概况。
-- [CREATE RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group/): TiDB 数据库中 CREATE RESOURCE GROUP 的使用概况。
-- [CREATE ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-create-role/): TiDB 数据库中 CREATE ROLE 的使用概况。
-- [CREATE SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-create-sequence/): CREATE SEQUENCE 在 TiDB 中的使用概况
-- [CREATE TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-create-table/): TiDB 数据库中 CREATE TABLE 的使用概况
-- [CREATE TABLE LIKE](https://docs.pingcap.com/tidb/stable/sql-statement-create-table-like/): TiDB 数据库中 CREATE TABLE LIKE 的使用概况。
-- [CREATE USER](https://docs.pingcap.com/tidb/stable/sql-statement-create-user/): TiDB 数据库中 CREATE USER 的使用概况。
-- [CREATE VIEW](https://docs.pingcap.com/tidb/stable/sql-statement-create-view/): TiDB 数据库中 CREATE VIEW 的使用概况。
-- [Data Migration DDL 特殊处理说明](https://docs.pingcap.com/tidb/stable/dm-ddl-compatible/): 数据迁移中，根据不同的 DDL 语句和场景，采用不同处理方式。DM 不支持的 DDL 语句会直接跳过。部分 DDL 语句在同步到下游前会进行改写。在合库合表迁移任务中，DDL 同步行为存在变更。Online DDL 特性也会对 DDL 事件进行特殊处理。
-- [Data Migration 中的 DML 同步机制](https://docs.pingcap.com/tidb/stable/dm-dml-replication-logic/): 了解 DM 核心处理单元 Sync 如何同步 DML 语句。
-- [Data Migration 常见问题](https://docs.pingcap.com/tidb/stable/dm-faq/): 数据迁移常见问题包括：DM 是否支持迁移阿里 RDS 和其他云数据库的数据、task 配置中的黑白名单的正则表达式是否支持非获取匹配、处理不兼容的 DDL 语句、重置数据迁移任务、全量导入过程中遇到报错等。
-- [Data Migration 架构](https://docs.pingcap.com/tidb/stable/dm-arch/): Data Migration 架构包括三个组件：DM-master，DM-worker 和 dmctl。DM-master 负责管理和调度数据迁移任务的各项操作。DM-worker 执行具体的数据迁移任务。dmctl 是用来控制 DM 集群的命令行工具。 DM 集群的拓扑信息、数据迁移任务的运行状态和管理统一入口都由 DM-master 负责。DM-worker 负责持久化保存 binlog 数据、保存数据迁移子任务的配置信息和监控数据迁移子任务的运行状态。dmctl 用来创建、更新或删除数据迁移任务、查看数据迁移任务状态、处理数据迁移任务错误和校验数据迁移任务配置的正确性。 Data Migration 高可用机制可以进一步探索。
-- [Data Migration 高可用机制](https://docs.pingcap.com/tidb/stable/dm-high-availability/): 了解 Data Migration (DM) 高可用的内部机制，以及对迁移任务的影响。
-- [DATA_LOCK_WAITS](https://docs.pingcap.com/tidb/stable/information-schema-data-lock-waits/): 了解 information_schema 表 `DATA_LOCK_WAITS`。
-- [DDL 语句的执行原理及最佳实践](https://docs.pingcap.com/tidb/stable/ddl-introduction/): 介绍 TiDB 中 DDL 语句的实现原理、在线变更过程、最佳实践等内容。
-- [DDL_JOBS](https://docs.pingcap.com/tidb/stable/information-schema-ddl-jobs/): 了解 information_schema 表 `DDL_JOBS`。
-- [DEADLOCKS](https://docs.pingcap.com/tidb/stable/information-schema-deadlocks/): 了解 INFORMATION_SCHEMA 表 `DEADLOCKS`。
-- [DEALLOCATE](https://docs.pingcap.com/tidb/stable/sql-statement-deallocate/): TiDB 数据库中 DEALLOCATE 的使用概况。
-- [DELETE](https://docs.pingcap.com/tidb/stable/sql-statement-delete/): TiDB 数据库中 DELETE 的使用概况。
-- [在 Kubernetes 上部署 DM](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tidb-dm/): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/deploy-tidb-dm
-- [DESC](https://docs.pingcap.com/tidb/stable/sql-statement-desc/): TiDB 数据库中 DESC 的使用概况。
-- [DESCRIBE](https://docs.pingcap.com/tidb/stable/sql-statement-describe/): TiDB 数据库中 DESCRIBE 的使用概况。
-- [Distinct 优化](https://docs.pingcap.com/tidb/stable/agg-distinct-optimization/): 本文介绍了对于 DISTINCT 的优化，包括简单 DISTINCT 和聚合函数 DISTINCT 的优化。简单的 DISTINCT 通常会被优化成 GROUP BY 来执行。而带有 DISTINCT 的聚合函数会在 TiDB 侧单线程执行，可以通过系统变量或 TiDB 配置项控制优化器是否执行。在优化后，DISTINCT 被下推到了 Coprocessor，在 HashAgg 里新增了一个 group by 列。
-- [DM 5.4.0 性能测试报告](https://docs.pingcap.com/tidb/stable/dm-benchmark-v5.4.0/): 了解 DM 5.4.0 版本的性能。
-- [DM Relay Log](https://docs.pingcap.com/tidb/stable/relay-log/): 了解目录结构、初始迁移规则和 DM relay log 的数据清理。
-- [DM Table Selector](https://docs.pingcap.com/tidb/stable/table-selector/): 介绍 DM 的 Table Selector
-- [DM 任务完整配置文件介绍](https://docs.pingcap.com/tidb/stable/task-configuration-file-full/): 本文介绍了 Data Migration (DM) 的任务完整配置文件，包括全局配置和实例配置两部分。全局配置包括任务基本信息配置和功能配置集，功能配置集包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers。实例配置定义了具体的数据迁移子任务，包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers 的配置名称。
-- [DM 告警信息](https://docs.pingcap.com/tidb/stable/dm-alert-rules/): 介绍 DM 的告警信息。
-- [DM 增量数据校验](https://docs.pingcap.com/tidb/stable/dm-continuous-data-validation/): 了解增量数据校验的原理，以及如何使用增量数据校验功能。
-- [DM 安全模式](https://docs.pingcap.com/tidb/stable/dm-safe-mode/): 介绍 DM safe mode 作用和原理
-- [DM 数据迁移最佳实践](https://docs.pingcap.com/tidb/stable/dm-best-practices/): 了解使用 TiDB Data Migration (DM) 进行数据迁移的一些最佳实践。
-- [DM 监控指标](https://docs.pingcap.com/tidb/stable/monitor-a-dm-cluster/): 介绍 DM 的监控指标
-- [DM 自定义加解密 key](https://docs.pingcap.com/tidb/stable/dm-customized-secret-key/): 介绍如何自定义密钥，用于加密和解密 DM（Data Migration）数据源和迁移任务配置中的密码。
-- [DM 配置优化](https://docs.pingcap.com/tidb/stable/dm-tune-configuration/): 介绍如何通过优化配置来提高数据迁移性能。
-- [DM 配置简介](https://docs.pingcap.com/tidb/stable/dm-config-overview/): 本文简要介绍了 DM（数据迁移）的配置文件和数据迁移任务的配置。配置文件包括 dm-master.toml、dm-worker.toml 和 source.yaml，分别用于配置 DM-master 进程、DM-worker 进程和上游数据库 MySQL/MariaDB。创建数据迁移任务的具体步骤包括使用 dmctl 加载数据源配置、参考数据任务配置向导创建 your_task.yaml 文件，以及使用 dmctl 创建数据迁移任务。关键概念包括 source-id、DM-master ID 和 DM-worker ID，分别用于唯一确定 MySQL 或 MariaDB 实例、DM-master 和 DM-worker。
-- [DM 集群性能测试](https://docs.pingcap.com/tidb/stable/dm-performance-test/): 了解如何测试 DM 集群的性能。
-- [DM-master 配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-master-configuration-file/): 本文介绍了 DM-master 的配置文件，包括示例配置和配置项说明。示例配置包括日志配置、DM-master 监听地址、集群配置等。配置项说明包括全局配置，如标识 DM-master、日志级别、日志文件、地址等。另外还包括 SSL 证书路径、证书检查 Common Name 列表和加解密密钥路径等内容。
-- [DM-worker 简介](https://docs.pingcap.com/tidb/stable/dm-worker-intro/): DM-worker 是 DM (Data Migration) 的一个组件，负责执行数据迁移任务。主要功能包括注册为 MySQL 或 MariaDB 服务器的 slave，读取 binlog event 并持久化保存在本地，支持迁移一个 MySQL 或 MariaDB 实例的数据到多个 TiDB 实例，以及支持迁移多个 MySQL 或 MariaDB 实例的数据到一个 TiDB 实例。处理单元包括 Relay log、dump、load 和 Binlog replication/sync。上游数据库用户需具有 SELECT、RELOAD、REPLICATION SLAVE 和 REPLICATION CLIENT 权限，下游数据库用户需具有 SELECT、INSERT、UPDATE、DELETE、CREATE、DROP 和 INDEX 权限。处理单元所需的最小权限根据具体情况可能会改变。
-- [DM-worker 配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-worker-configuration-file/): 本文介绍了 DM-worker 的配置文件，包括配置文件示例和配置项说明。配置文件示例包括了 worker 的名称、日志配置、worker 的地址等内容。配置项说明包括了全局配置中的各个配置项的说明，如 name、log-level、log-file 等。同时还介绍了一些新增的配置项，如 relay-keepalive-ttl 和 relay-dir。SSL 相关的配置项也有详细说明。
-- [DO | TiDB SQL Statement Reference](https://docs.pingcap.com/tidb/stable/sql-statement-do/): TiDB 数据库中 DO 的使用概况。
-- [DROP [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/tidb/stable/sql-statement-drop-binding/): TiDB 数据库中 DROP [GLOBAL|SESSION] BINDING 的使用概况。
-- [DROP COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-drop-column/): TiDB 数据库中 DROP COLUMN 的使用概况。
-- [DROP DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-database/): TiDB 数据库中 DROP DATABASE 的使用概况。
-- [DROP INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-drop-index/): TiDB 数据库中 DROP INDEX 的使用概况。
-- [DROP PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-drop-placement-policy/): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
-- [DROP RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-drop-resource-group/): TiDB 数据库中 DROP RESOURCE GROUP 的使用概况。
-- [DROP ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-role/): TiDB 数据库中 DROP ROLE 的使用概况。
-- [DROP SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-sequence/): TiDB 数据库中 DROP SEQUENCE 的使用概况。
-- [DROP STATS](https://docs.pingcap.com/tidb/stable/sql-statement-drop-stats/): TiDB 数据库中 DROP STATS 的使用概况。
-- [DROP TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-table/): TiDB 数据库中 DROP TABLE 的使用概况。
-- [DROP USER](https://docs.pingcap.com/tidb/stable/sql-statement-drop-user/): TiDB 数据库中 DROP USER 的使用概况。
-- [DROP VIEW](https://docs.pingcap.com/tidb/stable/sql-statement-drop-view/): TiDB 数据库中 DROP VIEW 的使用概况。
-- [ENGINES](https://docs.pingcap.com/tidb/stable/information-schema-engines/): 了解 information_schema 表 `ENGINES`。
-- [EXECUTE](https://docs.pingcap.com/tidb/stable/sql-statement-execute/): TiDB 数据库中 EXECUTE 的使用概况。
-- [EXPLAIN](https://docs.pingcap.com/tidb/stable/sql-statement-explain/): TiDB 数据库中 EXPLAIN 的使用概况。
-- [EXPLAIN ANALYZE](https://docs.pingcap.com/tidb/stable/sql-statement-explain-analyze/): TiDB 数据库中 EXPLAIN ANALYZE 的使用概况。
-- [FLASHBACK CLUSTER](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-cluster/): TiDB 数据库中 FLASHBACK CLUSTER 的使用概况。
-- [FLASHBACK DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-database/): TiDB 数据库中 FLASHBACK DATABASE 的使用概况。
-- [FLASHBACK TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-table/): TiDB 4.0 引入了 `FLASHBACK TABLE` 语法，可在 GC 生命周期内恢复被 `DROP` 或 `TRUNCATE` 删除的表和数据。使用系统变量 `tidb_gc_life_time` 配置历史版本保留时间，默认为 `10m0s`。查询当前`safePoint`：`SELECT * FROM mysql.tidb WHERE variable_name = 'tikv_gc_safe_point'`。注意，过了 GC 生命周期就无法恢复被删除的数据。
-- [FLUSH PRIVILEGES](https://docs.pingcap.com/tidb/stable/sql-statement-flush-privileges/): TiDB 数据库中 FLUSH PRIVILEGES 的使用概况。
-- [FLUSH STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-flush-status/): TiDB 数据库中 FLUSH STATUS 的使用概况。
-- [FLUSH TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-flush-tables/): TiDB 数据库中 FLUSH TABLES 的使用概况。
-- [Follower Read](https://docs.pingcap.com/tidb/stable/dev-guide-use-follower-read/): 使用 Follower Read 在特定情况下加速查询。
-- [Follower Read](https://docs.pingcap.com/tidb/stable/follower-read/): 了解 Follower Read 的使用与实现。
-- [GBK](https://docs.pingcap.com/tidb/stable/character-set-gbk/): 本文介绍 TiDB 对 GBK 字符集的支持情况。
-- [GC 机制简介](https://docs.pingcap.com/tidb/stable/garbage-collection-overview/): TiDB 的事务实现采用了 MVCC 机制，GC 的任务是清理不再需要的旧数据。整体流程包括 GC leader 控制 GC 的运行，定期触发 GC，以及三个步骤：Resolve Locks 清理锁，Delete Ranges 删除区间，Do GC 进行 GC 清理。Resolve Locks 清理锁有两种执行模式：LEGACY 和 PHYSICAL。Delete Ranges 删除区间会快速物理删除待删除的区间及删除操作的时间戳。Do GC 进行 GC 清理会删除所有 key 的过期版本。GC 每 10 分钟触发一次，默认保留最近 10 分钟内的数据。
-- [GC 配置](https://docs.pingcap.com/tidb/stable/garbage-collection-configuration/): TiDB 的 GC 配置可以通过系统变量进行设置，包括启用 GC、运行间隔、数据保留时限、并发线程数量等。此外，TiDB 还支持 GC 流控，可以限制每秒数据写入量。从 TiDB 5.0 版本开始，建议使用系统变量进行配置，避免异常行为。在 TiDB 6.1.0 版本引入了新的系统变量 `tidb_gc_max_wait_time`，用于控制活跃事务阻塞 GC safe point 推进的最长时间。另外，GC in Compaction Filter 机制可以通过配置文件或在线配置开启，但可能会影响 TiKV 扫描性能。
-- [Gitpod](https://docs.pingcap.com/tidb/stable/dev-guide-playground-gitpod/): Gitpod 是一个开源 Kubernetes 应用程序，可在浏览器中获得完整的开发环境，并立即编写代码。它能够为云中的每个任务提供全新的自动化开发环境，无需本地配置。Gitpod 提供了完整的、自动化的、预配置的云原生开发环境，让你可以直接在浏览器中开发、运行、测试代码。
-- [GRANT <privileges>](https://docs.pingcap.com/tidb/stable/sql-statement-grant-privileges/): TiDB 数据库中 GRANT <privileges> 的使用概况。
-- [GRANT <role>](https://docs.pingcap.com/tidb/stable/sql-statement-grant-role/): TiDB 数据库中 GRANT <role> 的使用概况。
-- [GROUP BY 修饰符](https://docs.pingcap.com/tidb/stable/group-by-modifier/): 了解如何使用 TiDB GROUP BY 修饰符。
-- [GROUP BY 聚合函数](https://docs.pingcap.com/tidb/stable/aggregate-group-by-functions/): TiDB支持的聚合函数包括 COUNT、COUNT(DISTINCT)、SUM、AVG、MAX、MIN、GROUP_CONCAT、VARIANCE、VAR_POP、STD、STDDEV、VAR_SAMP、STDDEV_SAMP 和 JSON_OBJECTAGG。除了 GROUP_CONCAT 和 APPROX_PERCENTILE 外，这些聚合函数可以作为窗口函数使用。另外，TiDB 的 GROUP BY 子句支持 WITH ROLLUP 修饰符，还支持 SQL 模式 ONLY_FULL_GROUP_BY。与 MySQL 的区别在于 TiDB 对标准 SQL 有一些扩展，允许在 HAVING 子句中使用别名和非列表达式。
-- [HAProxy 在 TiDB 中的最佳实践](https://docs.pingcap.com/tidb/stable/haproxy-best-practices/): HAProxy 是 TiDB 中实现负载均衡的最佳实践。它提供 TCP 协议下的负载均衡能力，通过连接 HAProxy 提供的浮动 IP 对数据进行操作，实现 TiDB Server 层的负载均衡。HAProxy 提供高可用性、负载均衡、健康检查、会话保持、SSL 支持和监控统计等核心功能。部署 HAProxy 需要满足一定的硬件和软件要求，配置和启动 HAProxy 后即可实现数据库负载均衡。
-- [HTAP 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-htap/): 本文介绍如何快速上手体验 TiDB 的 HTAP 功能。
-- [HTAP 查询](https://docs.pingcap.com/tidb/stable/dev-guide-hybrid-oltp-and-olap-queries/): 介绍 TiDB 中的 HTAP 查询功能。
-- [HTAP 深入探索指南](https://docs.pingcap.com/tidb/stable/explore-htap/): 本文介绍如何深入探索并使用 TiDB 的 HTAP 功能。
-- [IMPORT INTO](https://docs.pingcap.com/tidb/stable/sql-statement-import-into/): TiDB 数据库中 IMPORT INTO 的使用概况。
-- [IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性](https://docs.pingcap.com/tidb/stable/tidb-lightning-compatibility-and-scenarios/): 了解 IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性及使用场景。
-- [IMPORT INTO 和 TiDB Lightning 对比](https://docs.pingcap.com/tidb/stable/import-into-vs-tidb-lightning/): 了解 `IMPORT INTO` 和 TiDB Lightning 的差异。
-- [Information Schema](https://docs.pingcap.com/tidb/stable/information-schema/): Information Schema 是一种查看系统元数据的 ANSI 标准方法。TiDB 提供了许多自定义的 `INFORMATION_SCHEMA` 表，包括与 MySQL 兼容的表和 TiDB 中的扩展表。这些表提供了关于字符集、排序规则、列、存储引擎、索引、表大小、慢查询等信息，帮助用户进行系统监控和优化。
-- [INSERT](https://docs.pingcap.com/tidb/stable/sql-statement-insert/): TiDB 数据库中 INSERT 的使用概况。
-- [INSPECTION_RESULT](https://docs.pingcap.com/tidb/stable/information-schema-inspection-result/): 了解 TiDB 系统表 `INSPECTION_RESULT`。
-- [INSPECTION_RULES](https://docs.pingcap.com/tidb/stable/information-schema-inspection-rules/): 了解 information_schema 表 `INSPECTION_RULES`。
-- [INSPECTION_SUMMARY](https://docs.pingcap.com/tidb/stable/information-schema-inspection-summary/): 了解 TiDB 系统表 `INSPECTION_SUMMARY`。
-- [Join Reorder 算法简介](https://docs.pingcap.com/tidb/stable/join-reorder/): Join Reorder 算法决定了多表 Join 的顺序，影响执行效率。TiDB 中有贪心算法和动态规划算法两种实现。贪心算法选择行数最小的表与其他表做 Join，直到所有节点完成 Join。动态规划算法枚举所有可能的 Join 顺序，选择最优的。算法受系统变量控制，且存在一些限制，如无法保证一定选到合适的 Join 顺序。
-- [JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions/): TiDB 支持 MySQL 8.0 中提供的大部分 JSON 函数。
-- [JSON 效用函数](https://docs.pingcap.com/tidb/stable/json-functions-utility/): 了解 JSON 效用函数。
-- [JSON 数据类型](https://docs.pingcap.com/tidb/stable/data-type-json/): JSON 类型存储半结构化数据，使用 Binary 格式序列化，加快查询和解析速度。JSON 字段不能创建索引，但可以对 JSON 文档中的子字段创建索引。TiDB 仅支持下推部分 JSON 函数到 TiFlash，不建议使用 BR 恢复包含 JSON 列的数据到 v6.3.0 之前的 TiDB 集群。请勿同步非标准 JSON 类型的数据。MySQL 误标记二进制类型数据为 STRING 类型，TiDB 保持正确的二进制类型。ENUM 或 SET 数据类型转换为 JSON 时，TiDB 会检查格式正确性。TiDB 支持使用 ORDER BY 对 JSON Array 或 JSON Object 进行排序。在 INSERT JSON 列时，TiDB 会将值隐式转换为 JSON。
-- [KEY_COLUMN_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-key-column-usage/): 了解 information_schema 表 `KEY_COLUMN_USAGE`。
-- [KEYWORDS](https://docs.pingcap.com/tidb/stable/information-schema-keywords/): 了解 INFORMATION_SCHEMA 表 `KEYWORDS`。
-- [KILL](https://docs.pingcap.com/tidb/stable/sql-statement-kill/): TiDB 数据库中 KILL 的使用概况。
-- [Load Base Split](https://docs.pingcap.com/tidb/stable/configure-load-base-split/): 介绍 Load Base Split 功能。
-- [LOAD DATA](https://docs.pingcap.com/tidb/stable/sql-statement-load-data/): TiDB 数据库中 LOAD DATA 的使用概况。
-- [LOAD STATS](https://docs.pingcap.com/tidb/stable/sql-statement-load-stats/): TiDB 数据库中 LOAD STATS 的使用概况。
-- [LOCK STATS](https://docs.pingcap.com/tidb/stable/sql-statement-lock-stats/): TiDB 数据库中 LOCK STATS 的使用概况。
-- [LOCK TABLES 和 UNLOCK TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-lock-tables-and-unlock-tables/): TiDB 数据库中 LOCK TABLES 和 UNLOCK TABLES 的使用概况。
-- [Max/Min 函数消除规则](https://docs.pingcap.com/tidb/stable/max-min-eliminate/): SQL 中的 max/min 函数消除规则能够将 max/min 聚合函数转换为 TopN 算子，利用索引进行查询。当只有一个 max/min 函数时，会重写为 select max(a) from (select a from t where a is not null order by a desc limit 1) t，利用索引只扫描一行数据。存在多个 max/min 函数时，会先检查列是否有索引能够保序，然后重写为两个子查询的笛卡尔积，最终避免对整个表的扫描。
-- [MEMORY_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-memory-usage/): 了解 information_schema 表 `MEMORY_USAGE`。
-- [MEMORY_USAGE_OPS_HISTORY](https://docs.pingcap.com/tidb/stable/information-schema-memory-usage-ops-history/): 了解 information_schema 表 `MEMORY_USAGE_OPS_HISTORY`。
-- [Metrics Schema](https://docs.pingcap.com/tidb/stable/metrics-schema/): 了解 TiDB `METRICS SCHEMA` 系统数据库。
-- [METRICS_SUMMARY](https://docs.pingcap.com/tidb/stable/information-schema-metrics-summary/): 了解 TiDB 系统表 `METRICS_SUMMARY`。
-- [METRICS_TABLES](https://docs.pingcap.com/tidb/stable/information-schema-metrics-tables/): 了解 TiDB 系统表 `METRICS_TABLES`。
-- [MODIFY COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-modify-column/): TiDB 数据库中 MODIFY COLUMN 的使用概况。
-- [mysql Schema](https://docs.pingcap.com/tidb/stable/mysql-schema/): 了解 TiDB 系统表。
-- [mysql.tidb_mdl_view](https://docs.pingcap.com/tidb/stable/mysql-schema-tidb-mdl-view/): 了解 `mysql` schema 中的 `tidb_mdl_view` 视图。
-- [mysql.user](https://docs.pingcap.com/tidb/stable/mysql-schema-user/): 了解 `mysql` 系统表 `user`。
-- [OLTP 负载性能优化实践](https://docs.pingcap.com/tidb/stable/performance-tuning-practices/): 本文档介绍了如何对 OLTP 负载进行性能分析和优化。
-- [Online Unsafe Recovery 使用文档](https://docs.pingcap.com/tidb/stable/online-unsafe-recovery/): 如何使用 Online Unsafe Recovery。
-- [Optimizer Fix Controls](https://docs.pingcap.com/tidb/stable/optimizer-fix-controls/): 了解 Optimizer Fix Controls 以及如何使用 `tidb_opt_fix_control` 细粒度地控制 TiDB 优化器的行为。
-- [Optimizer Hints](https://docs.pingcap.com/tidb/stable/optimizer-hints/): 介绍 TiDB 中 Optimizer Hints 的语法和不同生效范围的 Hint 的使用方法。
-- [Oracle 与 TiDB 函数和语法差异对照](https://docs.pingcap.com/tidb/stable/oracle-functions-to-tidb/): 了解 Oracle 与 TiDB 函数和语法差异对照。
-- [Overview 面板重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-overview-dashboard/): TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview。重要监控指标包括服务在线节点数量、PD 角色、存储容量、Region 数量、TiDB 执行数量、CPU 使用率、内存大小、网络流量等。详细监控说明可参见文章。
-- [Partitioned Raft KV](https://docs.pingcap.com/tidb/stable/partitioned-raft-kv/): 了解 TiKV 的 Partitioned Raft KV 特性。
-- [PARTITIONS](https://docs.pingcap.com/tidb/stable/information-schema-partitions/): 了解 INFORMATION_SCHEMA 表 `PARTITIONS`。
-- [PD Control 使用说明](https://docs.pingcap.com/tidb/stable/pd-control/): PD Control 是 PD 的命令行工具，用于获取集群状态信息和调整集群。
-- [PD Recover 使用文档](https://docs.pingcap.com/tidb/stable/pd-recover/): PD Recover 是用于恢复无法正常启动或服务的 PD 集群的工具。安装方式包括从源代码编译和下载 TiDB 工具包。恢复集群的方式有两种：从存活的 PD 节点重建和完全重建。从存活的 PD 节点重建集群需要停止所有节点，启动存活的 PD 节点，并使用 pd-recover 修复元数据。完全重建 PD 集群需要获取 Cluster ID 和已分配 ID，部署新的 PD 集群，使用 pd-recover 修复，然后重启整个集群。
-- [PD 微服务](https://docs.pingcap.com/tidb/stable/pd-microservices/): 介绍如何开启 PD 微服务模式，以提高服务质量。
-- [PD 微服务部署拓扑](https://docs.pingcap.com/tidb/stable/pd-microservices-deployment-topology/): 了解在部署最小拓扑集群的基础上，部署 PD 微服务的拓扑结构。
-- [PD 调度策略最佳实践](https://docs.pingcap.com/tidb/stable/pd-scheduling-best-practices/): 了解 PD 调度策略的最佳实践和调优方式
-- [PD 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-pd-configuration/): PD 配置参数可以通过命令行参数或环境变量配置。包括外部访问 PD 的 URL 列表，其他 PD 节点访问某个 PD 节点的 URL 列表，PD 监听的客户端 URL 列表，PD 节点监听其他 PD 节点的 URL 列表，配置文件，PD 存储数据路径，初始化 PD 集群配置，动态加入 PD 集群，Log 级别，Log 文件，是否开启日志切割，当前 PD 的名字，CA 文件路径，包含 X509 证书的 PEM 文件路径，包含 X509 key 的 PEM 文件路径，指定 Prometheus Pushgateway 的地址，强制使用当前节点创建新的集群，输出版本信息并退出。
-- [PD 配置文件描述](https://docs.pingcap.com/tidb/stable/pd-configuration-file/): PD 配置文件包含了许多参数，如节点名称、数据路径、客户端 URL、广告客户端 URL、节点 URL 等。还包括了一些实验性特性的配置项，如内存限制、GC 触发阈值、GOGC Tuner 等。此外，还有监控、调度、副本、标签、Dashboard、同步模式和资源控制等相关配置项。
-- [PD 重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-pd-dashboard/): PD 重要监控指标详解：使用 TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构参见 [TiDB 监控框架概述]。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。通过观察 PD 面板上的 Metrics，可以了解 PD 当前的状态。监控包括 PD role、Storage capacity、Current storage size、Current storage usage、Normal stores、Number of Regions、Abnormal stores、Region health、Current peer count 等。Cluster、Operator、Statistics - Balance、Statistics - hot write、Statistics - hot read、Scheduler、gRPC、etcd、TiDB、Heartbeat、Region storage 等指标也很重要。
-- [Performance Overview 面板重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-performance-overview-dashboard/): 本文介绍 Performance Overview 面板上监控指标的含义。
-- [Performance Schema](https://docs.pingcap.com/tidb/stable/performance-schema/): 了解 TiDB `performance_schema` 系统数据库。
-- [PingCAP Clinic 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-clinic/): 了解如何使用 PingCAP Clinic 诊断服务快速采集、上传、查看集群诊断数据。
-- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/tidb/stable/clinic-data-instruction-for-tiup/): 详细说明 PingCAP Clinic 诊断服务在使用 TiUP 部署的 TiDB 集群和 DM 集群中能够采集哪些诊断数据。
-- [PingCAP Clinic 诊断服务简介](https://docs.pingcap.com/tidb/stable/clinic-introduction/): 介绍 PingCAP Clinic 诊断服务，包括工具组件、使用场景和工作原理。
-- [Pipelined DML](https://docs.pingcap.com/tidb/stable/pipelined-dml/): 介绍 Pipelined DML 的使用场景、使用方法、使用限制和使用该功能的常见问题。Pipelined DML 增强了 TiDB 批量处理的能力，使得事务大小不再受到 TiDB 内存限制。
-- [Placement Rules in SQL](https://docs.pingcap.com/tidb/stable/placement-rules-in-sql/): 了解如何通过 SQL 接口调度表和分区的放置位置。
-- [Placement Rules 使用文档](https://docs.pingcap.com/tidb/stable/configure-placement-rules/): 如何配置 Placement Rules
-- [PLACEMENT_POLICIES](https://docs.pingcap.com/tidb/stable/information-schema-placement-policies/): 了解 information_schema 表 `PLACEMENT_POLICIES`。
-- [PREPARE](https://docs.pingcap.com/tidb/stable/sql-statement-prepare/): TiDB 数据库中 PREPARE 的使用概况。
-- [Prepare 语句执行计划缓存](https://docs.pingcap.com/tidb/stable/sql-prepared-plan-cache/): Prepare 语句执行计划缓存功能默认打开，可通过变量启用或关闭。缓存功能仅针对 Prepare/Execute 请求，对普通查询无效。缓存功能会有一定内存开销，可通过监控查看内存使用情况。可手动清空计划缓存，但不支持一次性清空整个集群的计划缓存。忽略 COM_STMT_CLOSE 指令和 DEALLOCATE PREPARE 语句，可解决计划被立即清理的问题。监控 Queries Using Plan Cache OPS 和 Plan Cache Miss OPS，以确保 SQL 执行计划缓存正常工作。Prepared Statement Count 图表显示非零值，表示应用使用了预处理语句。
-- [PROCESSLIST](https://docs.pingcap.com/tidb/stable/information-schema-processlist/): 了解 information_schema 表 `PROCESSLIST`。
-- [ProxySQL 集成指南](https://docs.pingcap.com/tidb/stable/dev-guide-proxysql-integration/): 了解如何将本地部署的 TiDB 或 TiDB Cloud 集群与 ProxySQL 集成。
-- [QUERY WATCH](https://docs.pingcap.com/tidb/stable/sql-statement-query-watch/): TiDB 数据库中 QUERY WATCH 的使用概况。
-- [RECOVER TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-recover-table/): RECOVER TABLE 是用来恢复被删除的表及其数据的功能。在 DROP TABLE 后，在 GC life time 时间内，可以使用 RECOVER TABLE 语句来恢复被删除的表以及其数据。如果删除表后并过了 GC lifetime，就不能再用 RECOVER TABLE 来恢复被删除的表了。
-- [REFERENTIAL_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-referential-constraints/): 了解 INFORMATION_SCHEMA 表 `REFERENTIAL_CONSTRAINTS`。
-- [Region 性能调优](https://docs.pingcap.com/tidb/stable/tune-region-performance/): 了解如何通过调整 Region 大小等方法对 Region 进行性能调优以及如何在大 Region 下使用 bucket 进行并发查询优化。
-- [RENAME INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-rename-index/): TiDB 数据库中 RENAME INDEX 的使用概况。
-- [RENAME TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-rename-table/): TiDB 数据库中 RENAME TABLE 的使用概况。
-- [RENAME USER](https://docs.pingcap.com/tidb/stable/sql-statement-rename-user/): TiDB 数据库中 RENAME USER 的使用概况。
-- [REPLACE](https://docs.pingcap.com/tidb/stable/sql-statement-replace/): TiDB 数据库中 REPLACE 的使用概况。
-- [RESOURCE_GROUPS](https://docs.pingcap.com/tidb/stable/information-schema-resource-groups/): 了解 information_schema 表 `RESOURCE_GROUPS`。
-- [RESTORE](https://docs.pingcap.com/tidb/stable/sql-statement-restore/): TiDB 数据库中 RESTORE 的使用概况。
-- [REVOKE <privileges>](https://docs.pingcap.com/tidb/stable/sql-statement-revoke-privileges/): TiDB 数据库中 REVOKE <privileges> 的使用概况。
-- [REVOKE <role>](https://docs.pingcap.com/tidb/stable/sql-statement-revoke-role/): TiDB 数据库中 REVOKE <role> 的使用概况。
-- [RocksDB 简介](https://docs.pingcap.com/tidb/stable/rocksdb-overview/): RocksDB 是 Facebook 基于 LevelDB 开发的 LSM-tree 架构引擎，提供键值存储与读写功能。数据先写入磁盘上的 WAL，再写入内存中的跳表。内存数据达到阈值后刷到磁盘生成 SST 文件，分为多层，90% 数据存储在最后一层。RocksDB 允许创建多个 ColumnFamily，共享同一个 WAL 文件。为提高读取性能，文件按大小切分成 block，存在 BlockCache 中。后台线程执行 MemTable 转化为 SST 文件和合并操作。L0 文件数量过多会触发 WriteStall 阻塞写入。
-- [ROLLBACK](https://docs.pingcap.com/tidb/stable/sql-statement-rollback/): TiDB 数据库中 ROLLBACK 的使用概况。
-- [RUNAWAY_WATCHES](https://docs.pingcap.com/tidb/stable/information-schema-runaway-watches/): 了解 INFORMATION_SCHEMA 表 `RUNAWAY_WATCHES`。
-- [Runtime Filter](https://docs.pingcap.com/tidb/stable/runtime-filter/): 介绍 Runtime Filter 的原理及使用方式。
-- [SaaS 多租户场景最佳实践](https://docs.pingcap.com/tidb/stable/saas-best-practices/): 介绍 TiDB 在 SaaS (Software as a service) 多租户场景的最佳实践，特别适用于单集群表数量超过百万级别的场景。
-- [SAVEPOINT](https://docs.pingcap.com/tidb/stable/sql-statement-savepoint/): TiDB 数据库中 SAVEPOINT 的使用概况。
+- [TiDB 版本周期支持策略](https://cn.pingcap.com/tidb-release-support-policy.md): 阐述了 PingCAP 就 TiDB 版本提供支持服务的标准和规则。
+- [50 TiB 数据导入最佳实践](https://docs.pingcap.com/tidb/stable/data-import-best-practices.md): 了解将大规模数据导入 TiDB 的最佳实践。
+- [ADD COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-add-column.md): TiDB 数据库中 ADD COLUMN 的使用概况。
+- [ADD INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-add-index.md): TiDB 数据库中 ADD INDEX 的使用概况。
+- [ADMIN](https://docs.pingcap.com/tidb/stable/sql-statement-admin.md): TiDB的 `ADMIN` 语句是用于查看TiDB状态和对表数据进行校验的扩展语法。其中包括 `ADMIN RELOAD`、`ADMIN PLUGIN`、`ADMIN ... BINDINGS`、`ADMIN REPAIR TABLE` 和 `ADMIN SHOW NEXT_ROW_ID` 等扩展语句。这些语句可以用于重新加载表达式下推的黑名单、启用或禁用插件、持久化 SQL Plan 绑定信息、修复表的元信息以及查看表中特殊列的详情。这些功能对于管理和维护 TiDB 数据库非常有用。
+- [ADMIN [SET|SHOW|UNSET] BDR ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-admin-bdr-role.md): TiDB 数据库中 ADMIN [SET|SHOW|UNSET] BDR ROLE 的使用概况。
+- [ADMIN ALTER DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-alter-ddl.md): TiDB 数据库中 `ADMIN ALTER DDL JOBS` 的使用概况。
+- [ADMIN CANCEL DDL](https://docs.pingcap.com/tidb/stable/sql-statement-admin-cancel-ddl.md): TiDB 数据库中 ADMIN CANCEL DDL 的使用概况。
+- [ADMIN CHECK [TABLE|INDEX]](https://docs.pingcap.com/tidb/stable/sql-statement-admin-check-table-index.md): TiDB 数据库中 ADMIN CHECK [TABLE|INDEX] 的使用概况。
+- [ADMIN CHECKSUM TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-admin-checksum-table.md): TiDB 数据库中 ADMIN CHECKSUM TABLE 的使用概况。
+- [ADMIN CLEANUP INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-admin-cleanup.md): TiDB 数据库中 ADMIN CLEANUP 的使用概况。
+- [ADMIN PAUSE DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-pause-ddl.md): TiDB 数据库中 ADMIN PAUSE DDL JOBS 的使用概况。
+- [ADMIN RECOVER INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-admin-recover.md): TiDB 数据库中 ADMIN RECOVER INDEX 的使用概况。
+- [ADMIN RESUME DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-resume-ddl.md): TiDB 数据库中 ADMIN RESUME DDL 的使用概况。
+- [ADMIN SHOW DDL [JOBS|JOB QUERIES]](https://docs.pingcap.com/tidb/stable/sql-statement-admin-show-ddl.md): TiDB 数据库中 ADMIN SHOW DDL [JOBS|JOB QUERIES] 的使用概况。
+- [ALTER DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-database.md): TiDB 数据库中 ALTER DATABASE 的使用概况。
+- [ALTER INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-alter-index.md): TiDB 数据库中 ALTER INDEX 的使用概况。
+- [ALTER INSTANCE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-instance.md): TiDB 数据库中 ALTER INSTANCE 的使用概况。
+- [ALTER PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-alter-placement-policy.md): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
+- [ALTER RANGE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-range.md): TiDB 数据库中 ALTER RANGE 的使用概况。
+- [ALTER RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-alter-resource-group.md): TiDB 数据库中 ALTER RESOURCE GROUP 的使用概况。
+- [ALTER SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-sequence.md): 介绍 ALTER SEQUENCE 在 TiDB 中的使用概况。
+- [ALTER TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-table.md): TiDB 数据库中 ALTER TABLE 的使用概况。
+- [ALTER TABLE ... COMPACT](https://docs.pingcap.com/tidb/stable/sql-statement-alter-table-compact.md): TiDB 数据库中 ALTER TABLE ... COMPACT 语句的使用概况。
+- [ALTER USER](https://docs.pingcap.com/tidb/stable/sql-statement-alter-user.md): TiDB 数据库中 ALTER USER 的使用概况。
+- [ANALYZE](https://docs.pingcap.com/tidb/stable/sql-statement-analyze-table.md): TiDB 数据库中 ANALYZE 的使用概况。
+- [ANALYZE_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-analyze-status.md): 了解 information_schema 表 `ANALYZE_STATUS`。
+- [AUTO_INCREMENT](https://docs.pingcap.com/tidb/stable/auto-increment.md): 介绍 TiDB 的 `AUTO_INCREMENT` 列属性。
+- [AUTO_RANDOM](https://docs.pingcap.com/tidb/stable/auto-random.md): 本文介绍了 TiDB 的 `AUTO_RANDOM` 列属性。
+- [BACKUP](https://docs.pingcap.com/tidb/stable/sql-statement-backup.md): TiDB 数据库中 BACKUP 的使用概况。
+- [BATCH](https://docs.pingcap.com/tidb/stable/sql-statement-batch.md): TiDB 数据库中 BATCH 的使用概况。
+- [BEGIN](https://docs.pingcap.com/tidb/stable/sql-statement-begin.md): TiDB 数据库中 BEGIN 的使用概况。
+- [Bookshop 应用](https://docs.pingcap.com/tidb/stable/dev-guide-bookshop-schema-design.md): Bookshop 应用设计、数据导入、连接数据库等操作。
+- [br 命令行手册](https://docs.pingcap.com/tidb/stable/use-br-command-line-tool.md): 了解 br 命令行的定义、组成与使用。
+- [CALIBRATE RESOURCE](https://docs.pingcap.com/tidb/stable/sql-statement-calibrate-resource.md): TiDB 数据库中 CALIBRATE RESOURCE 的使用概况。
+- [CANCEL IMPORT](https://docs.pingcap.com/tidb/stable/sql-statement-cancel-import-job.md): TiDB 数据库中 CANCEL IMPORT 的使用概况。
+- [Cast 函数和操作符](https://docs.pingcap.com/tidb/stable/cast-functions-and-operators.md): Cast 函数和操作符用于将某种数据类型的值转换为另一种数据类型。TiDB 支持使用 MySQL 8.0 中提供的所有 Cast 函数和操作符。
+- [CHANGE COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-change-column.md): TiDB 数据库中 CHANGE COLUMN 的使用概况。
+- [Changefeed DDL 同步](https://docs.pingcap.com/tidb/stable/ticdc-ddl.md): 了解 TiCDC 支持同步的 DDL 和一些特殊情况
+- [Changefeed 日志过滤器](https://docs.pingcap.com/tidb/stable/ticdc-filter.md): 了解 TiCDC 的表过滤器和事件过滤器使用方法。
+- [Changefeed 概述](https://docs.pingcap.com/tidb/stable/ticdc-changefeed-overview.md): 了解 Changefeed 的基本概念和 Changefeed 状态的定义与流转
+- [CHARACTER_SETS](https://docs.pingcap.com/tidb/stable/information-schema-character-sets.md): 了解 INFORMATION_SCHEMA 表 `CHARACTER_SETS`。
+- [CHECK_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-check-constraints.md): 了解 INFORMATION_SCHEMA 表 `CHECK_CONSTRAINTS`。
+- [CLIENT_ERRORS_SUMMARY_BY_HOST](https://docs.pingcap.com/tidb/stable/client-errors-summary-by-host.md): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_HOST`。
+- [CLIENT_ERRORS_SUMMARY_BY_USER](https://docs.pingcap.com/tidb/stable/client-errors-summary-by-user.md): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_USER`。
+- [CLIENT_ERRORS_SUMMARY_GLOBAL](https://docs.pingcap.com/tidb/stable/client-errors-summary-global.md): 了解 information_schema 表 `CLIENT_ERRORS_SUMMARY_GLOBAL`。
+- [CLUSTER_CONFIG](https://docs.pingcap.com/tidb/stable/information-schema-cluster-config.md): 了解 information_schema 表 `CLUSTER_CONFIG`。
+- [CLUSTER_HARDWARE](https://docs.pingcap.com/tidb/stable/information-schema-cluster-hardware.md): 了解 TiDB 集群硬件表 `CLUSTER_HARDWARE`。
+- [CLUSTER_INFO](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info.md): 了解 TiDB 集群拓扑表 `CLUSTER_INFO`。
+- [CLUSTER_LOAD](https://docs.pingcap.com/tidb/stable/information-schema-cluster-load.md): 了解 information_schema 表 `CLUSTER_LOAD`。
+- [CLUSTER_LOG](https://docs.pingcap.com/tidb/stable/information-schema-cluster-log.md): 了解 information_schema 表 `CLUSTER_LOG`。
+- [CLUSTER_SYSTEMINFO](https://docs.pingcap.com/tidb/stable/information-schema-cluster-systeminfo.md): 了解 TiDB 集群负载表 `CLUSTER_SYSTEMINFO`。
+- [COLLATION_CHARACTER_SET_APPLICABILITY](https://docs.pingcap.com/tidb/stable/information-schema-collation-character-set-applicability.md): 了解 INFORMATION_SCHEMA 表 `COLLATION_CHARACTER_SET_APPLICABILITY`。
+- [COLLATIONS](https://docs.pingcap.com/tidb/stable/information-schema-collations.md): 了解 information_schema 表 `COLLATIONS`。
+- [COLUMNS](https://docs.pingcap.com/tidb/stable/information-schema-columns.md): 了解 INFORMATION_SCHEMA 表 `COLUMNS`。
+- [COMMIT](https://docs.pingcap.com/tidb/stable/sql-statement-commit.md): TiDB 数据库中 COMMIT 的使用概况。
+- [CREATE [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/tidb/stable/sql-statement-create-binding.md): TiDB 数据库中 CREATE [GLOBAL|SESSION] BINDING 的使用概况。
+- [CREATE DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-create-database.md): TiDB 数据库中 CREATE DATABASE 的使用概况。
+- [CREATE INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-create-index.md): CREATE INDEX 在 TiDB 中的使用概况
+- [CREATE PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-create-placement-policy.md): TiDB 数据库中 CREATE PLACEMENT POLICY 的使用概况。
+- [CREATE RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group.md): TiDB 数据库中 CREATE RESOURCE GROUP 的使用概况。
+- [CREATE ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-create-role.md): TiDB 数据库中 CREATE ROLE 的使用概况。
+- [CREATE SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-create-sequence.md): CREATE SEQUENCE 在 TiDB 中的使用概况
+- [CREATE TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-create-table.md): TiDB 数据库中 CREATE TABLE 的使用概况
+- [CREATE TABLE LIKE](https://docs.pingcap.com/tidb/stable/sql-statement-create-table-like.md): TiDB 数据库中 CREATE TABLE LIKE 的使用概况。
+- [CREATE USER](https://docs.pingcap.com/tidb/stable/sql-statement-create-user.md): TiDB 数据库中 CREATE USER 的使用概况。
+- [CREATE VIEW](https://docs.pingcap.com/tidb/stable/sql-statement-create-view.md): TiDB 数据库中 CREATE VIEW 的使用概况。
+- [Data Migration DDL 特殊处理说明](https://docs.pingcap.com/tidb/stable/dm-ddl-compatible.md): 数据迁移中，根据不同的 DDL 语句和场景，采用不同处理方式。DM 不支持的 DDL 语句会直接跳过。部分 DDL 语句在同步到下游前会进行改写。在合库合表迁移任务中，DDL 同步行为存在变更。Online DDL 特性也会对 DDL 事件进行特殊处理。
+- [Data Migration 中的 DML 同步机制](https://docs.pingcap.com/tidb/stable/dm-dml-replication-logic.md): 了解 DM 核心处理单元 Sync 如何同步 DML 语句。
+- [Data Migration 常见问题](https://docs.pingcap.com/tidb/stable/dm-faq.md): 数据迁移常见问题包括：DM 是否支持迁移阿里 RDS 和其他云数据库的数据、task 配置中的黑白名单的正则表达式是否支持非获取匹配、处理不兼容的 DDL 语句、重置数据迁移任务、全量导入过程中遇到报错等。
+- [Data Migration 架构](https://docs.pingcap.com/tidb/stable/dm-arch.md): Data Migration 架构包括三个组件：DM-master，DM-worker 和 dmctl。DM-master 负责管理和调度数据迁移任务的各项操作。DM-worker 执行具体的数据迁移任务。dmctl 是用来控制 DM 集群的命令行工具。 DM 集群的拓扑信息、数据迁移任务的运行状态和管理统一入口都由 DM-master 负责。DM-worker 负责持久化保存 binlog 数据、保存数据迁移子任务的配置信息和监控数据迁移子任务的运行状态。dmctl 用来创建、更新或删除数据迁移任务、查看数据迁移任务状态、处理数据迁移任务错误和校验数据迁移任务配置的正确性。 Data Migration 高可用机制可以进一步探索。
+- [Data Migration 高可用机制](https://docs.pingcap.com/tidb/stable/dm-high-availability.md): 了解 Data Migration (DM) 高可用的内部机制，以及对迁移任务的影响。
+- [DATA_LOCK_WAITS](https://docs.pingcap.com/tidb/stable/information-schema-data-lock-waits.md): 了解 information_schema 表 `DATA_LOCK_WAITS`。
+- [DDL 语句的执行原理及最佳实践](https://docs.pingcap.com/tidb/stable/ddl-introduction.md): 介绍 TiDB 中 DDL 语句的实现原理、在线变更过程、最佳实践等内容。
+- [DDL_JOBS](https://docs.pingcap.com/tidb/stable/information-schema-ddl-jobs.md): 了解 information_schema 表 `DDL_JOBS`。
+- [DEADLOCKS](https://docs.pingcap.com/tidb/stable/information-schema-deadlocks.md): 了解 INFORMATION_SCHEMA 表 `DEADLOCKS`。
+- [DEALLOCATE](https://docs.pingcap.com/tidb/stable/sql-statement-deallocate.md): TiDB 数据库中 DEALLOCATE 的使用概况。
+- [DELETE](https://docs.pingcap.com/tidb/stable/sql-statement-delete.md): TiDB 数据库中 DELETE 的使用概况。
+- [在 Kubernetes 上部署 DM](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tidb-dm.md): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/deploy-tidb-dm
+- [DESC](https://docs.pingcap.com/tidb/stable/sql-statement-desc.md): TiDB 数据库中 DESC 的使用概况。
+- [DESCRIBE](https://docs.pingcap.com/tidb/stable/sql-statement-describe.md): TiDB 数据库中 DESCRIBE 的使用概况。
+- [Distinct 优化](https://docs.pingcap.com/tidb/stable/agg-distinct-optimization.md): 本文介绍了对于 DISTINCT 的优化，包括简单 DISTINCT 和聚合函数 DISTINCT 的优化。简单的 DISTINCT 通常会被优化成 GROUP BY 来执行。而带有 DISTINCT 的聚合函数会在 TiDB 侧单线程执行，可以通过系统变量或 TiDB 配置项控制优化器是否执行。在优化后，DISTINCT 被下推到了 Coprocessor，在 HashAgg 里新增了一个 group by 列。
+- [DM 5.4.0 性能测试报告](https://docs.pingcap.com/tidb/stable/dm-benchmark-v5.4.0.md): 了解 DM 5.4.0 版本的性能。
+- [DM Relay Log](https://docs.pingcap.com/tidb/stable/relay-log.md): 了解目录结构、初始迁移规则和 DM relay log 的数据清理。
+- [DM Table Selector](https://docs.pingcap.com/tidb/stable/table-selector.md): 介绍 DM 的 Table Selector
+- [DM 任务完整配置文件介绍](https://docs.pingcap.com/tidb/stable/task-configuration-file-full.md): 本文介绍了 Data Migration (DM) 的任务完整配置文件，包括全局配置和实例配置两部分。全局配置包括任务基本信息配置和功能配置集，功能配置集包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers。实例配置定义了具体的数据迁移子任务，包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers 的配置名称。
+- [DM 告警信息](https://docs.pingcap.com/tidb/stable/dm-alert-rules.md): 介绍 DM 的告警信息。
+- [DM 增量数据校验](https://docs.pingcap.com/tidb/stable/dm-continuous-data-validation.md): 了解增量数据校验的原理，以及如何使用增量数据校验功能。
+- [DM 安全模式](https://docs.pingcap.com/tidb/stable/dm-safe-mode.md): 介绍 DM safe mode 作用和原理
+- [DM 数据迁移最佳实践](https://docs.pingcap.com/tidb/stable/dm-best-practices.md): 了解使用 TiDB Data Migration (DM) 进行数据迁移的一些最佳实践。
+- [DM 监控指标](https://docs.pingcap.com/tidb/stable/monitor-a-dm-cluster.md): 介绍 DM 的监控指标
+- [DM 自定义加解密 key](https://docs.pingcap.com/tidb/stable/dm-customized-secret-key.md): 介绍如何自定义密钥，用于加密和解密 DM（Data Migration）数据源和迁移任务配置中的密码。
+- [DM 配置优化](https://docs.pingcap.com/tidb/stable/dm-tune-configuration.md): 介绍如何通过优化配置来提高数据迁移性能。
+- [DM 配置简介](https://docs.pingcap.com/tidb/stable/dm-config-overview.md): 本文简要介绍了 DM（数据迁移）的配置文件和数据迁移任务的配置。配置文件包括 dm-master.toml、dm-worker.toml 和 source.yaml，分别用于配置 DM-master 进程、DM-worker 进程和上游数据库 MySQL/MariaDB。创建数据迁移任务的具体步骤包括使用 dmctl 加载数据源配置、参考数据任务配置向导创建 your_task.yaml 文件，以及使用 dmctl 创建数据迁移任务。关键概念包括 source-id、DM-master ID 和 DM-worker ID，分别用于唯一确定 MySQL 或 MariaDB 实例、DM-master 和 DM-worker。
+- [DM 集群性能测试](https://docs.pingcap.com/tidb/stable/dm-performance-test.md): 了解如何测试 DM 集群的性能。
+- [DM-master 配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-master-configuration-file.md): 本文介绍了 DM-master 的配置文件，包括示例配置和配置项说明。示例配置包括日志配置、DM-master 监听地址、集群配置等。配置项说明包括全局配置，如标识 DM-master、日志级别、日志文件、地址等。另外还包括 SSL 证书路径、证书检查 Common Name 列表和加解密密钥路径等内容。
+- [DM-worker 简介](https://docs.pingcap.com/tidb/stable/dm-worker-intro.md): DM-worker 是 DM (Data Migration) 的一个组件，负责执行数据迁移任务。主要功能包括注册为 MySQL 或 MariaDB 服务器的 slave，读取 binlog event 并持久化保存在本地，支持迁移一个 MySQL 或 MariaDB 实例的数据到多个 TiDB 实例，以及支持迁移多个 MySQL 或 MariaDB 实例的数据到一个 TiDB 实例。处理单元包括 Relay log、dump、load 和 Binlog replication/sync。上游数据库用户需具有 SELECT、RELOAD、REPLICATION SLAVE 和 REPLICATION CLIENT 权限，下游数据库用户需具有 SELECT、INSERT、UPDATE、DELETE、CREATE、DROP 和 INDEX 权限。处理单元所需的最小权限根据具体情况可能会改变。
+- [DM-worker 配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-worker-configuration-file.md): 本文介绍了 DM-worker 的配置文件，包括配置文件示例和配置项说明。配置文件示例包括了 worker 的名称、日志配置、worker 的地址等内容。配置项说明包括了全局配置中的各个配置项的说明，如 name、log-level、log-file 等。同时还介绍了一些新增的配置项，如 relay-keepalive-ttl 和 relay-dir。SSL 相关的配置项也有详细说明。
+- [DO | TiDB SQL Statement Reference](https://docs.pingcap.com/tidb/stable/sql-statement-do.md): TiDB 数据库中 DO 的使用概况。
+- [DROP [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/tidb/stable/sql-statement-drop-binding.md): TiDB 数据库中 DROP [GLOBAL|SESSION] BINDING 的使用概况。
+- [DROP COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-drop-column.md): TiDB 数据库中 DROP COLUMN 的使用概况。
+- [DROP DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-database.md): TiDB 数据库中 DROP DATABASE 的使用概况。
+- [DROP INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-drop-index.md): TiDB 数据库中 DROP INDEX 的使用概况。
+- [DROP PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-drop-placement-policy.md): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
+- [DROP RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-drop-resource-group.md): TiDB 数据库中 DROP RESOURCE GROUP 的使用概况。
+- [DROP ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-role.md): TiDB 数据库中 DROP ROLE 的使用概况。
+- [DROP SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-sequence.md): TiDB 数据库中 DROP SEQUENCE 的使用概况。
+- [DROP STATS](https://docs.pingcap.com/tidb/stable/sql-statement-drop-stats.md): TiDB 数据库中 DROP STATS 的使用概况。
+- [DROP TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-table.md): TiDB 数据库中 DROP TABLE 的使用概况。
+- [DROP USER](https://docs.pingcap.com/tidb/stable/sql-statement-drop-user.md): TiDB 数据库中 DROP USER 的使用概况。
+- [DROP VIEW](https://docs.pingcap.com/tidb/stable/sql-statement-drop-view.md): TiDB 数据库中 DROP VIEW 的使用概况。
+- [ENGINES](https://docs.pingcap.com/tidb/stable/information-schema-engines.md): 了解 information_schema 表 `ENGINES`。
+- [EXECUTE](https://docs.pingcap.com/tidb/stable/sql-statement-execute.md): TiDB 数据库中 EXECUTE 的使用概况。
+- [EXPLAIN](https://docs.pingcap.com/tidb/stable/sql-statement-explain.md): TiDB 数据库中 EXPLAIN 的使用概况。
+- [EXPLAIN ANALYZE](https://docs.pingcap.com/tidb/stable/sql-statement-explain-analyze.md): TiDB 数据库中 EXPLAIN ANALYZE 的使用概况。
+- [FLASHBACK CLUSTER](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-cluster.md): TiDB 数据库中 FLASHBACK CLUSTER 的使用概况。
+- [FLASHBACK DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-database.md): TiDB 数据库中 FLASHBACK DATABASE 的使用概况。
+- [FLASHBACK TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-table.md): TiDB 4.0 引入了 `FLASHBACK TABLE` 语法，可在 GC 生命周期内恢复被 `DROP` 或 `TRUNCATE` 删除的表和数据。使用系统变量 `tidb_gc_life_time` 配置历史版本保留时间，默认为 `10m0s`。查询当前`safePoint`：`SELECT * FROM mysql.tidb WHERE variable_name = 'tikv_gc_safe_point'`。注意，过了 GC 生命周期就无法恢复被删除的数据。
+- [FLUSH PRIVILEGES](https://docs.pingcap.com/tidb/stable/sql-statement-flush-privileges.md): TiDB 数据库中 FLUSH PRIVILEGES 的使用概况。
+- [FLUSH STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-flush-status.md): TiDB 数据库中 FLUSH STATUS 的使用概况。
+- [FLUSH TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-flush-tables.md): TiDB 数据库中 FLUSH TABLES 的使用概况。
+- [Follower Read](https://docs.pingcap.com/tidb/stable/dev-guide-use-follower-read.md): 使用 Follower Read 在特定情况下加速查询。
+- [Follower Read](https://docs.pingcap.com/tidb/stable/follower-read.md): 了解 Follower Read 的使用与实现。
+- [GBK](https://docs.pingcap.com/tidb/stable/character-set-gbk.md): 本文介绍 TiDB 对 GBK 字符集的支持情况。
+- [GC 机制简介](https://docs.pingcap.com/tidb/stable/garbage-collection-overview.md): TiDB 的事务实现采用了 MVCC 机制，GC 的任务是清理不再需要的旧数据。整体流程包括 GC leader 控制 GC 的运行，定期触发 GC，以及三个步骤：Resolve Locks 清理锁，Delete Ranges 删除区间，Do GC 进行 GC 清理。Resolve Locks 清理锁有两种执行模式：LEGACY 和 PHYSICAL。Delete Ranges 删除区间会快速物理删除待删除的区间及删除操作的时间戳。Do GC 进行 GC 清理会删除所有 key 的过期版本。GC 每 10 分钟触发一次，默认保留最近 10 分钟内的数据。
+- [GC 配置](https://docs.pingcap.com/tidb/stable/garbage-collection-configuration.md): TiDB 的 GC 配置可以通过系统变量进行设置，包括启用 GC、运行间隔、数据保留时限、并发线程数量等。此外，TiDB 还支持 GC 流控，可以限制每秒数据写入量。从 TiDB 5.0 版本开始，建议使用系统变量进行配置，避免异常行为。在 TiDB 6.1.0 版本引入了新的系统变量 `tidb_gc_max_wait_time`，用于控制活跃事务阻塞 GC safe point 推进的最长时间。另外，GC in Compaction Filter 机制可以通过配置文件或在线配置开启，但可能会影响 TiKV 扫描性能。
+- [Gitpod](https://docs.pingcap.com/tidb/stable/dev-guide-playground-gitpod.md): Gitpod 是一个开源 Kubernetes 应用程序，可在浏览器中获得完整的开发环境，并立即编写代码。它能够为云中的每个任务提供全新的自动化开发环境，无需本地配置。Gitpod 提供了完整的、自动化的、预配置的云原生开发环境，让你可以直接在浏览器中开发、运行、测试代码。
+- [GRANT <privileges>](https://docs.pingcap.com/tidb/stable/sql-statement-grant-privileges.md): TiDB 数据库中 GRANT <privileges> 的使用概况。
+- [GRANT <role>](https://docs.pingcap.com/tidb/stable/sql-statement-grant-role.md): TiDB 数据库中 GRANT <role> 的使用概况。
+- [GROUP BY 修饰符](https://docs.pingcap.com/tidb/stable/group-by-modifier.md): 了解如何使用 TiDB GROUP BY 修饰符。
+- [GROUP BY 聚合函数](https://docs.pingcap.com/tidb/stable/aggregate-group-by-functions.md): TiDB支持的聚合函数包括 COUNT、COUNT(DISTINCT)、SUM、AVG、MAX、MIN、GROUP_CONCAT、VARIANCE、VAR_POP、STD、STDDEV、VAR_SAMP、STDDEV_SAMP 和 JSON_OBJECTAGG。除了 GROUP_CONCAT 和 APPROX_PERCENTILE 外，这些聚合函数可以作为窗口函数使用。另外，TiDB 的 GROUP BY 子句支持 WITH ROLLUP 修饰符，还支持 SQL 模式 ONLY_FULL_GROUP_BY。与 MySQL 的区别在于 TiDB 对标准 SQL 有一些扩展，允许在 HAVING 子句中使用别名和非列表达式。
+- [HAProxy 在 TiDB 中的最佳实践](https://docs.pingcap.com/tidb/stable/haproxy-best-practices.md): HAProxy 是 TiDB 中实现负载均衡的最佳实践。它提供 TCP 协议下的负载均衡能力，通过连接 HAProxy 提供的浮动 IP 对数据进行操作，实现 TiDB Server 层的负载均衡。HAProxy 提供高可用性、负载均衡、健康检查、会话保持、SSL 支持和监控统计等核心功能。部署 HAProxy 需要满足一定的硬件和软件要求，配置和启动 HAProxy 后即可实现数据库负载均衡。
+- [HTAP 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-htap.md): 本文介绍如何快速上手体验 TiDB 的 HTAP 功能。
+- [HTAP 查询](https://docs.pingcap.com/tidb/stable/dev-guide-hybrid-oltp-and-olap-queries.md): 介绍 TiDB 中的 HTAP 查询功能。
+- [HTAP 深入探索指南](https://docs.pingcap.com/tidb/stable/explore-htap.md): 本文介绍如何深入探索并使用 TiDB 的 HTAP 功能。
+- [IMPORT INTO](https://docs.pingcap.com/tidb/stable/sql-statement-import-into.md): TiDB 数据库中 IMPORT INTO 的使用概况。
+- [IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性](https://docs.pingcap.com/tidb/stable/tidb-lightning-compatibility-and-scenarios.md): 了解 IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性及使用场景。
+- [IMPORT INTO 和 TiDB Lightning 对比](https://docs.pingcap.com/tidb/stable/import-into-vs-tidb-lightning.md): 了解 `IMPORT INTO` 和 TiDB Lightning 的差异。
+- [Information Schema](https://docs.pingcap.com/tidb/stable/information-schema.md): Information Schema 是一种查看系统元数据的 ANSI 标准方法。TiDB 提供了许多自定义的 `INFORMATION_SCHEMA` 表，包括与 MySQL 兼容的表和 TiDB 中的扩展表。这些表提供了关于字符集、排序规则、列、存储引擎、索引、表大小、慢查询等信息，帮助用户进行系统监控和优化。
+- [INSERT](https://docs.pingcap.com/tidb/stable/sql-statement-insert.md): TiDB 数据库中 INSERT 的使用概况。
+- [INSPECTION_RESULT](https://docs.pingcap.com/tidb/stable/information-schema-inspection-result.md): 了解 TiDB 系统表 `INSPECTION_RESULT`。
+- [INSPECTION_RULES](https://docs.pingcap.com/tidb/stable/information-schema-inspection-rules.md): 了解 information_schema 表 `INSPECTION_RULES`。
+- [INSPECTION_SUMMARY](https://docs.pingcap.com/tidb/stable/information-schema-inspection-summary.md): 了解 TiDB 系统表 `INSPECTION_SUMMARY`。
+- [Join Reorder 算法简介](https://docs.pingcap.com/tidb/stable/join-reorder.md): Join Reorder 算法决定了多表 Join 的顺序，影响执行效率。TiDB 中有贪心算法和动态规划算法两种实现。贪心算法选择行数最小的表与其他表做 Join，直到所有节点完成 Join。动态规划算法枚举所有可能的 Join 顺序，选择最优的。算法受系统变量控制，且存在一些限制，如无法保证一定选到合适的 Join 顺序。
+- [JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分 JSON 函数。
+- [JSON 效用函数](https://docs.pingcap.com/tidb/stable/json-functions-utility.md): 了解 JSON 效用函数。
+- [JSON 数据类型](https://docs.pingcap.com/tidb/stable/data-type-json.md): JSON 类型存储半结构化数据，使用 Binary 格式序列化，加快查询和解析速度。JSON 字段不能创建索引，但可以对 JSON 文档中的子字段创建索引。TiDB 仅支持下推部分 JSON 函数到 TiFlash，不建议使用 BR 恢复包含 JSON 列的数据到 v6.3.0 之前的 TiDB 集群。请勿同步非标准 JSON 类型的数据。MySQL 误标记二进制类型数据为 STRING 类型，TiDB 保持正确的二进制类型。ENUM 或 SET 数据类型转换为 JSON 时，TiDB 会检查格式正确性。TiDB 支持使用 ORDER BY 对 JSON Array 或 JSON Object 进行排序。在 INSERT JSON 列时，TiDB 会将值隐式转换为 JSON。
+- [KEY_COLUMN_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-key-column-usage.md): 了解 information_schema 表 `KEY_COLUMN_USAGE`。
+- [KEYWORDS](https://docs.pingcap.com/tidb/stable/information-schema-keywords.md): 了解 INFORMATION_SCHEMA 表 `KEYWORDS`。
+- [KILL](https://docs.pingcap.com/tidb/stable/sql-statement-kill.md): TiDB 数据库中 KILL 的使用概况。
+- [Load Base Split](https://docs.pingcap.com/tidb/stable/configure-load-base-split.md): 介绍 Load Base Split 功能。
+- [LOAD DATA](https://docs.pingcap.com/tidb/stable/sql-statement-load-data.md): TiDB 数据库中 LOAD DATA 的使用概况。
+- [LOAD STATS](https://docs.pingcap.com/tidb/stable/sql-statement-load-stats.md): TiDB 数据库中 LOAD STATS 的使用概况。
+- [LOCK STATS](https://docs.pingcap.com/tidb/stable/sql-statement-lock-stats.md): TiDB 数据库中 LOCK STATS 的使用概况。
+- [LOCK TABLES 和 UNLOCK TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-lock-tables-and-unlock-tables.md): TiDB 数据库中 LOCK TABLES 和 UNLOCK TABLES 的使用概况。
+- [Max/Min 函数消除规则](https://docs.pingcap.com/tidb/stable/max-min-eliminate.md): SQL 中的 max/min 函数消除规则能够将 max/min 聚合函数转换为 TopN 算子，利用索引进行查询。当只有一个 max/min 函数时，会重写为 select max(a) from (select a from t where a is not null order by a desc limit 1) t，利用索引只扫描一行数据。存在多个 max/min 函数时，会先检查列是否有索引能够保序，然后重写为两个子查询的笛卡尔积，最终避免对整个表的扫描。
+- [MEMORY_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-memory-usage.md): 了解 information_schema 表 `MEMORY_USAGE`。
+- [MEMORY_USAGE_OPS_HISTORY](https://docs.pingcap.com/tidb/stable/information-schema-memory-usage-ops-history.md): 了解 information_schema 表 `MEMORY_USAGE_OPS_HISTORY`。
+- [Metrics Schema](https://docs.pingcap.com/tidb/stable/metrics-schema.md): 了解 TiDB `METRICS SCHEMA` 系统数据库。
+- [METRICS_SUMMARY](https://docs.pingcap.com/tidb/stable/information-schema-metrics-summary.md): 了解 TiDB 系统表 `METRICS_SUMMARY`。
+- [METRICS_TABLES](https://docs.pingcap.com/tidb/stable/information-schema-metrics-tables.md): 了解 TiDB 系统表 `METRICS_TABLES`。
+- [MODIFY COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-modify-column.md): TiDB 数据库中 MODIFY COLUMN 的使用概况。
+- [mysql Schema](https://docs.pingcap.com/tidb/stable/mysql-schema.md): 了解 TiDB 系统表。
+- [mysql.tidb_mdl_view](https://docs.pingcap.com/tidb/stable/mysql-schema-tidb-mdl-view.md): 了解 `mysql` schema 中的 `tidb_mdl_view` 视图。
+- [mysql.user](https://docs.pingcap.com/tidb/stable/mysql-schema-user.md): 了解 `mysql` 系统表 `user`。
+- [OLTP 负载性能优化实践](https://docs.pingcap.com/tidb/stable/performance-tuning-practices.md): 本文档介绍了如何对 OLTP 负载进行性能分析和优化。
+- [Online Unsafe Recovery 使用文档](https://docs.pingcap.com/tidb/stable/online-unsafe-recovery.md): 如何使用 Online Unsafe Recovery。
+- [Optimizer Fix Controls](https://docs.pingcap.com/tidb/stable/optimizer-fix-controls.md): 了解 Optimizer Fix Controls 以及如何使用 `tidb_opt_fix_control` 细粒度地控制 TiDB 优化器的行为。
+- [Optimizer Hints](https://docs.pingcap.com/tidb/stable/optimizer-hints.md): 介绍 TiDB 中 Optimizer Hints 的语法和不同生效范围的 Hint 的使用方法。
+- [Oracle 与 TiDB 函数和语法差异对照](https://docs.pingcap.com/tidb/stable/oracle-functions-to-tidb.md): 了解 Oracle 与 TiDB 函数和语法差异对照。
+- [Overview 面板重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-overview-dashboard.md): TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview。重要监控指标包括服务在线节点数量、PD 角色、存储容量、Region 数量、TiDB 执行数量、CPU 使用率、内存大小、网络流量等。详细监控说明可参见文章。
+- [Partitioned Raft KV](https://docs.pingcap.com/tidb/stable/partitioned-raft-kv.md): 了解 TiKV 的 Partitioned Raft KV 特性。
+- [PARTITIONS](https://docs.pingcap.com/tidb/stable/information-schema-partitions.md): 了解 INFORMATION_SCHEMA 表 `PARTITIONS`。
+- [PD Control 使用说明](https://docs.pingcap.com/tidb/stable/pd-control.md): PD Control 是 PD 的命令行工具，用于获取集群状态信息和调整集群。
+- [PD Recover 使用文档](https://docs.pingcap.com/tidb/stable/pd-recover.md): PD Recover 是用于恢复无法正常启动或服务的 PD 集群的工具。安装方式包括从源代码编译和下载 TiDB 工具包。恢复集群的方式有两种：从存活的 PD 节点重建和完全重建。从存活的 PD 节点重建集群需要停止所有节点，启动存活的 PD 节点，并使用 pd-recover 修复元数据。完全重建 PD 集群需要获取 Cluster ID 和已分配 ID，部署新的 PD 集群，使用 pd-recover 修复，然后重启整个集群。
+- [PD 微服务](https://docs.pingcap.com/tidb/stable/pd-microservices.md): 介绍如何开启 PD 微服务模式，以提高服务质量。
+- [PD 微服务部署拓扑](https://docs.pingcap.com/tidb/stable/pd-microservices-deployment-topology.md): 了解在部署最小拓扑集群的基础上，部署 PD 微服务的拓扑结构。
+- [PD 调度策略最佳实践](https://docs.pingcap.com/tidb/stable/pd-scheduling-best-practices.md): 了解 PD 调度策略的最佳实践和调优方式
+- [PD 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-pd-configuration.md): PD 配置参数可以通过命令行参数或环境变量配置。包括外部访问 PD 的 URL 列表，其他 PD 节点访问某个 PD 节点的 URL 列表，PD 监听的客户端 URL 列表，PD 节点监听其他 PD 节点的 URL 列表，配置文件，PD 存储数据路径，初始化 PD 集群配置，动态加入 PD 集群，Log 级别，Log 文件，是否开启日志切割，当前 PD 的名字，CA 文件路径，包含 X509 证书的 PEM 文件路径，包含 X509 key 的 PEM 文件路径，指定 Prometheus Pushgateway 的地址，强制使用当前节点创建新的集群，输出版本信息并退出。
+- [PD 配置文件描述](https://docs.pingcap.com/tidb/stable/pd-configuration-file.md): PD 配置文件包含了许多参数，如节点名称、数据路径、客户端 URL、广告客户端 URL、节点 URL 等。还包括了一些实验性特性的配置项，如内存限制、GC 触发阈值、GOGC Tuner 等。此外，还有监控、调度、副本、标签、Dashboard、同步模式和资源控制等相关配置项。
+- [PD 重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-pd-dashboard.md): PD 重要监控指标详解：使用 TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构参见 [TiDB 监控框架概述]。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。通过观察 PD 面板上的 Metrics，可以了解 PD 当前的状态。监控包括 PD role、Storage capacity、Current storage size、Current storage usage、Normal stores、Number of Regions、Abnormal stores、Region health、Current peer count 等。Cluster、Operator、Statistics - Balance、Statistics - hot write、Statistics - hot read、Scheduler、gRPC、etcd、TiDB、Heartbeat、Region storage 等指标也很重要。
+- [Performance Overview 面板重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-performance-overview-dashboard.md): 本文介绍 Performance Overview 面板上监控指标的含义。
+- [Performance Schema](https://docs.pingcap.com/tidb/stable/performance-schema.md): 了解 TiDB `performance_schema` 系统数据库。
+- [PingCAP Clinic 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-clinic.md): 了解如何使用 PingCAP Clinic 诊断服务快速采集、上传、查看集群诊断数据。
+- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/tidb/stable/clinic-data-instruction-for-tiup.md): 详细说明 PingCAP Clinic 诊断服务在使用 TiUP 部署的 TiDB 集群和 DM 集群中能够采集哪些诊断数据。
+- [PingCAP Clinic 诊断服务简介](https://docs.pingcap.com/tidb/stable/clinic-introduction.md): 介绍 PingCAP Clinic 诊断服务，包括工具组件、使用场景和工作原理。
+- [Pipelined DML](https://docs.pingcap.com/tidb/stable/pipelined-dml.md): 介绍 Pipelined DML 的使用场景、使用方法、使用限制和使用该功能的常见问题。Pipelined DML 增强了 TiDB 批量处理的能力，使得事务大小不再受到 TiDB 内存限制。
+- [Placement Rules in SQL](https://docs.pingcap.com/tidb/stable/placement-rules-in-sql.md): 了解如何通过 SQL 接口调度表和分区的放置位置。
+- [Placement Rules 使用文档](https://docs.pingcap.com/tidb/stable/configure-placement-rules.md): 如何配置 Placement Rules
+- [PLACEMENT_POLICIES](https://docs.pingcap.com/tidb/stable/information-schema-placement-policies.md): 了解 information_schema 表 `PLACEMENT_POLICIES`。
+- [PREPARE](https://docs.pingcap.com/tidb/stable/sql-statement-prepare.md): TiDB 数据库中 PREPARE 的使用概况。
+- [Prepare 语句执行计划缓存](https://docs.pingcap.com/tidb/stable/sql-prepared-plan-cache.md): Prepare 语句执行计划缓存功能默认打开，可通过变量启用或关闭。缓存功能仅针对 Prepare/Execute 请求，对普通查询无效。缓存功能会有一定内存开销，可通过监控查看内存使用情况。可手动清空计划缓存，但不支持一次性清空整个集群的计划缓存。忽略 COM_STMT_CLOSE 指令和 DEALLOCATE PREPARE 语句，可解决计划被立即清理的问题。监控 Queries Using Plan Cache OPS 和 Plan Cache Miss OPS，以确保 SQL 执行计划缓存正常工作。Prepared Statement Count 图表显示非零值，表示应用使用了预处理语句。
+- [PROCESSLIST](https://docs.pingcap.com/tidb/stable/information-schema-processlist.md): 了解 information_schema 表 `PROCESSLIST`。
+- [ProxySQL 集成指南](https://docs.pingcap.com/tidb/stable/dev-guide-proxysql-integration.md): 了解如何将本地部署的 TiDB 或 TiDB Cloud 集群与 ProxySQL 集成。
+- [QUERY WATCH](https://docs.pingcap.com/tidb/stable/sql-statement-query-watch.md): TiDB 数据库中 QUERY WATCH 的使用概况。
+- [RECOVER TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-recover-table.md): RECOVER TABLE 是用来恢复被删除的表及其数据的功能。在 DROP TABLE 后，在 GC life time 时间内，可以使用 RECOVER TABLE 语句来恢复被删除的表以及其数据。如果删除表后并过了 GC lifetime，就不能再用 RECOVER TABLE 来恢复被删除的表了。
+- [REFERENTIAL_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-referential-constraints.md): 了解 INFORMATION_SCHEMA 表 `REFERENTIAL_CONSTRAINTS`。
+- [Region 性能调优](https://docs.pingcap.com/tidb/stable/tune-region-performance.md): 了解如何通过调整 Region 大小等方法对 Region 进行性能调优以及如何在大 Region 下使用 bucket 进行并发查询优化。
+- [RENAME INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-rename-index.md): TiDB 数据库中 RENAME INDEX 的使用概况。
+- [RENAME TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-rename-table.md): TiDB 数据库中 RENAME TABLE 的使用概况。
+- [RENAME USER](https://docs.pingcap.com/tidb/stable/sql-statement-rename-user.md): TiDB 数据库中 RENAME USER 的使用概况。
+- [REPLACE](https://docs.pingcap.com/tidb/stable/sql-statement-replace.md): TiDB 数据库中 REPLACE 的使用概况。
+- [RESOURCE_GROUPS](https://docs.pingcap.com/tidb/stable/information-schema-resource-groups.md): 了解 information_schema 表 `RESOURCE_GROUPS`。
+- [RESTORE](https://docs.pingcap.com/tidb/stable/sql-statement-restore.md): TiDB 数据库中 RESTORE 的使用概况。
+- [REVOKE <privileges>](https://docs.pingcap.com/tidb/stable/sql-statement-revoke-privileges.md): TiDB 数据库中 REVOKE <privileges> 的使用概况。
+- [REVOKE <role>](https://docs.pingcap.com/tidb/stable/sql-statement-revoke-role.md): TiDB 数据库中 REVOKE <role> 的使用概况。
+- [RocksDB 简介](https://docs.pingcap.com/tidb/stable/rocksdb-overview.md): RocksDB 是 Facebook 基于 LevelDB 开发的 LSM-tree 架构引擎，提供键值存储与读写功能。数据先写入磁盘上的 WAL，再写入内存中的跳表。内存数据达到阈值后刷到磁盘生成 SST 文件，分为多层，90% 数据存储在最后一层。RocksDB 允许创建多个 ColumnFamily，共享同一个 WAL 文件。为提高读取性能，文件按大小切分成 block，存在 BlockCache 中。后台线程执行 MemTable 转化为 SST 文件和合并操作。L0 文件数量过多会触发 WriteStall 阻塞写入。
+- [ROLLBACK](https://docs.pingcap.com/tidb/stable/sql-statement-rollback.md): TiDB 数据库中 ROLLBACK 的使用概况。
+- [RUNAWAY_WATCHES](https://docs.pingcap.com/tidb/stable/information-schema-runaway-watches.md): 了解 INFORMATION_SCHEMA 表 `RUNAWAY_WATCHES`。
+- [Runtime Filter](https://docs.pingcap.com/tidb/stable/runtime-filter.md): 介绍 Runtime Filter 的原理及使用方式。
+- [SaaS 多租户场景最佳实践](https://docs.pingcap.com/tidb/stable/saas-best-practices.md): 介绍 TiDB 在 SaaS (Software as a service) 多租户场景的最佳实践，特别适用于单集群表数量超过百万级别的场景。
+- [SAVEPOINT](https://docs.pingcap.com/tidb/stable/sql-statement-savepoint.md): TiDB 数据库中 SAVEPOINT 的使用概况。
 - [Scale A Tidb Cluster](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/scale-a-tidb-cluster): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/scale-a-tidb-cluster
-- [Scheduling 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-scheduling-configuration/): Scheduling 配置参数可以通过命令行参数或环境变量配置。
-- [Scheduling 配置文件描述](https://docs.pingcap.com/tidb/stable/scheduling-configuration-file/): Scheduling 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
-- [Schema 对象名](https://docs.pingcap.com/tidb/stable/schema-object-names/): 本文介绍 TiDB SQL 语句中的模式对象名。
-- [Schema 缓存](https://docs.pingcap.com/tidb/stable/schema-cache/): TiDB 对于 schema 信息采用基于 LRU 的缓存机制，在大量数据库和表的场景下能够显著减少 schema 信息的内存占用以及提高性能。
-- [schema_unused_indexes](https://docs.pingcap.com/tidb/stable/sys-schema-unused-indexes/): 了解 TiDB `sys` 系统数据库中的 `schema_unused_indexes` 表。
-- [SCHEMATA](https://docs.pingcap.com/tidb/stable/information-schema-schemata/): 了解 information_schema 表 `SCHEMATA`。
-- [SELECT](https://docs.pingcap.com/tidb/stable/sql-statement-select/): TiDB 数据库中 SELECT 的使用概况。
-- [SEQUENCES](https://docs.pingcap.com/tidb/stable/information-schema-sequences/): 了解 INFORMATION_SCHEMA 表 `SEQUENCES`。
-- [SESSION_CONNECT_ATTRS](https://docs.pingcap.com/tidb/stable/performance-schema-session-connect-attrs/): 了解 performance_schema 表 `SESSION_CONNECT_ATTRS`。
-- [SESSION_VARIABLES](https://docs.pingcap.com/tidb/stable/information-schema-session-variables/): 了解 INFORMATION_SCHEMA 表 `SESSION_VARIABLES`。
-- [SET [GLOBAL|SESSION] <variable>](https://docs.pingcap.com/tidb/stable/sql-statement-set-variable/): TiDB 数据库中 SET [GLOBAL|SESSION] <variable> 的使用概况。
-- [SET [NAMES|CHARACTER SET]](https://docs.pingcap.com/tidb/stable/sql-statement-set-names/): TiDB 数据库中 SET [NAMES|CHARACTER SET] 的使用概况。
-- [SET DEFAULT ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-set-default-role/): TiDB 数据库中 SET DEFAULT ROLE 的使用概况。
-- [SET PASSWORD](https://docs.pingcap.com/tidb/stable/sql-statement-set-password/): TiDB 数据库中 SET PASSWORD 的使用概况。
-- [SET RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-set-resource-group/): TiDB 数据库中 SET RESOURCE GROUP 的使用概况。
-- [SET ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-set-role/): TiDB 数据库中 SET ROLE 的使用概况。
-- [SET TRANSACTION](https://docs.pingcap.com/tidb/stable/sql-statement-set-transaction/): TiDB 数据库中 SET TRANSACTION 的使用概况。
-- [SHARD_ROW_ID_BITS](https://docs.pingcap.com/tidb/stable/shard-row-id-bits/): 介绍 TiDB 的 `SHARD_ROW_ID_BITS` 表属性。
-- [SHOW [BACKUPS|RESTORES]](https://docs.pingcap.com/tidb/stable/sql-statement-show-backups/): TiDB 数据库中 SHOW [BACKUPS|RESTORES] 的使用概况。
-- [SHOW [FULL] COLUMNS FROM](https://docs.pingcap.com/tidb/stable/sql-statement-show-columns-from/): TiDB 数据库中 SHOW [FULL] COLUMNS FROM 的使用概况。
-- [SHOW [FULL] FIELDS FROM](https://docs.pingcap.com/tidb/stable/sql-statement-show-fields-from/): TiDB 数据库中 SHOW [FULL] FIELDS FROM 的使用概况。
-- [SHOW [FULL] PROCESSLIST](https://docs.pingcap.com/tidb/stable/sql-statement-show-processlist/): TiDB 数据库中 SHOW [FULL] PROCESSLIST 的使用概况。
-- [SHOW [FULL] TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-show-tables/): TiDB 数据库中 SHOW [FULL] TABLES 的使用概况。
-- [SHOW [GLOBAL|SESSION] BINDINGS](https://docs.pingcap.com/tidb/stable/sql-statement-show-bindings/): TiDB 数据库中 SHOW [GLOBAL|SESSION] BINDINGS 的使用概况。
-- [SHOW [GLOBAL|SESSION] STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-status/): TiDB 数据库中 SHOW [GLOBAL|SESSION] STATUS 的使用概况。
-- [SHOW [GLOBAL|SESSION] VARIABLES](https://docs.pingcap.com/tidb/stable/sql-statement-show-variables/): TiDB 数据库中 SHOW [GLOBAL|SESSION] VARIABLES 的使用概况。
-- [SHOW ANALYZE STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-analyze-status/): TiDB 数据库中 SHOW ANALYZE STATUS 的使用概况。
-- [SHOW BUILTINS](https://docs.pingcap.com/tidb/stable/sql-statement-show-builtins/): TiDB 数据库中 SHOW BUILTINS 的使用概况。
-- [SHOW CHARACTER SET](https://docs.pingcap.com/tidb/stable/sql-statement-show-character-set/): TiDB 数据库中 SHOW CHARACTER SET 的使用概况。
-- [SHOW COLLATION](https://docs.pingcap.com/tidb/stable/sql-statement-show-collation/): TiDB 数据库中 SHOW COLLATION 的使用概况。
-- [SHOW COLUMN_STATS_USAGE](https://docs.pingcap.com/tidb/stable/sql-statement-show-column-stats-usage/): TiDB 数据库中 SHOW COLUMN_STATS_USAGE 的使用概况。
-- [SHOW CONFIG](https://docs.pingcap.com/tidb/stable/sql-statement-show-config/): TiDB 数据库中 SHOW CONFIG 的使用概况。
-- [SHOW CREATE DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-database/): TiDB 数据库中 SHOW CREATE DATABASE 的使用概况。
-- [SHOW CREATE PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-placement-policy/): TiDB 数据库中 SHOW CREATE PLACEMENT POLICY 的使用概况。
-- [SHOW CREATE RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-resource-group/): TiDB 数据库中 SHOW CREATE RESOURCE GROUP 的使用概况。
-- [SHOW CREATE SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-sequence/): TiDB 数据库中 SHOW CREATE SEQUENCE 的使用概况。
-- [SHOW CREATE TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-table/): TiDB 数据库中 SHOW CREATE TABLE 的使用概况。
-- [SHOW CREATE USER](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-user/): TiDB 数据库中 SHOW CREATE USER 的使用概况。
-- [SHOW DATABASES](https://docs.pingcap.com/tidb/stable/sql-statement-show-databases/): TiDB 数据库中 SHOW DATABASES 的使用概况。
-- [SHOW ENGINES](https://docs.pingcap.com/tidb/stable/sql-statement-show-engines/): TiDB 数据库中 SHOW ENGINES 的使用概况。
-- [SHOW ERRORS](https://docs.pingcap.com/tidb/stable/sql-statement-show-errors/): TiDB 数据库中 SHOW ERRORS 的使用概况。
-- [SHOW GRANTS](https://docs.pingcap.com/tidb/stable/sql-statement-show-grants/): TiDB 数据库中 SHOW GRANTS 的使用概况。
-- [SHOW IMPORT](https://docs.pingcap.com/tidb/stable/sql-statement-show-import-job/): TiDB 数据库中 SHOW IMPORT 的使用概况。
-- [SHOW INDEXES [FROM|IN]](https://docs.pingcap.com/tidb/stable/sql-statement-show-indexes/): TiDB 数据库中 SHOW INDEXES [FROM|IN] 的使用概况。
-- [SHOW MASTER STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-master-status/): TiDB 数据库中 SHOW MASTER STATUS 的使用概况。
-- [SHOW PLACEMENT](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement/): TiDB 数据库中 SHOW PLACEMENT 的使用概况。
-- [SHOW PLACEMENT FOR](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-for/): TiDB 数据库中 SHOW PLACEMENT FOR 的使用概况。
-- [SHOW PLACEMENT LABELS](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-labels/): TiDB 数据库中 SHOW PLACEMENT LABELS 的使用概况。
-- [SHOW PLUGINS](https://docs.pingcap.com/tidb/stable/sql-statement-show-plugins/): TiDB 数据库中 SHOW PLUGINS 的使用概况。
-- [SHOW PRIVILEGES](https://docs.pingcap.com/tidb/stable/sql-statement-show-privileges/): TiDB 数据库中 SHOW PRIVILEGES 的使用概况。
-- [SHOW PROFILES](https://docs.pingcap.com/tidb/stable/sql-statement-show-profiles/): TiDB 数据库中 SHOW PROFILES 的使用概况。
-- [SHOW SCHEMAS](https://docs.pingcap.com/tidb/stable/sql-statement-show-schemas/): TiDB 数据库中 SHOW SCHEMAS 的使用概况。
-- [SHOW STATS_BUCKETS](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-buckets/): TiDB 数据库中 SHOW STATS_BUCKETS 的使用概况。
-- [SHOW STATS_HEALTHY](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-healthy/): TiDB 数据库中 SHOW STATS_HEALTHY 的使用概况。
-- [SHOW STATS_HISTOGRAMS](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-histograms/): TiDB 数据库中 SHOW STATS_HISTOGRAMS 语句的简单说明。
-- [SHOW STATS_LOCKED](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-locked/): TiDB 数据库中 SHOW STATS_LOCKED 的使用概况。
-- [SHOW STATS_META](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-meta/): TiDB 数据库中 SHOW STATS_META 语句的简单说明。
-- [SHOW STATS_TOPN](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-topn/): TiDB 数据库中 SHOW STATS_TOPN 的使用概况。
-- [SHOW TABLE NEXT_ROW_ID](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-next-rowid/): TiDB 数据库中 SHOW TABLE NEXT_ROW_ID 的使用概况。
-- [SHOW TABLE REGIONS](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-regions/): 了解如何使用 TiDB 数据库中的 SHOW TABLE REGIONS。
-- [SHOW TABLE STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-status/): TiDB 数据库中 SHOW TABLE STATUS 的使用概况。
-- [SHOW WARNINGS](https://docs.pingcap.com/tidb/stable/sql-statement-show-warnings/): TiDB 数据库中 SHOW WARNINGS 的使用概况。
-- [SHUTDOWN](https://docs.pingcap.com/tidb/stable/sql-statement-shutdown/): TiDB 数据库中 SHUTDOWN 的使用概况。
-- [SLOW_QUERY](https://docs.pingcap.com/tidb/stable/information-schema-slow-query/): 了解 INFORMATION_SCHEMA 表 `SLOW_QUERY`。
-- [Split Region 使用文档](https://docs.pingcap.com/tidb/stable/sql-statement-split-region/): TiDB 中的 Split Region 功能可以解决表数据超过默认 Region 大小限制后的热点问题。预切分 Region 可以根据指定的参数，预先为某个表切分出多个 Region，并打散到各个 TiKV 上去。使用 `SPLIT` 语句可以实现均匀切分和不均匀切分，返回结果包括新增预切分的 Region 数量和打散完成的比率。需要注意 `tidb_wait_split_region_finish` 和 `tidb_wait_split_region_timeout` 会影响 `SPLIT` 语句的行为。
-- [SQL 优化流程简介](https://docs.pingcap.com/tidb/stable/sql-optimization-concepts/): TiDB 中的 SQL 优化流程包括查询文本解析、逻辑等价变化和最终执行计划生成。经过 parser 解析和合法性验证后，TiDB 会对查询进行逻辑上的等价变化，使得查询在逻辑执行计划上更易处理。之后根据数据分布和执行开销生成最终执行计划。同时，TiDB 在执行 PREPARE 语句时可以选择开启缓存来降低执行计划生成的开销。
-- [SQL 基本操作](https://docs.pingcap.com/tidb/stable/basic-sql-operations/): TiDB 是一个兼容 MySQL 的数据库，可以执行 DDL、DML、DQL 和 DCL 操作。可以使用 SHOW DATABASES 查看数据库列表，使用 CREATE DATABASE 创建数据库，使用 DROP DATABASE 删除数据库。使用 CREATE TABLE 创建表，使用 SHOW CREATE TABLE 查看建表语句，使用 DROP TABLE 删除表。使用 CREATE INDEX 创建索引，使用 SHOW INDEX 查看表内所有索引，使用 DROP INDEX 删除索引。使用 INSERT 向表内插入记录，使用 UPDATE 修改记录，使用 DELETE 删除记录。使用 SELECT 检索表内数据，使用 WHERE 子句进行筛选。使用 CREATE USER 创建用户，使用 GRANT 授权用户，使用 DROP USER 删除用户。
-- [SQL 开发规范](https://docs.pingcap.com/tidb/stable/dev-guide-sql-development-specification/): TiDB 的 SQL 开发规范。
-- [SQL 性能调优](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql/): 介绍 TiDB 的 SQL 性能调优方案和分析办法。
-- [SQL 性能调优](https://docs.pingcap.com/tidb/stable/sql-tuning-overview/): SQL 性能调优是重要的，TiDB 会优化 SQL 语句的执行，以最省时的方式返回结果。这个过程类似于 GPS 导航，利用统计信息和实时交通信息规划最佳路线。了解 TiDB 执行计划、SQL 优化流程和控制执行计划可以帮助提高查询性能。
-- [SQL 或事务问题](https://docs.pingcap.com/tidb/stable/dev-guide-troubleshoot-overview/): 学习诊断在应用开发过程中可能产生的 SQL 或事务问题的方法。
-- [SQL 操作常见问题](https://docs.pingcap.com/tidb/stable/sql-faq/): 介绍 SQL 操作相关的常见问题。
-- [SQL 模式](https://docs.pingcap.com/tidb/stable/sql-mode/): TiDB 服务器采用不同 SQL 模式来操作，可以使用 `SET [SESSION | GLOBAL] sql_mode='modes'` 语句设置 SQL 模式。`GLOBAL` 级别的 SQL 模式需要 `SUPER` 权限，影响新连接；`SESSION` 级别的 SQL 模式只影响当前客户端。重要的 sql_mode 值包括 `ANSI`、`STRICT_TRANS_TABLES` 和 `TRADITIONAL`。SQL mode 列表包括 `PIPES_AS_CONCAT`、`ANSI_QUOTES`、`IGNORE_SPACE`、`ONLY_FULL_GROUP_BY` 等。
-- [SQL 诊断](https://docs.pingcap.com/tidb/stable/information-schema-sql-diagnostics/): 了解 SQL 诊断功能。
-- [SQL 语句概述](https://docs.pingcap.com/tidb/stable/sql-statement-overview/): 介绍 TiDB 支持的 SQL 语句。
-- [Stale Read](https://docs.pingcap.com/tidb/stable/dev-guide-use-stale-read/): 使用 Stale Read 在特定情况下加速查询。
-- [Stale Read 功能的使用场景](https://docs.pingcap.com/tidb/stable/stale-read/): 介绍 Stale Read 功能和使用场景。
-- [START TRANSACTION](https://docs.pingcap.com/tidb/stable/sql-statement-start-transaction/): TiDB 数据库中 START TRANSACTION 的使用概况。
-- [Statement Summary Tables](https://docs.pingcap.com/tidb/stable/statement-summary-tables/): MySQL 的 `performance_schema` 提供了 `statement summary tables`，用于监控和统计 SQL 性能。TiDB 在 `information_schema` 中提供了类似功能的系统表，包括 `statements_summary`、`statements_summary_history`、`cluster_statements_summary` 和 `cluster_statements_summary_history`。这些表用于保存 SQL 监控指标聚合后的结果，帮助用户定位 SQL 问题。同时，还提供了参数配置来控制 statement summary 的功能，如清空周期、保存历史的数量等。
-- [STATISTICS](https://docs.pingcap.com/tidb/stable/information-schema-statistics/): 了解 information_schema 表 `STATISTICS`。
-- [Storage sink 消费程序开发指引](https://docs.pingcap.com/tidb/stable/ticdc-storage-consumer-dev-guide/): 了解如何设计与实现一个消费程序来消费 storage sink 中的变更数据。
-- [Store Limit](https://docs.pingcap.com/tidb/stable/configure-store-limit/): 介绍 Store Limit 功能。
-- [sync-diff-inspector 用户文档](https://docs.pingcap.com/tidb/stable/sync-diff-inspector-overview/): sync-diff-inspector 是一个用于校验 MySQL/TiDB 中数据一致性的工具，提供修复数据的功能。它支持对比表结构和数据，生成用于修复数据的 SQL 语句。需要注意的是，在校验数据时会消耗一定的服务器资源，需要避免在业务高峰期间校验。生成的 SQL 文件仅作为修复数据的参考，需要确认后再执行这些 SQL 修复数据。
-- [sys Schema](https://docs.pingcap.com/tidb/stable/sys-schema/): 了解 TiDB `sys` 系统数据库。
-- [TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-table/): TiDB 数据库中 TABLE 语句的使用概况。
-- [TABLE_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-table-constraints/): 了解 information_schema 表 `TABLE_CONSTRAINTS`。
-- [TABLE_STORAGE_STATS](https://docs.pingcap.com/tidb/stable/information-schema-table-storage-stats/): 了解 INFORMATION_SCHEMA 表 `TABLE_STORAGE_STATS`。
-- [TABLES](https://docs.pingcap.com/tidb/stable/information-schema-tables/): 了解 information_schema 表 `TABLES`。
-- [TiCDC Avro Protocol](https://docs.pingcap.com/tidb/stable/ticdc-avro-protocol/): 了解 TiCDC Avro Protocol 的概念和使用方法。
-- [TiCDC Canal-JSON Protocol](https://docs.pingcap.com/tidb/stable/ticdc-canal-json/): 了解 TiCDC Canal-JSON Protocol 的概念和使用方法。
-- [TiCDC Changefeed 命令行参数和配置参数](https://docs.pingcap.com/tidb/stable/ticdc-changefeed-config/): 了解 TiCDC Changefeed 详细的命令行参数和配置文件定义。
-- [TiCDC CSV Protocol](https://docs.pingcap.com/tidb/stable/ticdc-csv/): 了解 TiCDC CSV Protocol 的概念和使用方法。
-- [TiCDC Debezium Protocol](https://docs.pingcap.com/tidb/stable/ticdc-debezium/): 了解 TiCDC Debezium Protocol 的概念和使用方法。
-- [TiCDC Open Protocol](https://docs.pingcap.com/tidb/stable/ticdc-open-protocol/): 了解 TiCDC Open Protocol 的概念和使用方法。
-- [TiCDC OpenAPI v1](https://docs.pingcap.com/tidb/stable/ticdc-open-api/): 了解如何使用 OpenAPI 接口来管理集群状态和数据同步。
-- [TiCDC OpenAPI v2](https://docs.pingcap.com/tidb/stable/ticdc-open-api-v2/): 了解如何使用 OpenAPI v2 接口来管理集群状态和数据同步。
-- [TiCDC Server 配置](https://docs.pingcap.com/tidb/stable/ticdc-server-config/): 了解 TiCDC 详细的命令行参数和配置文件定义。
-- [TiCDC Simple Protocol](https://docs.pingcap.com/tidb/stable/ticdc-simple-protocol/): 本文介绍了 TiCDC Simple Protocol 的使用方法和数据格式实现。
-- [TiCDC 兼容性](https://docs.pingcap.com/tidb/stable/ticdc-compatibility/): 了解 TiCDC 兼容性相关限制和问题处理。
-- [TiCDC 单行数据正确性校验](https://docs.pingcap.com/tidb/stable/ticdc-integrity-check/): 介绍 TiCDC 数据正确性校验功能的实现原理和使用方法。
-- [TiCDC 双向复制](https://docs.pingcap.com/tidb/stable/ticdc-bidirectional-replication/): 了解 TiCDC 双向复制的使用方法。
-- [TiCDC 基本监控指标](https://docs.pingcap.com/tidb/stable/ticdc-summary-monitor/): 了解 TiCDC 基本的监控指标。
-- [TiCDC 安装部署与集群运维](https://docs.pingcap.com/tidb/stable/deploy-ticdc/): 了解 TiCDC 软硬件环境要求以及如何安装部署和运维 TiCDC 集群。
-- [TiCDC 客户端鉴权](https://docs.pingcap.com/tidb/stable/ticdc-client-authentication/): 介绍使用 TiCDC 命令行工具或通过 OpenAPI 访问 TiCDC 时，如何进行客户端鉴权。
-- [TiCDC 常见问题解答](https://docs.pingcap.com/tidb/stable/ticdc-faq/): 了解 TiCDC 相关的常见问题。
-- [TiCDC 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/ticdc-performance-tuning-methods/): 本文介绍了 Performance Overview 面板中的 TiCDC 部分，帮助你了解和监控 TiCDC 工作负载。
-- [TiCDC 拆分 UPDATE 事件行为说明](https://docs.pingcap.com/tidb/stable/ticdc-split-update-behavior/): 介绍 TiCDC changefeed 拆分 UPDATE 事件的行为变更，说明变更原因以及影响范围。
-- [TiCDC 故障处理](https://docs.pingcap.com/tidb/stable/troubleshoot-ticdc/): 了解如何解决使用 TiCDC 时经常遇到的问题。
-- [TiCDC 术语表](https://docs.pingcap.com/tidb/stable/ticdc-glossary/): 了解 TiCDC 相关的术语及定义。
-- [TiCDC 架构设计与原理](https://docs.pingcap.com/tidb/stable/ticdc-architecture/): 了解 TiCDC 软件的架构设计和运行原理。
-- [TiCDC 简介](https://docs.pingcap.com/tidb/stable/ticdc-overview/): TiCDC 是一款 TiDB 增量数据同步工具，适用于多 TiDB 集群的高可用和容灾方案，以及实时同步变更数据到异构系统。其主要特性包括数据容灾复制、双向复制、低延迟的增量数据同步能力等。TiCDC 架构包括 TiKV Server、TiCDC 和 PD，支持将数据同步到 TiDB、MySQL 数据库、Kafka 以及存储服务。目前暂不支持单独使用 RawKV 的 TiKV 集群，创建 SEQUENCE 的 DDL 操作和在同步过程中对 TiCDC 正在同步的表和库进行 BR 数据恢复和 TiDB Lightning 导入。
-- [TiCDC 详细监控指标](https://docs.pingcap.com/tidb/stable/monitor-ticdc/): 了解 TiCDC 详细的监控指标。
-- [TiCDC 部署拓扑](https://docs.pingcap.com/tidb/stable/ticdc-deployment-topology/): 介绍 TiCDC 部署 TiDB 集群的拓扑结构。
-- [TiCDC 集群监控报警规则](https://docs.pingcap.com/tidb/stable/ticdc-alert-rules/): 了解 TiCDC 集群监控报警规则以及处理方法。
-- [TiDB 1.0 release notes](https://docs.pingcap.com/tidb/stable/release-1.0-ga/): TiDB 1.0 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 优化了 SQL 查询优化器、内部数据格式、MySQL 兼容性，并支持 `NO_SQL_CACHE` 语法。PD 支持基于读流量的热点调度和设置 Store 权重。TiKV 支持更多下推函数和手动触发数据 Compact。TiSpark Beta 版本支持可配置框架和 ThriftSever/JDBC 和 Spark SQL 脚本入口。感谢参与项目的企业和团队，以及提供出色开源软件/服务的组织/个人。
-- [TiDB 1.1 Alpha Release Notes](https://docs.pingcap.com/tidb/stable/release-1.1-alpha/): TiDB 1.1 Alpha 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。包括 SQL parser 兼容更多语法，SQL 查询优化器优化统计信息、代价估算，使用 `Count-Min Sketch` 更精确地估算点查的代价，SQL 执行器重构执行器算子，优化 `INSERT IGNORE` 语句性能，下推更多类型和函数，支持更多 `SQL_MODE`，优化 `Load Data` 性能，支持对物理算子内存使用进行统计。PD 增加更多 API，支持 TLS，调度适应不同的 Region size，修复调度 bug。TiKV 支持 Raft learner，优化 Raft Snapshot，支持 TLS，优化 RocksDB 配置，优化 Coprocessor 性能，增加 Failpoint 和稳定性测试 case，解决 PD 和 TiKV 重连问题，增强数据恢复工具功能，Region 支持按 table 分裂，支持 `Delete Range` 功能，支持设置 snapshot 导致的 I/O 上限，完善流控机制。
-- [TiDB 1.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-1.1-beta/): TiDB 1.1 Beta 版本在 MySQL 兼容性和系统稳定性方面有多项改进。TiDB 新增监控项和优化日志，兼容更多 MySQL 语法，支持显示建表时间，加快查询速度，控制 Join 产生的中间结果集大小，修复多项问题，优化 SQL 引擎查询性能。PD 新增调试接口和 metrics，提高 TiKV 宕机时数据恢复优先级和恢复速度，优化 Region heartbeat 性能，修复热点调度问题。TiKV 消除潜在的 GC 问题，支持批量 resolve lock 和并行 GC，使用 RocksDB compaction listener 更新 Region Size，设置 Raft snapshot max size，支持更多修复操作，优化有序流式聚合操作，完善 metrics，修复 bug。
-- [TiDB 2.0 RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.1/): TiDB 2.0 RC1 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持限制单条 SQL 语句内存使用，下推流式聚合算子到 TiKV，配置文件合法性检测，HTTP API 获取参数信息。Parser 兼容更多 MySQL 语法，提升对 Navicat 的兼容性。优化器提升，提取多个 OR 条件的公共表达式，选取更优执行计划。PD 优化检查 Region 状态的代码逻辑，异常情况下日志信息输出，修复监控中 TiKV 节点磁盘空间不足统计。TiKV 修复 PD leader 切换 gRPC call 问题，增加获取 metrics 的 gRPC API，启动时检查是否使用 SSD，使用 ReadPool 优化读性能。
-- [TiDB 2.0 RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.3/): TiDB 2.0 RC3 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 修复了 MAX/MIN 结果错误、Sort Merge Join 排序问题、uint 和 int 比较错误等。PD 支持 Region Merge 和忽略有大量 pending peer 的节点。TiKV 支持 Region Merge、Raft snapshot 通知 PD 加速调度、增加 Raw DeleteRange API 等。
-- [TiDB 2.0 RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.4/): TiDB 2.0 RC4 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持了一些新的语法和修复了一些问题。PD 支持手动 split Region 和优化了 metrics 及代码结构。TiKV 限制了接收 snapshot 时的内存使用，支持导数据模式和改善了在被隔离的情况下的输出问题。
-- [TiDB 2.0 RC5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.5/): TiDB 2.0 RC5 版本发布，对 MySQL 兼容性、系统稳定性和优化器做了很多改进。TiDB 修复了多个问题，并优化了性能。PD 添加了 Raft Learner 支持，优化了 Balance Region Scheduler，并修复了多个问题。TiKV 支持了更多功能，并解决了多个问题。
-- [TiDB 2.0 release notes](https://docs.pingcap.com/tidb/stable/release-2.0-ga/): TiDB 2.0 GA 版本发布，对 MySQL 兼容性、系统稳定性、优化器和执行器做了很多改进。包括 SQL 优化器、SQL 执行引擎、Server、兼容性、DDL、PD、TiKV 和 TiSpark 的功能、性能和稳定性优化。
-- [TiDB 2.0.1 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.1/): TiDB 2.0.1 版本对 MySQL 兼容性和系统稳定性做出了改进。TiDB 新增了实时更新 `Add Index` 进度到 DDL 任务信息中的功能，添加了 Session 变量 `tidb_auto_analyze_ratio` 控制统计信息自动更新阈值的功能。修复了事务提交失败时可能未清理所有残留状态的问题，以及其他 Bug 和兼容性问题。PD 新增了 `Scatter Range` 调度和 learner 相关的 metrics，修复了多个问题。TiKV 修复了多个问题，优化了慢查询的日志，减少了 `thread_yield` 的调用次数。
-- [TiDB 2.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.10/): TiDB 2.0.10 版本发布，修复了系统兼容性和稳定性问题。包括取消 DDL 任务可能导致的问题，ORDER BY 和 UNION 语句无法引用带表名的列的问题，UNCOMPRESS 函数错误输入长度的问题等。PD 修复了 RaftCluster 退出时可能的死锁问题，TiKV 修复了迁移 Leader 到新节点时造成请求延时问题和多余的 Region 心跳问题。
-- [TiDB 2.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.11/): TiDB 2.0.11 版本发布，对系统兼容性和稳定性做出改进。修复了多个问题，包括 PD 异常处理问题、Rename 行为问题、ADMIN CHECK TABLE 误报问题、前缀索引错误问题和添加列导致 UPDATE 语句 panic 问题。TiKV 修复了两个 Region merge 相关问题。
-- [TiDB 2.0.2 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.2/): TiDB 2.0.2 版本发布，改进了系统稳定性。TiDB 修复了 Decimal 除法内置函数下推的问题，支持 `Delete` 语句中使用 `USE INDEX` 的语法，禁止在带有 `Auto-Increment` 的列中使用 `shard_row_id_bits` 特性，并增加了写入 Binlog 的超时机制。PD 使 balance leader scheduler 过滤失连节点，更改 transfer leader operator 的超时时间为 10 秒，修复 label scheduler 在集群 Regions 不健康状态下不调度的问题，修复 evict leader scheduler 调度不当的问题。TiKV 修复了 Raft 日志没有打出来的问题，支持配置更多 gRPC 相关参数，支持配置选举超时的取值范围，修复过期 learner 没有删掉的问题，修复 snapshot 中间文件被误删的问题。
-- [TiDB 2.0.3 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.3/): TiDB 2.0.3 版本在 2.0.2 版的基础上做出了改进，包括系统兼容性和稳定性的改进。TiDB 支持在线更改日志级别和 `COM_CHANGE_USER` 命令，优化查询条件代价估算和修复多个问题。PD 修复了特定条件下的问题，TiKV 修复了错误上报和除数为 0 的问题。
-- [TiDB 2.0.4 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.4/): TiDB 2.0.4 版本发布，改进了系统兼容性和稳定性。TiDB 支持了新的语法和变量设置，优化了监控项和查询代价估计精度。PD 改进了调度参数行为，TiKV 新增了调试接口和命令，优化了问题和修复了崩溃。
-- [TiDB 2.0.5 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.5/): TiDB 2.0.5 版本发布，改进了系统兼容性和稳定性。新增系统变量 `tidb_disable_txn_auto_retry`，调整计算 `Selection` 代价的方式，优化查询条件匹配唯一索引或主键，修复多个 bug。PD 修复副本迁移导致 TiKV 磁盘空间耗尽和 `AdjacentRegionScheduler` 导致的崩溃问题。TiKV 修复 decimal 运算中的溢出和 merge 过程中的脏读问题。
-- [TiDB 2.0.6 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.6/): TiDB 2.0.6 版本在系统兼容性和稳定性方面有所改进。包括日志长度精简、记录 ADD INDEX 执行过程中的慢操作、减少更新统计信息操作中的事务冲突等。此外，修复了多个 bug，包括 DROP USER 语句和 MySQL 行为不兼容、tidb_batch_insert 打开后 INSERT/LOAD DATA 语句在某些场景下 OOM 的问题等。TiKV 方面扩大了默认 scheduler slots 值以减少假冲突现象，修复了字符串转 Decimal 时出现的 crash。
-- [TiDB 2.0.7 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.7/): TiDB 2.0.7 版本在系统兼容性和稳定性方面有改进。TiDB 新增了在 `information_schema` 中添加 `PROCESSLIST` 表的功能。还对语句执行细节进行了改进，并在 `SLOW QUERY` 日志中输出更多信息。修复了多个 bug，包括 `PRIMARY KEY` 为整数的表无法使用 `USE INDEX(PRIMARY)` 的问题，以及 `Merge Join` 和 `Index Join` 在 inner row 为 `NULL` 时输出多余结果的问题。TiKV 方面，空集群默认打开 `dynamic-level-bytes` 参数减少空间放大，并在 Region merge 之后更新 Region 的 `approximate size` 和 keys。
-- [TiDB 2.0.8 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.8/): TiDB 2.0.8 版本在 2.0.7 版的基础上做出了改进，包括功能改进和 Bug 修复。TiKV 也修复了节点宕机时内存持续上升的问题。
-- [TiDB 2.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.9/): TiDB 2.0.9 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括统计信息、DDL JOB、Commit 操作、Limit 值、字符集支持、内建函数、主键选择率估算、Session 变量、Union 语句、统计信息清除、事务运行时间、表创建语句、取消 DDL 任务、全局环境变量等。PD 修复了 etcd 启动失败和 pd-ctl 读取 Region key 的问题。TiKV 增加了 kv_scan 接口扫描上界的限制，废弃了 max-tasks-xxx 配置，并修复了 RocksDB CompactFiles 的问题。
-- [TiDB 2.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-beta/): TiDB 2.1 Beta 版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。SQL 优化器优化了 Index Join 选择范围和关联子查询，下推 Filter 和扩大索引选择范围。SQL 执行引擎实现了并行 Hash Aggregate 和 Project 算子，提高了执行性能。Server 添加了 HTTP API 控制功能和支持 Server side cursor。兼容性方面支持更多 MySQL 语法和 SHOW PRIVILEGES 语句。PD 优化了 Balance Scheduler 和热点调度器，TiKV 升级了 Rust 版本和优化了性能。
-- [TiDB 2.1 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-ga/): TiDB 2.1 GA 版本发布，对系统稳定性、性能、兼容性、易用性做了大量改进。包括 SQL 优化器、SQL 执行引擎、统计信息、表达式、Server、DDL、兼容性等方面的优化。PD (Placement Driver) 进行了可用性优化、调度器优化、API 及运维工具优化、监控和性能优化。TiKV 进行了 Coprocessor、Transaction、Raftstore、存储引擎和 tikv-ctl 方面的优化。同时支持全量数据快速导入工具 TiDB Lightning。升级兼容性说明包括存储引擎更新不支持回退至 2.0.x 或更旧版本，以及升级前需要确认集群中是否存在正在运行中的 DDL 操作。
-- [TiDB 2.1 RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.1/): TiDB 2.1 RC1 版本于 2018 年 8 月 24 日发布。该版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、DML、DDL 等方面的改进。PD 方面新增了版本控制机制，支持集群滚动兼容升级等功能。TiKV 方面新增了支持 batch split 等新特性，以及对性能和功能进行了优化和改进。
-- [TiDB 2.1 RC2 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.2/): TiDB 2.1 RC2 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。具体包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、表达式、DML、DDL、TiKV 和 PD 的新特性、功能改进和 Bug 修复。
-- [TiDB 2.1 RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.3/): TiDB 2.1 RC3 版本对系统稳定性、兼容性、优化器和执行引擎做了很多改进。包括修复了多个 SQL 优化器和执行引擎的问题，增强了部分执行器的性能，修复了配置文件内存配额选项不生效的问题，支持使用 `admin show slow` 语句来获取 SLOW QUERY LOG，修复了一些兼容性问题，增加了一些内建函数的支持，修复了一些 DML 和 DDL 的问题。PD 新增了获取按大小逆序排序的 Region 列表 API，Region API 返回更详细的信息，修复了 PD 切换 leader 后可能导致 crash 的问题。TiKV 进行了性能优化，并新增了一些函数的支持，同时修复了一些 Bug。
-- [TiDB 2.1 RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.4/): TiDB 2.1 RC4 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个 SQL 优化器和执行引擎的问题，重构了 Latch，提升了并发事务的执行性能。PD 修复了多个 TiKV 下线后的问题。TiKV 优化了 apply snapshot 导致的 RocksDB Write stall 的问题，并增加了 raftstore tick 相关 metrics。
-- [TiDB 2.1 RC5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.5/): TiDB 2.1 RC5 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括修复了多个问题，提升了性能，增加了环境变量设置功能。PD 修复了多个问题，TiKV 优化了报错信息和接口限制。
-- [TiDB 2.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.1/): TiDB 2.1.1 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括时间四舍五入错误、uncompress 函数未检查数据长度、PD 故障获取错误 TSO、不规范语句导致启动失败等。DDL 改变了表的默认字符集和排序规则，增加了控制添加索引速度的变量。PD 修复了配置项无法设置为 0 的问题，避免了 transfer leader 至新创建的 Peer 产生的延迟增加问题。TiKV 也避免了相同的问题。 Lightning 优化了对导入表的 analyze 机制，提升了导入速度。 TiDB Binlog 修复了 pb files 输出 bug。
-- [TiDB 2.1.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.10/): TiDB 2.1.10 发布，修复了多个 bug 和兼容性问题，增强了安全性。PD 修复了 Leader 优先级不生效的问题。TiKV 修复了多个问题，包括 transfer leader 中可能发生的脏读问题。TiDB Lightning 新增了发送数据到 importer 失败时进行重试的功能。TiDB Binlog 优化了 Pump storage 组件 log。TiDB Ansible 更新了配置文件，新增了 tidb_lightning_ctl 脚本。
-- [TiDB 2.1.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.11/): TiDB 2.1.11 发布，修复多表 join 删除错误 schema 问题，更新统计信息合并反馈信息，修复函数返回错误字段类型问题，修复时间计算错误问题，修复与 MySQL 8.0 不兼容问题，支持 SHOW OPEN TABLES 语句，修复 goroutine 泄露问题，修复设置 tidb_snapshot 变量时间格式解析出错问题。PD 修复热点 Region 调度问题，新增热点调度优先级配置项。TiKV 修复 leader, learner 读到空 index 问题，处理锁命令放在高优先级线程池中。TiDB Binlog 新增 GC 删数据限速功能。TiDB Ansible 新增 Drainer 参数。
-- [TiDB 2.1.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.12/): TiDB 2.1.12 发布，修复了多个 bug，包括类型不匹配导致进程 panic、字符集改变导致类型变化、事务中的 GRANT 误报错误等问题。同时提升了与 MySQL 的兼容性，修复了 TiDB 跟 TiKV 在 gRPC 最大封包设置不一致导致的超大封包报错问题。PD 修复了极端情况下 etcd Leader 选举阻塞的问题，TiKV 修复了 Leader 迁移过程中 Region 不可用的问题和异常掉电导致丢数据的问题。
-- [TiDB 2.1.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.13/): TiDB 2.1.13 发布，新增了列属性包含 `AUTO_INCREMENT` 时利用 `SHARD_ROW_ID_BITS` 打散行 ID 功能，优化无效 DDL 元信息存活时间，修复了在大并发场景下 OOM 的问题，新增了 `update-stats` 配置项，新增了 3 个 TiDB 特有语法，修复了某些情况下 `KILL` 语句导致的 panic 问题，增强了 `ADD_DATE` 在某些情况下跟 MySQL 的兼容性，修复了 index join 中内表过滤条件在某些情况下的选择率估计错误的问题。TiKV 修复了因迭代器未检查状态导致系统生成残缺 snapshot 的问题，新增了检查 `block-size` 配置的有效性功能。TiDB Binlog 修复了 Pump 因写入失败时未检查返回值导致偏移量错误问题，Drainer 新增了 `advertise-addr` 配置，支持容器环境中使用桥接模式。
-- [TiDB 2.1.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.14/): TiDB 2.1.14 发布说明：修复查询结果不正确的问题，支持自动调整 Auto ID 分配的步长，新增全局系统变量 `max_execution_time`，修复内存配额超出时返回结果不正确的问题，禁用 `TRACE` 语句，新增系统表控制函数下推，优化 Raftstore 消息处理，调整无效配置项日志级别，新增 Binlog 配置项，修复 Binlog 更新失败问题，新增 Ansible 命令预检查功能。
-- [TiDB 2.1.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.15/): TiDB 2.1.15 发布，修复了多个函数处理微秒、空值比较、插入参数、索引建立等问题，并新增了多个 SQL 语句和监控项。TiKV 统一日志格式，提高了调度准确度。PD 也统一了日志格式。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修复了导入错误问题。TiDB Ansible 新增监控项用于监测 SQL 语句解析耗时和执行计划编译耗时。
-- [TiDB 2.1.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.16/): TiDB 2.1.16 发布，修复了 SQL 优化器和执行引擎的多个问题。TiKV 支持逆向 raw_scan 和 raw_batch_scan 接口。TiDB Binlog 和 TiDB Lightning 做了一些功能增强和 bug 修复。TiDB Ansible 也有多个 bug 修复和功能优化。
-- [TiDB 2.1.17 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.17/): TiDB 2.1.17 发布，新增了 `SHOW TABLE REGIONS` 语法的 `WHERE` 条件子句，以及 TiKV、PD 的 `config-check` 功能。PD 优化调度流程，TiKV 优化启动流程。TiDB 慢日志中的 `start ts` 和 `Index_ids` 字段有改动。SQL 优化器和执行引擎修复了多个问题。DDL 改进了 `SPLIT TABLE` 语法的行为。TiKV 解决了一些问题并新增了 `config-check` 选项。PD 新增了 `config-check` 选项和 `remove-tombstone` 命令。Reparo 新增了配置项，用于控制恢复速率。TiDB Ansible 更新了 Spark 版本和修复了连接等待问题。
-- [TiDB 2.1.18 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.18/): TiDB 2.1.18 发布，修复了多项 SQL 优化器和执行引擎的问题，改进了 Server、DDL 和 Monitor 功能，同时 TiDB Ansible 也有多项更新。
-- [TiDB 2.1.19 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.19/): TiDB 2.1.19 发布，包含了对 SQL 优化器、SQL 执行引擎、Server、DDL、TiKV、PD 和 TiDB Ansible 的多项修复和优化。修复了多个查询和更新语句中可能出现的错误，提升了系统稳定性和性能。
-- [TiDB 2.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.2/): TiDB 2.1.2 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括索引 panic、优化器执行计划、字符集检查和时间类型字段错误。PD 修复了 Region Merge 相关问题，TiKV 支持日为时间单位的配置格式，并解决了配置兼容性问题，修复了 Approximate Size Split 和两个 Region merge 相关问题。TiDB Lightning 支持最小 TiDB 集群版本为 2.1.0，修复了解析 JSON 类型数据文件内容出错和使用 checkpoint 重启后的错误。TiDB Binlog 消除了往 Kafka 写数据的瓶颈点，支持写 Kafka 版本的 TiDB Binlog。
-- [TiDB 2.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.3/): TiDB 2.1.3 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个问题，包括 Prepared Plan Cache panic、Range 计算错误、统计信息溢出、Generated Column 在 Update 中 Panic 等。还支持了一些新特性，如对 `_tidb_rowid` 构造查询的 Range、`CASE` 子句返回 JSON 类型等。PD 修复了 Leader 选举相关的 Watch 问题，TiKV 支持了使用 HTTP 方式获取监控信息，并修复了一些问题。TiDB Binlog 也修复了一些启动或重启时的问题。
-- [TiDB 2.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.4/): TiDB 2.1.4 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个函数处理结果不正确的问题，优化了服务器日志和 DDL 操作。TiKV 修复了关闭时可能发生重复写的问题和事件监听器处理异常的问题。工具方面优化了内存使用，减少了对 dump 文件的解析，提高了导入稳定性。数据同步对比统计支持使用 TiDB 统计信息来划分 chunk。
-- [TiDB 2.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.5/): TiDB 2.1.5 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括优化器 / 执行器、Server、DDL、PD、TiKV 和 Tools 的改进和修复。
-- [TiDB 2.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.6/): TiDB 2.1.6 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括索引扫描选择问题、聚合函数兼容性问题、变量设置导致的 Panic 问题等。TiKV 修复了解析 protobuf 失败导致的错误。Lightning 修复了多个导入相关的问题，并支持 CSV 格式。
-- [TiDB 2.1.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.7/): TiDB 2.1.7 发布，修复了 DDL 取消导致升级程序启动时间变长的问题，提升了内置函数的兼容性，新增了系统表管理 Table 与 Index 之间的关系，支持在 DO 语句中使用子查询，修复了对 JSON 数据的聚合函数在计算过程中 Panic 的问题。PD 修改副本数为 1 时 balance-region 无法迁移 leader 的问题。Tools 支持 binlog 同步 generated column。TiDB Ansible 将 Prometheus 监控数据默认保留时间改成 30d。
-- [TiDB 2.1.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.8/): TiDB 2.1.8 发布，修复了多个函数和语句的兼容性问题，优化了日志格式规范和统计信息估算准确性。PD 和 TiKV 也有多项修复和优化。工具方面，Lightning 和 Binlog Pump 等新增了多项配置和性能优化。TiDB Ansible 修改了操作系统版本限制和滚动升级版本限制。
-- [TiDB 2.1.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.9/): TiDB 2.1.9 发布，修复了多个函数和权限检查问题，支持指定 collation 为 utf8mb4_0900_ai_ci，改进了慢日志输出和 PD 服务支持。 TiKV 修复了在 transfer leader 时的问题。 TiDB Binlog 和 TiDB Lightning 也有多个修复和改进。 TiDB Ansible 更新了文档链接和移除了一个参数。
-- [TiDB 3.0 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0-beta/): TiDB 3.0 Beta 版本发布，新增支持 View、窗口函数、Range 分区、Hash 分区等特性。SQL 优化器做了很多改进，包括重新支持聚合消除、优化 `NOT EXISTS` 子查询、支持 Index Join 等。SQL 执行引擎优化了 Merge Join 算子、日志打印等功能。权限管理增加了对 `ANALYZE`、`USE`、`SET GLOBAL`、`SHOW PROCESSLIST` 语句的权限检查。Server 支持了 `Trace` 功能、插件框架、`unix_socket` 和 TCP 连接等功能。兼容性方面支持了 `ALLOW_INVALID_DATES` SQL mode、load data 对 CSV 文件的容错能力等。DDL 支持了快速恢复误删除的表、动态调整 ADD INDEX 的并发数等功能。Tools 方面 TiDB Lightning 大幅优化了 SQL 转 KV 的处理速度。PD 和 TiKV 也做了很多功能增加和优化。
-- [TiDB 3.0 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0-ga/): TiDB 3.0 GA 版本于 2019 年 6 月 28 日发布，对应的 TiDB Ansible 版本为 3.0.0。V3.0.0 版本相比 V2.1 在稳定性、易用性、性能和新功能方面有重要改进。新增功能包括窗口函数、视图、分区表、插件系统、悲观锁、SQL Plan Management 等。SQL 优化器和执行引擎也有多项优化，包括对 `NOT EXISTS` 子查询、`Outer Join`、`IN` 子查询、Index Join 等的性能提升。PD 新增了从单个节点重建集群的功能，将 Region 元信息从 etcd 移至 go-leveldb 存储引擎。TiKV 新增了分布式 GC、并行 Resolve Lock、多线程 Raftstore 和 Apply 等功能，以及对 Engine、Server、RaftStore 和 Coprocessor 的优化。Tools 方面 TiDB Lightning 新增了多项功能，TiDB Binlog 新增了多项功能，sync-diff-inspector 也新增了多项功能。TiDB Ansible 升级了监控组件版本，新增了多项监控面板和功能。
-- [TiDB 3.0.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-beta.1/): TiDB 3.0.0 Beta.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、权限管理、Server、DDL、PD、TiKV 和 Tools 的更新。
-- [TiDB 3.0.0-rc.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.1/): TiDB 3.0.0-rc.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Tools 和 TiDB Ansible 的更新和修复。
-- [TiDB 3.0.0-rc.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.2/): TiDB 3.0.0-rc.2 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL 和 PD 的更新。TiKV 的更新包括 Engine、Server、Raftstore 和 Coprocessor 的改进。工具方面，TiDB Binlog 增加下游同步延迟监控项，TiDB Lightning 支持数据库合并和新增 KV 写入失败重试机制。
-- [TiDB 3.0.0-rc.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.3/): TiDB 3.0.0-rc.3 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Transaction、tikv-ctl、Misc 等方面的修复和新增功能。TiDB Ansible 新增预测集群最大 QPS 的监控项。
-- [TiDB 3.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.1/): TiDB 3.0.1 发布，新增多项功能和修复了多个问题。TiKV 新增了对 Blob 文件大小的统计和死锁检测性能的提升。PD 优化了热点 Region 调度策略和 Region Merge 处理逻辑。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修正了导入错误的问题。TiDB Ansible 新增了预检查功能和更新了监控信息。
-- [TiDB 3.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.10/): TiDB 3.0.10 发布，修复了多个 bug 和性能问题。TiKV 修复了 Region merge 失败导致系统 Panic 的问题。PD 自动更新 Region 缓存信息，解决缓存失效问题。TiDB Binlog 支持 relay log。TiDB Lightning 优化配置项和修复 web 界面无法打开的问题。TiDB Ansible 修复获取不到 PD Leader 导致命令执行失败的问题，并新增多个监控项。
-- [TiDB 3.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.11/): TiDB 3.0.11 发布，包含兼容性变化、新功能和 Bug 修复。新增配置项 `max-index-length` 控制索引最大长度，显示分区表的分区元信息，以及 TiDB 集群之间数据双向复制功能。Bug 修复包括查询结果不正确、Goroutine 泄露等问题。TiKV 也进行了日志输出优化和问题修复。TiDB Ansible 修复了失效文档链接和未定义变量问题。
-- [TiDB 3.0.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.12/): TiDB 3.0.12 发布日期为 2020 年 3 月 16 日。该版本存在一些已知问题，建议使用最新版本。兼容性变化包括修复慢日志中记录 prewrite binlog 时间计时不准确的问题。新功能包括动态加载已被替换的证书文件，添加配置项，限流功能，以及在 binlog 写入失败时 TiDB 退出。Bug 修复包括保证原子性，悲观锁加锁问题修复，建索引长度超过限制时的报错信息显示，FROM_UNIXTIME 函数小数点位数不正确的问题修复，以及其他问题的修复。
-- [TiDB 3.0.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.13/): TiDB 3.0.13 发布日期为 2020 年 04 月 22 日。此版本修复了 TiDB 和 TiKV 中的一些 bug。其中 TiDB 修复了由于未检查 `MemBuffer`，事务内执行 `INSERT ... ON DUPLICATE KEY UPDATE` 语句插入多行重复数据可能出错的问题。TiKV 修复了重复多次执行 `Region Merge` 导致系统被阻塞的问题，阻塞期间服务不可用。
-- [TiDB 3.0.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.14/): TiDB 3.0.14 发布日期为 2020 年 5 月 9 日。该版本兼容性变化包括 `performance_schema` 和 `metrics_schema` 由读写改为只读。重点修复的 Bug 包括 join 条件在 handle 列上存在多个等值条件时，index join 查询结果错误等问题。新功能包括 `admin show ddl jobs` 查询结果中添加库名和表名列等功能。Bug 修复包括 `WEEKEND` 函数在 SQL mode 为 `ALLOW_INVALID_DATES` 时结果与 MySQL 不兼容等问题。TiKV 也有相关 Bug 修复，如节点隔离恢复之后无法被正确删掉等问题。
-- [TiDB 3.0.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.15/): TiDB 3.0.15 发布，新增禁止分区表查询使用 plan cache 功能、支持 admin recover index、admin check index 语句、优化统计信息 CMSketch 的内存分配机制等功能。PD 新增按照 Leader 个数调度的策略。修复了多处 Bug，包括 Hash 聚合函数中的深拷贝方式、点查整数溢出处理逻辑、CHAR() 函数查询条件处理逻辑等问题。TiKV 修复了长时间运行后碎片整理不再有效、系统意外重启后删除 snapshot 文件导致系统 panic、消息包过大导致 gRPC 连接断开的问题。
-- [TiDB 3.0.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.16/): TiDB 3.0.16 发布，优化了 hash partition pruning 和 Region 设置，修复了多个 Bug，包括锁住的 primary key 造成的结果不一致问题和 JSON 数据中 int 和 float 类型比较的问题。TiKV 也进行了稳定性优化和 Bug 修复。PD 修复了查询 Region 报 404 错误的问题。
-- [TiDB 3.0.17 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.17/): TiDB 3.0.17 发布，修复了多个 bug，包括查询返回错误和函数处理问题。优化了配置项和 HTTP API 访问速度。TiKV 修复了数据读取和调度问题，新增了配置支持。TiDB Lightning 解决了参数不生效的问题，并新增了更简单易用的过滤规则。
-- [TiDB 3.0.18 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.18/): TiDB 3.0.18 发布，提升了 TiDB Binlog 工具的细粒度 Pump GC 时间支持。修复了 TiDB 中 Hash 函数对 Decimal 类型的错误处理问题，以及对 Set 和 Enum 类型的错误处理问题。还修复了 Duplicate Key 检测在悲观事务下失效的问题，以及其他执行结果错误的问题。TiKV 将 GC 的失败日志级别改为 Warning。TiDB Lightning 修复了多个命令行参数和使用 TiDB backend 时的问题。
-- [TiDB 3.0.19 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.19/): TiDB 3.0.19 发布，兼容性变化包括更改 PD 的导入路径和版权信息。提升改进方面，缓解故障恢复对 QPS 的影响，支持调整 `union` 运算符的并发数。Bug 修复包括解决 `slow-log` 文件不存在导致查询出错的问题，添加权限检查命令，修复类型转换问题等。TiKV 修复了 status server 解析响应出错导致 panic 的问题。TiDB Lightning 修复了严格模式下 CSV 中遇到不合法 UTF 字符集没有及时退出进程的问题。
-- [TiDB 3.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.2/): TiDB 3.0.2 发布日期为 2019 年 8 月 7 日。该版本修复了多个 SQL 优化器和执行引擎的问题，包括修复了查询结果列名称不正确、LIKE 表达式被隐式转换为 0、SHOW 语句中使用子查询等问题。此外，还修复了 TiKV panic、悲观事务下 Insert 行为不正确等问题。PD 也修复了 Scatter Region 调度器不能工作等 bug。TiDB Ansible 也有多个修复和更新，包括修复了 Disk Performance 监控单位错误、新增了 TiDB Summary Dashboard 等。
-- [TiDB 3.0.20 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.20/): TiDB 3.0.20 发布，兼容性更改包括废弃 `enable-streaming` 配置项。改进提升包括优化 `LOAD DATA` 语句执行报错信息。Bug 修复包括缓存悲观事务提交状态问题、查询统计信息不准确问题等。TiKV 修复事务删除 key 报错问题，PD 修复启动时打印过量日志问题。
-- [TiDB 3.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.3/): TiDB 3.0.3 发布，包含了多项 SQL 优化器和执行引擎的修复，以及 Server、DDL、Monitor、TiKV、PD、Tools 和 TiDB Ansible 的更新和修复。
-- [TiDB 3.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.4/): TiDB 3.0.4 发布日期为 2019 年 10 月 8 日。此版本新增了系统表 `performance_schema.events_statements_summary_by_digest` 用于排查 SQL 性能问题。同时，TiDB 的 `SHOW TABLE REGIONS` 语法新增了 `WHERE` 条件子句。此外，Reparo 新增了 `worker-count` 和 `txn-batch` 配置项，用于控制恢复速率。还修复了一些问题，如特殊语法 `PRE_SPLIT_REGIONS` 没有使用注释的方式向下游同步的问题。
-- [TiDB 3.0.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.5/): TiDB 3.0.5 发布，包含 SQL 优化器和执行引擎的多项修复和改进，支持事务 TTL 修改接口函数，以及对 Region Cache TTL 的配置修改。TiKV 新特性包括悲观事务 Cleanup 接口支持和 Raftstore 性能优化。PD 提高了 Region 占用空间的精度和 label 监控可读性。TiDB Binlog 和 TiDB Lightning 也有多项修复和功能增强。TiDB Ansible 更新了监控表达式和配置文件内容。
-- [TiDB 3.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.6/): TiDB 3.0.6 发布，包含多项 SQL 优化器和执行引擎的修复和优化，以及 Server、DDL、TiKV、PD 和 Tools 的更新和修复。TiKV 修复了悲观锁支持和 GC worker 写入量限制等问题。PD 添加了新维度和降低日志级别。Tools 中 TiDB Binlog 和 TiDB Lightning 也有多项修复和新增配置。
-- [TiDB 3.0.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.7/): TiDB 3.0.7 发布，修复了多个问题，包括本地时间落后导致锁的 TTL 过大、解析日期时时区不正确、整型数据转换精度丢失等问题。TiKV 也修复了死锁检测和内存泄漏问题。
-- [TiDB 3.0.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.8/): TiDB 3.0.8 发布，修复了 SQL 优化器、SQL 执行引擎、DDL、Server、Transaction、Monitor 等方面的多个问题。TiKV 也进行了多项修复和优化。PD 新增了一些功能，并升级了 etcd 版本。TiDB Ansible 进行了配置项回滚和优化，TiSpark 版本升级到 2.1.8。
-- [TiDB 3.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.9/): TiDB 3.0.9 发布日期为 2020 年 1 月 14 日。该版本修复了一些已知问题，并提升了性能。包括 Executor 修复了聚合函数作用于枚举和集合列时结果不正确的问题，Server 支持了系统变量 `auto_increment_increment` 和 `auto_increment_offset`，新增了监控项等。TiKV 提升了 Raft 成员变更的速度，新增了监控项用于监控 `waiter` 的生命周期等。PD 新增了一些功能和修复了一些问题。Tools 方面也有一些新增和优化。TiDB Ansible 优化了 Lightning 部署。
-- [TiDB 3.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta/): TiDB 3.1 Beta 发布说明：发版日期为 2019 年 12 月 20 日，TiDB 版本为 3.1.0-beta，TiDB Ansible 版本为 3.1.0-beta。TiDB 新增 SQL 优化器和丰富的 SQL hint 功能。另外，TiDB 还支持 Follower Read 功能。TiKV 新增支持分布式备份恢复功能和 Follower Read 功能。PD 也新增支持分布式备份恢复功能。
-- [TiDB 3.1 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.1/): TiDB 3.1 Beta.1 发布日期为 2020 年 1 月 10 日。TiDB 版本为 3.1.0-beta.1，TiDB Ansible 版本也为 3.1.0-beta.1。TiKV 新增了备份功能和 SST 文件恢复修复。Tools 中 BR 组件修复了备份进度信息不准确的问题，并新增了自动调度 PD schedulers 功能。TiDB Ansible 新增了初始化阶段自动关闭操作系统 THP 的功能和 BR 组件的 Grafana 监控。
-- [TiDB 3.1 Beta.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.2/): TiDB 3.1 Beta.2 发布日期为 2020 年 3 月 9 日。该版本存在已知问题，建议使用最新版本。兼容性变化包括 TiDB Lightning 配置项优化和新增命令行参数。新功能包括支持在列属性上添加 `AutoRandom` 关键字，新增通过 DDL 语句为表创建、删除列存储副本的功能等。Bug 修复包括修复静默 Region 读数据处理不当导致无法处理读请求的问题等。
-- [TiDB 3.1 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-ga/): TiDB 3.1 GA 发布说明：兼容性变化包括支持报告状态配置项和 BR 不支持旧版 TiKV 集群恢复。新功能包括展示 coprocessor 任务信息和减少日志冗余信息。PD 优化热点 Region 调度，TiFlash 添加读写负载信息和支持函数下推。TiDB Ansible 新增 TiFlash 监控和优化配置参数。Bug 修复包括修复 merge join 和计算选择率问题。TiKV 修复 replica read 和 restore 问题，TiFlash 修复同步 schema 和数据丢失问题。TiDB Binlog 修复因 TiFlash 相关 DDL job 导致同步中断问题，BR 修复 checksum 和增量备份失败问题。
-- [TiDB 3.1 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-rc/): TiDB 3.1 RC 发布日期为 2020 年 4 月 2 日。该版本存在已知问题，建议使用最新版本 3.1.x。新功能包括性能提升、数据恢复、TLS 证书动态更新等。Bug 修复包括信息 schema 错误、DDL 卡住、冲突检测失效等。PD 修复了数据竞争、规则未遵守等问题。工具方面优化了性能、修复了数据错误和无法恢复的问题。
-- [TiDB 3.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.1/): TiDB 3.1.1 发布，新增了 auto_rand_base 表选项和 Feature ID 注释。TiFlash 优化了读写负载相关图表和 chunk encode decimal 数据的流程。修复了隔离读设置不生效、hash 分区表上的分区选择语法报错、update sql 中包含 view 仍然报错等问题。TiFlash 修复了非 normal 状态时读取数据错误、表名映射方式支持 recover table/flashback table、数据存储路径问题、读模型优化和特殊字符导致无法启动的问题。BR 修复了恢复带有 auto_random 属性的表后插入数据触发 duplicate entry 错误的问题。
-- [TiDB 3.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.2/): TiDB 3.1.2 发布日期为 2020 年 6 月 4 日。此版本修复了 TiKV 和 Tools 中的一些错误，包括 S3 和 GCS 备份恢复时的错误处理问题，备份过程中的 DefaultNotFound 错误，以及 BR 在备份恢复到 S3 和 GCS 存储时的稳定性提升等问题。同时还修复了 BR 在恢复数据时出现的一些错误，并增加了备份恢复 S3 时的 AWS KMS 服务端加密支持。
-- [TiDB 4.0 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta/): TiDB 4.0 Beta 发布说明：TiDB 版本 4.0.0-beta 和 TiDB Ansible 版本 4.0.0-beta 已发布。更新内容包括性能优化、新功能支持、bug 修复等。详细信息请查阅官方发布说明。
-- [TiDB 4.0 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0-ga/): TiDB 4.0 GA 发布日期为 2020 年 5 月 28 日。该版本包含兼容性变化、重点修复的 Bug、新功能、Bug 修复等内容。其中 TiDB 新增了多项配置项和语法支持，TiFlash 修复了多项功能不一致的问题，TiKV 修复了多个备份和系统 panic 相关的问题，PD 修复了删除调度器和 presplit 功能无法正常使用的问题，Tools 中 BR 修复了从云存储恢复数据失败的问题，TiCDC 修复了多个系统 panic 和资源泄露的问题。
-- [TiDB 4.0 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc/): TiDB 4.0 RC 发布日期为 2020 年 4 月 8 日，版本为 4.0.0-rc，TiUP 版本为 0.0.3。该版本存在已知问题，建议使用最新版本 4.0.x。兼容性变化包括 TiDB、TiKV 和 Tools 的更新。重点修复了 TiDB 的 Bug，并新增了一些功能。TiKV 修复了启用 Follower Read 功能导致系统 Panic 的问题。Tools 中 TiDB Lightning 修复了字符转换错误导致数据错误的问题，TiCDC 新增了一些功能。
-- [TiDB 4.0 RC.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.1/): TiDB 4.0 RC.1 发布说明：TiDB 4.0.0-rc.1 版本兼容性变化包括 TiKV 默认关闭 hibernate region，TiDB Binlog 增加对 Sequence DDL 的支持。重点修复了多个 Bug，包括 TiDB 事务内执行 INSERT ... ON DUPLICATE KEY UPDATE 语句插入多行重复数据可能出错的问题等。新增功能包括 TiDB 支持发送 batch coprocessor 请求给 TiFlash 等。Bug 修复包括 TiDB 系统表由于 unsigned 列定义导致无法正确显示负数的问题等。
-- [TiDB 4.0 RC.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.2/): TiDB 4.0 RC.2 发布说明：兼容性变化包括事务容量上限统一为 10GB，查询 CLUSTER_LOG 表需指定时间范围，CREATE TABLE 创建分区表时指定未支持的选项将创建非分区普通表。重点修复了多个 Bug。新增了备份和恢复语句，支持预检查单个 Region 提交数据量。TiKV 新增了加密存储适配和配置 gRPC 消息大小上限。PD 修复了 pd-ctl 命令错误和缺失监控的问题。TiFlash 优化了系统负载和新增了容量配置参数。Tools 方面修复了多个问题和优化了功能。
-- [TiDB 4.0.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.1/): TiDB 4.0.0 Beta.1 发布，包含兼容性变化、新功能和 Bug 修复。兼容性变化包括配置项类型修改和默认值调整。新增慢日志系统表支持查询任意时间段的日志，SQL 性能诊断功能和 Sequence 功能。Bug 修复包括视图创建、时区修改和函数表达式问题。TiKV 和 PD 也有新增功能和 Bug 修复。TiDB Ansible 新增部署多个 Grafana/Prometheus/Alertmanager 的功能和 TiFlash 监控 Dashboard。
-- [TiDB 4.0.0 Beta.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.2/): TiDB 4.0.0 Beta.2 发布日期为 2020 年 3 月 18 日。该版本修复了 TiDB Binlog 在配置 `disable-dispatch`、`disable-causality` 时系统直接报错并退出的问题。新增了 TiKV 和 PD 支持将动态修改配置的结果持久化存储到硬盘的功能。另外，TiDB Binlog 新增了 TiDB 集群之间数据双向复制功能，TiDB Lightning 新增了配置 TLS 功能，新增了 TiCDC 工具，提供了进程级别的高可用能力。此外，BR 开启了增量备份、支持将备份文件存储在 AWS S3 等实验性功能。TiDB Ansible 新增了将节点信息注册到 etcd 的功能，新增支持在 ARM 平台上部署 TiDB 服务的功能。修复了 TiKV、PD 和 Tools 中的多个 bug。
-- [TiDB 4.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.1/): TiDB 4.0.1 发布日期为 2020 年 6 月 12 日。新功能包括 TiKV 添加 `--advertise-status-addr` 启动参数，PD 支持内部代理和客户端自定义超时设置，TiFlash 支持新的排序规则框架和函数下推，以及 BR 增加集群版本检查。Bug 修复方面，TiKV 修复了多个问题，PD 修复了错误配置和 panic 问题，TiFlash 修复了默认值解析和时区计算错误的问题。
-- [TiDB 4.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.10/): TiDB 4.0.10 发布日期为 2021 年 1 月 15 日。新功能包括 PD 添加了配置项 `enable-redact-log` 和 TiFlash 添加了配置项 `security.redact_info_log`。改进提升方面，TiDB 添加了 `txn-entry-size-limit` 配置项，PD 优化了 `store-state-filter` 监控，Tools 中 TiCDC 默认开启了 old value 特性。Bug 修复方面，TiDB 修复了多个并发导致的问题，TiKV 修复了 peer 和 ready 之间的错误映射，PD 修复了 ID 分配不是单调递增的问题，TiFlash 修复了多个启动和函数调用的问题，Tools 中 TiCDC 修复了多个协议和内存问题，Dumpling 修改了默认设置的行为。 Backup & Restore (BR) 修复了多个备份和恢复问题，TiDB Binlog 修复了启用 `AMEND TRANSACTION` 特性时的问题，TiDB Lightning 修复了多个备份和使用问题。
-- [TiDB 4.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.11/): TiDB 4.0.11 发布，新增支持 `uft8_unicode_ci` 和 `utf8mb4_unicode_ci` 排序规则。TiKV 支持 `utf8mb4_unicode_ci` 和 `cast_year_as_time` 排序规则。TiFlash 增加排队处理 Coprocessor 任务的线程池。改进包括重排由 `outer join` 简化的 `inner join` 顺序，Grafana 面板支持多集群，Bug 修复包括修复异常的 `unicode_ci` 常数传递等。PD 修复成员健康的监控显示不正确的问题。TiFlash 修复 Decimal 类型的 `min`/`max` 计算结果错误等。Tools 修复 TiCDC 服务在同时发生 `ErrTaskStatusNotExists` 和 `capture` 会话关闭的情况下的非预期的退出等。
-- [TiDB 4.0.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.12/): TiDB 4.0.12 发布，新增 TiFlash 工具用于检测状态。优化了 EXPLAIN 语句输出信息，在 metrics 监控中记录了 PREPARE 执行失败的问题。TiKV 修复了多个问题，包括处理 JSON 向字符串转换时空格缺失的问题。PD 修复了 store 缺失 label 的隔离级别错误问题。TiFlash 修复了多个查询结果错误的问题。TiCDC 修复了多个数据丢失和资源释放问题。BR 修复了多个备份和恢复问题。TiDB Lightning 修复了多个数据错误和文件损坏问题。
-- [TiDB 4.0.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.13/): TiDB 4.0.13 发布，新增 `AUTO_INCREMENT` 变更为 `AUTO_RANDOM` 功能，引入 `infoschema.client_errors_summary` 表。提升内存中统计信息缓存，减少 CPU 使用率。TiKV 提高 `store used size` 计算准确性，返回更多的 Region 以降低 Region miss。PD 优化 TSO 处理时间统计指标，更新 Dashboard 版本。TiFlash 自动清除过期历史数据。BR 支持备份恢复系统库，检查集群版本和备份数据版本。TiCDC 增加流程控制，清理陈旧临时文件，增加 HTTP 接口调用。修复多个 Bug。
-- [TiDB 4.0.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.14/): TiDB 4.0.14 发布，包含兼容性更改、功能增强、改进提升和 Bug 修复。兼容性更改包括默认值修改和配置项更新。功能增强包括监控项添加和新功能支持。改进提升包括算子优化和系统变量支持。Bug 修复包括查询结果错误和函数参数错误修复。PD、TiDB Dashboard、TiFlash 和 Tools 也有相关更新和修复。
-- [TiDB 4.0.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.15/): TiDB 4.0.15 发布，修复了执行 `SHOW VARIABLES` 速度慢的问题，以及多个 Bug 和兼容性变化。TiKV 支持动态修改 TiCDC 配置。TiDB 基于直方图的 row count 来触发 auto-analyze。TiKV 分离处理读写的 ready 状态以减少读延迟。PD 提升了同步 Region 信息的性能。BR 支持并发执行分裂和打散 Region 的操作。Dumpling 提升了 `SHOW TABLE STATUS` 的过滤效率。TiCDC 支持导入数据到带有表达式索引或带有基于虚拟生成列的索引的表中。修复了多个 Bug 和问题。
-- [TiDB 4.0.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.16/): TiDB 4.0.16 发布，包含兼容性更改、提升改进和 Bug 修复。TiKV 改进了对非法 UTF-8 字符串的处理，Tools 中 TiCDC 改变了 Kafka Sink 默认值。TiDB 升级了 Grafana，TiKV 使用 zstd 算法压缩 SST 文件。Bug 修复包括统计信息模块的查询崩溃、`ENUM` 类型控制函数返回结果不正确等问题。TiKV 修复了多个问题，包括 Decimal 除法计算结果为负、监控项中 gRPC 平均延迟时间不准确等问题。PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了无法启动的问题。Tools 中 TiDB Binlog 修复了 Drainer 传输事务超过 1 GB 时退出的问题，TiCDC 修复了多个问题。
-- [TiDB 4.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.2/): TiDB 4.0.2 发布，兼容性改进和新功能增加。TiDB 默认收集使用情况信息，并分享给 PingCAP 用于改善产品。新增功能包括支持 INSERT 语句中使用 MEMORY_QUOTA() hint，基于 TLS 证书 SAN 属性的登录认证，以及其他函数和表的新增配置项。Bug 修复包括执行计划不正确、运行时错误、内存统计过大等问题。PD、TiKV、TiFlash 和 TiCDC 也有相关改进和修复。Tools 中 Backup & Restore (BR) 提升了多表场景下的恢复数据性能。
-- [TiDB 4.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.3/): TiDB 4.0.3 发布了新版本，包括 TiDB Dashboard、TiFlash、Tools 和改进提升等多个方面的更新和修复。新增功能包括 TiDB Dashboard 显示详细信息、TiFlash 支持文件加密、Tools 支持多种算法压缩备份文件等。改进提升方面包括增加全局变量控制日志记录、加速执行速度、默认打开执行信息收集等。此外，还修复了多个 Bug，包括 gRPC transportReader 异常、数据不完整、无法正确设置 safepoint 等问题。
-- [TiDB 4.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.4/): TiDB 4.0.4 发布日期为 2020 年 7 月 31 日。此版本修复了多个 bug，包括查询 `information_schema.columns` 卡死的问题、`PointGet` 和 `BatchPointGet` 在遇到 `in(null)` 条件时出错的问题、`BatchPointGet` 算子结果不正确的问题以及 `HashJoin` 算子在遇到 `set`、`enum` 类型时查询结果不正确的问题。
-- [TiDB 4.0.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.5/): TiDB 4.0.5 发布，兼容性变化包括修改参数和添加状态检查。新增功能包括为错误定义错误码和支持统一的 log 格式。优化提升包括减少 GC 锁扫描次数和降低统计信息对性能的影响。Bug 修复包括函数错误处理和查询结果错误等。PD 修复了 TSO 不可用和 Region 调度问题。TiFlash 修复了进程启动和升级问题。Tools 修复了恢复缓慢和同步任务问题。
-- [TiDB 4.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.6/): TiDB 4.0.6 发布日期为 2020 年 9 月 15 日。新功能包括 TiFlash 中支持在广播 Join 中使用外连接，TiDB Dashboard 添加了多个页面和功能。TiCDC 从 v4.0.6 起成为正式功能。优化提升方面，TiDB 提升了分区表的写性能，支持调整 Union 执行算子的并发度等。Bug 修复方面，TiDB 修复了多个查询结果不正确的问题。TiKV 修复了统计信息估算错误的问题等。PD 修复了 store limit 的单位问题等。TiFlash 修复了多个启动失败和异常问题。Tools 方面也有多个问题得到解决。
-- [TiDB 4.0.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.7/): TiDB 4.0.7 发布，新增 PD 客户端函数 `GetAllMembers` 和 TiDB Dashboard 统计指标关系图支持。TiDB 优化了 `join` 算子执行信息和协处理器缓存命中率信息，支持将 `ROUND` 函数下推至 TiFlash，并修复了多个 bug。TiKV 支持日志输出为 JSON 格式，修复了 TLS 握手失败导致 Status API 不可用的问题。PD 修复了多个问题，TiFlash 修正了 right outer join 结果错误。Backup & Restore (BR) 修复了恢复数据后导致 TiDB 配置变更的错误，Dumpling 修复了 metadata 解析失败的问题。
-- [TiDB 4.0.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.8/): TiDB 4.0.8 发布，新增聚合函数 `APPROX_PERCENTILE` 和 `CAST` 函数下推支持。优化了索引组合计算表达式选择率的贪心算法，记录更多的 RPC 信息，提升慢查询性能。修复了多个 BUG，如分区表可能遇到非预期 Panic、外连接时 Index Merge Join 结果不正确等。 PD 修复了 TiDB Dashboard 引起 PD panic 的错误。TiFlash 修复了多个问题，如日志信息中时间戳错误、重启后可能提示数据文件损坏等。Backup & Restore (BR) 修复了 Restore 期间可能发生的 `send on closed channel` panic 问题。
-- [TiDB 4.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.9/): TiDB 4.0.9 发布日期为 2020 年 12 月 21 日。该版本包含兼容性更改、新功能、优化提升、Bug 修复等内容。兼容性更改包括废弃配置文件中的某些配置项。新功能包括 TiFlash 支持存储引擎的新数据分布在多个硬盘上等。优化提升方面包括避免生成 (index) merge join 以得到更好的执行计划等。Bug 修复方面包括修复了前缀索引和 `OR` 条件一起使用时结果不正确的问题等。
-- [TiDB 5.0 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.0-rc/): TiDB 5.0.0-rc 版本是 5.0 版本的前序版本。在 5.0 版本中，我们专注于帮助企业基于 TiDB 数据库快速构建应用程序，提升数据库性能、降低写入数据延迟、稳定性、可用性、容灾、SQL 语句效率等问题。新增聚簇索引、异步提交事务、Raft Joint Consensus 算法、不可见索引、`EXCEPT`/`INTERSECT` 操作符、悲观事务执行成功概率、字符集和排序规则优化、错误信息和日志信息脱敏、优化器选择索引稳定性、调度功能优化、备份与恢复、数据导入导出、`EXPLAIN` 功能优化、TiUP 增强功能等特性。
-- [TiDB 5.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.1/): TiDB 5.0.1 发布日期为 2021 年 4 月 24 日。此版本包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括 TiDB 配置文件的默认值改变。改进提升方面，TiDB 支持 `VITESS_HASH()` 函数，TiKV 使用 `zstd` 压缩 Region Snapshot，PD 调整 Region 分数公式等。Bug 修复方面，TiDB 修复了多个查询结果可能错误的问题，TiKV 修复了多个导致问题的 Bug。Tools 方面也有多个 Bug 修复。
-- [TiDB 5.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.2/): TiDB 5.0.2 发布日期为 2021 年 6 月 10 日。此版本包含兼容性更改、新功能、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具中的参数废弃和 TiKV 默认开启 Hibernate Region 特性。新功能包括 BR 支持 S3 兼容的存储和 TiFlash 优化锁操作。提升改进方面，TiDB 避免后台作业频繁读取表造成高 CPU 使用率，TiKV 添加背压功能和减少扫描的内存使用量。Bug 修复方面，修复了多个问题，包括索引导致的 panic、事务中的语句不正确使用、排序规则写入错误值等。
-- [TiDB 5.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.3/): TiDB 5.0.3 发布日期为 2021 年 7 月 2 日。此版本包含兼容性更改、功能增强、提升改进和 Bug 修复。兼容性更改包括 `tidb_multi_statement_mode` 变量默认值变更和兼容 MySQL 5.7 的 noop 变量配置。功能增强方面，TiCDC 增加了 HTTP API 获取 changefeed 信息和节点健康信息。TiDB 提升了多个内置函数的支持和优化了聚合算子的代价常数。Bug 修复方面，修复了多个查询和函数使用时可能出现的问题。PD 升级了 TiDB Dashboard。TiFlash 支持了多个新功能和修复了多个问题。TiCDC、BR 和 TiDB Lightning 也进行了多项修复和优化。
-- [TiDB 5.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.4/): TiDB 5.0.4 发布日期为 2021 年 9 月 27 日。此版本包含兼容性更改、功能增强、提升改进、Bug 修复等内容。兼容性更改包括修复了 `SHOW VARIABLES` 速度慢的问题，系统变量 `tidb_stmt_summary_max_stmt_count` 默认值修改为 `3000` 等。功能增强包括支持将系统变量 `tidb_enforce_mpp` 的值设为 `1` 以忽略优化器代价估算，强制使用 MPP 模式。提升改进包括基于直方图的 row count 来触发 auto-analyze、支持 MPP 查询的重试等。Bug 修复包括修复了查询分区表且分区键带有 `IS NULL` 条件时 TiDB 可能 panic 的问题等。
-- [TiDB 5.0.5 Release Note](https://docs.pingcap.com/tidb/stable/release-5.0.5/): TiDB 5.0.5 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。详细信息请查看 issue
-- [TiDB 5.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.6/): TiDB 5.0.6 发布日期为 2021 年 12 月 31 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具的错误输出改为标准错误，以及 Kafka sink 模块的默认值设置。提升改进方面，TiDB 改进了 coprocessor 遇到锁时的调试日志显示，TiKV 提高了插入 SST 文件的速度，PD 优化了调度器退出的速度。Bug 修复方面，TiDB 修复了多个问题，包括乐观事务冲突、MPP 查询相关日志、DML 和 DDL 语句并发执行等。TiKV 修复了多个节点停机导致的问题，PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了多个数据不一致的问题。TiCDC 修复了多个同步任务推进停滞的问题。Backup & Restore (BR) 修复了平均速度不准确的问题。Dumpling 修复了导出速度过慢的问题。
-- [TiDB 5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.0/): TiDB 5.1 版本新增了许多关键特性，包括对 MySQL 8 中的公共表表达式和动态权限的支持，以及对数据表列类型的在线变更。此外，还引入了新的统计信息类型和锁视图功能，以提升查询稳定性和性能。同时，TiDB 5.1 修复了许多 Bug，包括投影消除、列包含 NULL 值时查询结果错误等问题。这些改进和修复将提升 TiDB 的性能和稳定性。
-- [TiDB 5.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.1/): TiDB 5.1.1 发布，兼容性更改包括默认值修改和权限变更。功能增强方面新增 OIDC SSO 支持和 DAG 请求中的 `HAVING()` 函数。改进提升包括 Stale Read 成为正式功能、加快数据插入速度、稳定结果模式支持等。Bug 修复方面修复了多个问题，包括数据丢失、panic、数据不一致等。 Tools 方面也有多个修复，包括 TiCDC、Backup & Restore、TiDB Lightning。
-- [TiDB 5.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.2/): TiDB 5.1.2 发布，包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括修复多个 Bug，改进提升包括根据直方图行数触发 auto-analyze、支持动态更改 TiCDC 配置项等。Bug 修复涉及 hash 列为 ENUM 类型时 index hash join 的结果可能出错、TiKV 从 v3.x 升级至较高版本后出现 Panic 等问题。Tools 方面的改进包括 BR 修复备份数据和恢复数据时显示的平均速度数值不准确的问题、Dumpling 修复特定 MySQL 版本下导致 dump 阶段卡死的问题等。
-- [TiDB 5.1.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.1.3/): TiDB 5.1.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
-- [TiDB 5.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.4/): TiDB 5.1.4 发布日期为 2022 年 2 月 22 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括系统变量 `tidb_analyze_version` 默认值修改为 `1`，以及 TiKV 在开启 `storage.enable-ttl` 后拒绝 TiDB 请求。提升改进方面，TiDB 支持在 Range 类型分区表中对 `IN` 表达式进行分区裁剪，TiKV 升级了 proc filesystem 版本。Bug 修复方面，修复了多个 TiDB 和 TiKV 的问题，包括内存泄露、配置项不生效、panic 等。Tools 方面也有多个修复和改进，包括 TiCDC、Backup & Restore、TiDB Binlog 和 TiDB Lightning。
-- [TiDB 5.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.5/): TiDB 5.1.5 发布日期为 2022 年 12 月 28 日。此版本包含 PD 默认关闭编译 swagger server 的兼容性变更以及 TiDB、TiKV、PD、TiFlash 和 Tools 中的多项 Bug 修复。修复内容涵盖了窗口函数执行、动态模式、函数传入值计算、left join 删除数据、SQL 语句计算、连接错误、索引错误、HTTP 服务异常、并发列类型变更、空闲链接、SESSION 变量、Region 合并、KV client 连接、TiDB Binlog 错误、TiKV 运行、Raftstore 线程、Region merge、Follower Read、Async Commit、网络问题、Unified Read Pool CPU 表达式、TLS、并行聚合、查询错误、日期格式、MPP query、数据回收、逻辑运算符、备份系统表、增量扫描、Sorter 组件监控数据和 ddl schema 缓存优化。
-- [TiDB 5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.0/): TiDB 5.2 版本于 2021 年 8 月 27 日发布。该版本新增了许多功能和改进，包括支持基于部分函数创建表达式索引、提升优化器的估算准确度、锁视图成为 GA 特性等。此外，还修复了多个 bug，提升了稳定性和性能。
-- [TiDB 5.2.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.1/): TiDB 5.2.1 发布日期为 2021 年 9 月 9 日。此版本修复了 TiDB 在分区中下推聚合算子时的执行计划和执行报错问题。同时，TiKV 修复了 Region 迁移时出现的死锁导致 TiKV 不可用的问题。用户可通过关闭调度并重启出问题的 TiKV 来临时应对。
-- [TiDB 5.2.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.2/): TiDB 5.2.2 发布日期为 2021 年 10 月 29 日。此版本包含了对 TiDB、TiKV、PD 和 Tools 的多项提升改进和 bug 修复。其中 TiDB 修复了多项问题，如 `plan cache` 无法感知 `unsigned` 标志变化、分区功能出现 `out of range` 时 `partition pruning` 出错等。TiKV 修复了因 Congest 错误而导致的 CDC 频繁增加 scan 重试的问题等。PD 修复了因超过副本配置数量而导致错误删除带有数据且处于 pending 状态的副本的问题等。TiFlash 修复了在部分平台上由于缺失 `nsl` 库而无法启动的问题。Tools 中的 TiCDC 也进行了多项修复，如当上游 TiDB 实例意外退出时，TiCDC 同步任务推进可能停滞的问题等。
-- [TiDB 5.2.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.2.3/): TiDB 5.2.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
-- [TiDB 5.2.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.4/): TiDB 5.2.4 发布日期为 2022 年 4 月 26 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB、TiKV 和 Tools 的调整。提升改进主要针对 TiKV 和 Tools 进行了优化。Bug 修复方面涉及 TiDB、TiKV、PD、TiFlash 和 Tools 的修复。
-- [TiDB 5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.0/): TiDB 5.3.0 版本发布了许多重要的功能和改进，包括临时表、表属性设置、TiDB Dashboard 安全性提升、PD 时间戳处理流程优化、DM 同步性能提升、TiDB Lightning 分布式并行导入等。此外，还修复了许多 bug，提升了稳定性和性能。
-- [TiDB 5.3.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.1/): TiDB 5.3.1 发布日期为 2022 年 3 月 3 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB Lightning 工具的默认值调整。提升改进包括 TiDB、TiKV 和 PD 的优化。Bug 修复包括 TiDB、TiKV、PD、TiFlash、Backup & Restore (BR)、TiCDC、TiDB Data Migration (DM) 和 TiDB Lightning 工具的问题修复。
-- [TiDB 5.3.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.2/): TiDB 5.3.2 发布日期为 2022 年 6 月 29 日。该版本存在 bug，建议升级至 v5.3.3。兼容性变更包括修复了 auto ID 超出范围时的问题。TiKV 提升了 Raft 客户端的效率，并修复了多个 bug。TiDB 修复了多个 bug，包括 Amazon S3 数据计算错误和网络连接问题。PD 也修复了多个 bug。TiFlash 修复了存储目录配置错误和数据不一致的问题。BR 和 TiCDC 也有多个 bug 修复。DM 和 TiDB Lightning 也有 bug 修复。
-- [TiDB 5.3.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.3.3/): TiDB 5.3.3 发布日期为 2022 年 9 月 14 日。此版本修复了 TiKV 存在的 bug，该 bug 导致在执行 SQL 语句时出现持续报错的问题。影响版本为 v5.3.2 和 v5.4.2，已在 v5.3.3 上修复。如果使用 v5.3.2 的 TiDB 集群，可以升级至 v5.3.3。除升级外，还可以重启无法向 PD 发送 Region 心跳的 TiKV 节点，直至不再有待发送的 Region 心跳为止。
-- [TiDB 5.3.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.4/): TiDB 5.3.4 发布，提升了 TiKV 的自动 TLS 证书重新加载功能。修复了 TiDB、PD 和 TiFlash 的多个 bug，包括 Region 合并、权限清理、连接失败等问题。同时修复了工具 Dumpling 和 TiCDC 的导出数据和同步任务状态不正确的问题。
-- [TiDB 5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.0/): TiDB 5.4.0 版本发布日期为 2022 年 2 月 15 日。此版本新增了许多功能和改进，包括支持 GBK 字符集、索引合并、有界限过期数据读取、统计信息采集配置持久化等。同时还修复了许多 bug，提升了稳定性和性能。
-- [TiDB 5.4.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.1/): TiDB 5.4.1 发布日期为 2022 年 5 月 13 日。该版本未引入产品设计上的兼容性变化，但 Bug 修复可能带来兼容性变更。提升改进包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个方面的改进。Bug 修复方面包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个问题的修复。
-- [TiDB 5.4.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.2/): TiDB 5.4.2 发布日期为 2022 年 7 月 8 日。该版本存在 bug，建议升级至 v5.4.3。此版本提升了 TiDB、TiKV、PD 和 Tools 的稳定性和可用性，并修复了多个 bug。
-- [TiDB 5.4.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.3/): TiDB 5.4.3 发布，提升了 TiKV 和 Tools 的功能，修复了多个 Bug。包括 TiKV 支持更小的 RocksDB write stall 参数，TiDB 修复了多个查询和执行时可能出现的问题。PD 也修复了一些请求和权限问题。TiFlash 修复了一些函数和并行聚合的错误。Tools 中的 TiDB Lightning 修复了一些数据导入和连接问题，DM 修复了一些数据同步和连接问题，BR 修复了备份恢复和 Region 不均衡的问题，Dumpling 修复了 IPv6 的支持问题。
-- [TiDB 6.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.0.0-dmr/): 了解 TiDB 6.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.0/): 了解 TiDB 6.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.1/): TiDB 6.1.1 发布日期为 2022 年 9 月 1 日。该版本兼容性变更包括大小写敏感语句不再敏感，以及默认关闭持续性能分析特性。其他变更包括新增内容和不同操作系统和 CPU 架构的支持。提升改进方面，引入了新的优化器提示和支持通过 gzip 压缩 metrics 响应减少 HTTP body 大小。Bug 修复方面，修复了多个 TiDB、TiKV、PD 和 TiFlash 的问题。 Tools 方面，TiDB Lightning 修复了多个问题，TiDB Data Migration (DM) 修复了多个问题，TiCDC 修复了多个问题，Backup & Restore (BR) 修复了多个问题，Dumpling 修复了一个问题，TiDB Binlog 修复了一个问题。
-- [TiDB 6.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.2/): TiDB 6.1.2 发布，包括 TiDB、TiKV、Tools 和 Bug 修复。提升改进包括允许在一张表上同时设置数据放置规则和 TiFlash 副本。Bug 修复包括修复数据库级别的权限清理不正确的问题。
-- [TiDB 6.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.3/): TiDB 6.1.3 发布日期为 2022 年 12 月 5 日。此版本兼容性变更包括 TiCDC 的默认值修改和事务拆分功能的优化。提升改进方面，PD 优化了锁的粒度，TiCDC 默认关闭 safeMode 并开启大事务拆分功能。此外，为了提升 TiDB 稳定性，Go 编译器版本从 go1.18 升级到了 go1.19。Bug 修复方面，修复了多个 TiDB、PD、TiKV、TiFlash 和 Tools 的问题。
-- [TiDB 6.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.4/): 了解 TiDB 6.1.4 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.5/): 了解 TiDB 6.1.5 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.6/): 了解 TiDB 6.1.6 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.1.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.7/): 了解 TiDB 6.1.7 版本的改进提升与错误修复。
-- [TiDB 6.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.2.0/): 了解 TiDB 6.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.3.0/): 了解 TiDB 6.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.4.0/): 了解 TiDB 6.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.0/): 了解 TiDB 6.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.1/): 了解 TiDB 6.5.1 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.10/): 了解 TiDB 6.5.10 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.11/): 了解 TiDB 6.5.11 版本的改进提升和错误修复。
-- [TiDB 6.5.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.12/): 了解 TiDB 6.5.12 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.2/): 了解 TiDB 6.5.2 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.3/): 了解 TiDB 6.5.3 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.4/): 了解 TiDB 6.5.4 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.5/): 了解 TiDB 6.5.5 版本的改进提升与错误修复。
-- [TiDB 6.5.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.6/): 了解 TiDB 6.5.6 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.7/): 了解 TiDB 6.5.7 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.8/): 了解 TiDB 6.5.8 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.5.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.9/): 了解 TiDB 6.5.9 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 6.6.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.6.0/): 了解 TiDB 6.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.0.0/): 了解 TiDB 7.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.0/): 了解 TiDB 7.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.1/): 了解 TiDB 7.1.1 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.2/): 了解 TiDB 7.1.2 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.3/): 了解 TiDB 7.1.3 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.4/): 了解 TiDB 7.1.4 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.5/): 了解 TiDB 7.1.5 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.6/): 了解 TiDB 7.1.6 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.2.0/): 了解 TiDB 7.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.3.0/): 了解 TiDB 7.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.4.0/): 了解 TiDB 7.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.0/): 了解 TiDB 7.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.1/): 了解 TiDB 7.5.1 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.2/): 了解 TiDB 7.5.2 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.3/): 了解 TiDB 7.5.3 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.4/): 了解 TiDB 7.5.4 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.5/): 了解 TiDB 7.5.5 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.5.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.6/): 了解 TiDB 7.5.6 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 7.6.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.6.0/): 了解 TiDB 7.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.0.0/): 了解 TiDB 8.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.0/): 了解 TiDB 8.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.1/): 了解 TiDB 8.1.1 版本的兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.2/): 了解 TiDB 8.1.2 版本的改进提升和错误修复。
-- [TiDB 8.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.2.0/): 了解 TiDB 8.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.3.0/): 了解 TiDB 8.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.4.0/): 了解 TiDB 8.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.5.0/): 了解 TiDB 8.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
-- [TiDB 8.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.5.1/): 了解 TiDB 8.5.1 版本的操作系统支持变更、改进提升，以及错误修复。
-- [TiDB Control 使用说明](https://docs.pingcap.com/tidb/stable/tidb-control/): TiDB Control 是 TiDB 的命令行工具，用于获取 TiDB 状态信息和调试。可通过 TiUP 安装或从源代码编译安装。使用介绍包括命令、选项和参数组成，以及全局参数和各子命令的功能。其中包括获取帮助信息、解码 base64 数据、解码 row key 和 value、操作 etcd、格式化日志文件，以及查询关键 key range 信息。注意：TiDB Control 主要用于诊断调试，不保证和 TiDB 未来引入的新特性完全兼容。
-- [TiDB Dashboard SQL 语句分析列表页面](https://docs.pingcap.com/tidb/stable/dashboard-statement-list/): 查看所有 SQL 语句在集群上执行情况
-- [TiDB Dashboard SQL 语句分析执行详情页面](https://docs.pingcap.com/tidb/stable/dashboard-statement-details/): 查看单个 SQL 语句执行的详细情况
-- [TiDB Dashboard Top SQL 页面](https://docs.pingcap.com/tidb/stable/top-sql/): 使用 Top SQL 找到 CPU 开销较大的 SQL 语句
-- [TiDB Dashboard 介绍](https://docs.pingcap.com/tidb/stable/dashboard-intro/): TiDB Dashboard 是 TiDB 4.0 版本后提供的图形化界面，用于监控和诊断集群。它内置于 TiDB 的 PD 组件中，无需独立部署。可以查看集群整体运行概况、组件及主机运行状态、集群读写流量分布、SQL 查询的执行信息、耗时较长的 SQL 语句执行信息、诊断集群问题并生成报告、查询所有组件日志、预估资源管控容量、收集分析各个组件的性能数据。
-- [TiDB Dashboard 实例性能分析 - 手动分析页面](https://docs.pingcap.com/tidb/stable/dashboard-profiling/): 了解如何收集集群各个实例当前性能数据，从而分析复杂问题
-- [TiDB Dashboard 实例性能分析 - 持续分析页面](https://docs.pingcap.com/tidb/stable/continuous-profiling/): 了解如何持续地收集 TiDB、TiKV、PD 各个实例的性能数据，缩短平均故障恢复时间
-- [TiDB Dashboard 常见问题](https://docs.pingcap.com/tidb/stable/dashboard-faq/): TiDB Dashboard 常见问题汇总，包括访问、界面功能方面的常见问题与解决办法。若无法解决，请获取官方或社区支持。
-- [TiDB Dashboard 慢查询页面](https://docs.pingcap.com/tidb/stable/dashboard-slow-query/): 了解如何在 TiDB Dashboard 中查看慢查询。
-- [TiDB Dashboard 日志搜索页面](https://docs.pingcap.com/tidb/stable/dashboard-log-search/): 在集群中搜索所有节点上的日志
-- [TiDB Dashboard 概况页面](https://docs.pingcap.com/tidb/stable/dashboard-overview/): TiDB Dashboard 概况页面显示整个集群的 QPS、查询延迟、Top SQL 语句、最近的慢查询、实例状态和监控及告警信息。登录后默认进入该页面，也可通过左侧导航条点击概况进入。包含最近一小时整个集群的 QPS 和查询延迟，以及最近一段时间内累计耗时最多的 SQL 语句和运行时间超过一定阈值的慢查询。还显示各个实例的节点数和状态，以及提供了便捷的链接方便用户查看详细监控或告警。
-- [TiDB Dashboard 流量可视化页面](https://docs.pingcap.com/tidb/stable/dashboard-key-visualizer/): TiDB Dashboard 的流量可视化页面可用于分析 TiDB 集群的使用模式和排查流量热点。通过登录 TiDB Dashboard 或在浏览器中访问指定链接，可以查看流量可视化页面。页面展示了流量热力图，可观察到整体访问流量随时间的变化情况，以及热力图某个坐标的详细信息。流量可视化页面涉及的基本概念包括 Region、热点、热力图和 Region 压缩。使用介绍包括设置、观察时间段或 Region 范围、调整亮度、选择指标、刷新与自动刷新以及查看详情。常见热力图解读包括均衡结果、X 轴明暗交替、Y 轴明暗交替和明亮斜线。解决热点问题可参考 TiDB 高并发写入场景最佳实践。
-- [TiDB Dashboard 用户管理](https://docs.pingcap.com/tidb/stable/dashboard-user/): 了解如何创建 SQL 用户用于访问 TiDB Dashboard
-- [TiDB Dashboard 监控关系图](https://docs.pingcap.com/tidb/stable/dashboard-metrics-relation/): 了解 TiDB Dashboard 监控关系图
-- [TiDB Dashboard 监控页面](https://docs.pingcap.com/tidb/stable/dashboard-monitoring/): 介绍如何通过 TiDB Dashboard 监控页面查看 Performance Overview 面板，以及如何理解面板上的关键指标项。
-- [TiDB Dashboard 诊断报告](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-report/): TiDB Dashboard 诊断报告介绍了诊断报告的内容和查看技巧。报告包括基本信息、诊断信息、负载信息、概览信息、TiDB/PD/TiKV 监控信息和配置信息。对比报告显示两个时间段的差异，通过 DIFF_RATIO 和 Maximum Different Item 报表可以快速发现监控项的差异。
-- [TiDB Dashboard 资源管控页面](https://docs.pingcap.com/tidb/stable/dashboard-resource-manager/): 介绍如何使用 TiDB Dashboard 的资源管控页面查看资源管控相关信息，以便预估集群容量，更好地进行资源配置。
-- [TiDB Dashboard 集群信息页面](https://docs.pingcap.com/tidb/stable/dashboard-cluster-info/): 查看整个集群中 TiDB、TiKV、PD、TiFlash 组件的运行状态及其所在主机的运行状态
-- [TiDB Dashboard 集群诊断页面](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-access/): TiDB Dashboard 集群诊断页面是用于诊断集群问题并生成诊断报告的工具。可以通过 TiDB Dashboard 或浏览器访问诊断页面。生成诊断报告的步骤包括设置时间范围和长度，然后点击开始。还可以生成对比报告来比较异常时间段和正常时间段的情况。已生成的报告会显示在主页列表中，可随时查看。
-- [TiDB Data Migration 1.0.x 到 2.0+ 手动升级](https://docs.pingcap.com/tidb/stable/manually-upgrade-dm-1.0-to-2.0/): 了解如何从 TiDB Data Migration 1.0.x 手动升级到 2.0+。
-- [TiDB Data Migration Binlog 事件过滤](https://docs.pingcap.com/tidb/stable/dm-binlog-event-filter/): 了解 DM 的关键特性 binlog 事件过滤 (Binlog event filter) 的使用方法和注意事项。
-- [TiDB Data Migration 上游数据库配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-source-configuration-file/): TiDB Data Migration (DM) 上游数据库配置文件包括示例与配置项说明。示例配置文件包括上游数据库的配置项，如是否开启 GTID、是否开启 relay log、拉取上游 binlog 的起始文件名等。配置项说明包括全局配置、relay log 清理策略配置、任务状态检查配置和 Binlog event filter。配置项包括标识一个 MySQL 实例、是否使用 GTID 方式、是否开启 relay log、存储 relay log 的目录等。从 DM v2.0.2 开始，Binlog event filter 也可以在上游数据库配置文件中进行配置。
-- [TiDB Data Migration 任务前置检查](https://docs.pingcap.com/tidb/stable/dm-precheck/): 了解 DM 执行数据迁移任务时将进行的前置检查。
-- [TiDB Data Migration 兼容性目录](https://docs.pingcap.com/tidb/stable/dm-compatibility-catalog/): 了解 DM 各版本与上下游各类型数据库的兼容关系
-- [TiDB Data Migration 分库分表合并](https://docs.pingcap.com/tidb/stable/dm-shard-merge/): 了解 DM 的分库分表合并功能。
-- [TiDB Data Migration 命令行参数](https://docs.pingcap.com/tidb/stable/dm-command-line-flags/): 介绍 DM 各组件的主要命令行参数。
-- [TiDB Data Migration 处理告警](https://docs.pingcap.com/tidb/stable/dm-handle-alerts/): 了解 DM 中各主要告警信息的处理方法。
-- [TiDB Data Migration 对 online DDL 工具的支持](https://docs.pingcap.com/tidb/stable/dm-online-ddl-tool-support/): 了解 DM 对常见 online DDL 工具的支持情况，使用方法和注意事项。
-- [TiDB Data Migration 导出和导入集群的数据源和任务配置](https://docs.pingcap.com/tidb/stable/dm-export-import-config/): 了解 TiDB Data Migration 导出和导入集群的数据源和任务配置。
-- [TiDB Data Migration 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-dm/): 了解如何使用 TiUP Playground 快速部署试用 TiDB Data Migration 数据迁移工具。
-- [TiDB Data Migration 性能问题及处理方法](https://docs.pingcap.com/tidb/stable/dm-handle-performance-issues/): 了解 DM 可能存在的常见性能问题及其处理方法。
-- [TiDB Data Migration 故障及处理方法](https://docs.pingcap.com/tidb/stable/dm-error-handling/): 了解 DM 的错误系统及常见故障的处理方法。
-- [TiDB Data Migration 数据迁移任务配置向导](https://docs.pingcap.com/tidb/stable/dm-task-configuration-guide/): 本文介绍了如何配置 TiDB Data Migration (DM) 的数据迁移任务。包括配置数据源、目标 TiDB 集群、需要迁移的表、需要过滤的操作、数据源表到目标 TiDB 表的映射以及分库分表合并等配置。详细配置规则可参考相关链接。
-- [TiDB Data Migration 日常巡检](https://docs.pingcap.com/tidb/stable/dm-daily-check/): 了解 DM 工具的日常巡检。
-- [TiDB Data Migration 术语表](https://docs.pingcap.com/tidb/stable/dm-glossary/): 学习 TiDB Data Migration 相关术语
-- [TiDB Data Migration 查询任务状态](https://docs.pingcap.com/tidb/stable/dm-query-status/): 深入了解 TiDB Data Migration 如何查询数据迁移任务状态
-- [TiDB Data Migration 版本发布历史](https://docs.pingcap.com/tidb/stable/dm-release-notes/): TiDB Data Migration 版本发布历史从 DM v5.4.0 起，TiDB Data Migration 的 Release Notes 合并入相同版本号的 TiDB Release Notes。如需阅读 v5.4.0 及之后版本的 DM Release Notes，请查看对应版本的 TiDB Release Notes 中 DM 相关的内容。如需阅读 v5.3.0 及更早版本的 DM Release Notes，请参考以下链接：5.3.0, 2.0.7, 2.0.6, 2.0.5, 2.0.4, 2.0.3, 2.0.2, 2.0.1, 2.0 GA, 2.0.0-rc.2, 2.0.0-rc, 1.0.7, 1.0.6, 1.0.5, 1.0.4, 1.0.3, 1.0.2.
-- [TiDB Data Migration 生成自签名证书](https://docs.pingcap.com/tidb/stable/dm-generate-self-signed-certificates/): 了解如何生成自签名证书。
-- [TiDB Data Migration 简介](https://docs.pingcap.com/tidb/stable/dm-overview/): 了解 TiDB Data Migration
-- [TiDB Data Migration 表路由](https://docs.pingcap.com/tidb/stable/dm-table-routing/): 了解 DM 的关键特性表路由 (Table Routing) 的使用方法和注意事项。
-- [TiDB Data Migration 集群软硬件环境需求](https://docs.pingcap.com/tidb/stable/dm-hardware-and-software-requirements/): 了解部署 DM 集群的软件和硬件要求。
-- [TiDB Data Migration 黑白名单过滤](https://docs.pingcap.com/tidb/stable/dm-block-allow-table-lists/): 了解 DM 的关键特性黑白名单过滤 (Block & Allow List) 的使用方法和注意事项。
-- [TiDB Lightning Web 界面](https://docs.pingcap.com/tidb/stable/tidb-lightning-web-interface/): 了解 TiDB Lightning 的服务器模式——通过 Web 界面来控制 TiDB Lightning。
-- [TiDB Lightning 前置检查](https://docs.pingcap.com/tidb/stable/tidb-lightning-prechecks/): 本文档介绍了 TiDB Lightning 前置检查功能，确保 TiDB Lightning 能够顺利执行任务。
-- [TiDB Lightning 命令行参数](https://docs.pingcap.com/tidb/stable/tidb-lightning-command-line-full/): 使用命令行配置 TiDB Lightning。
-- [TiDB Lightning 常见问题](https://docs.pingcap.com/tidb/stable/tidb-lightning-faq/): TiDB Lightning 常见问题的摘要：TiDB Lightning 对TiDB/TiKV/PD 的最低版本要求，支持导入多个库，对下游数据库的账号权限要求，导数据过程中某个表报错不会影响其他表，正确重启 TiDB Lightning 的步骤，校验导入数据的正确性方法，支持的数据源格式，禁止导入不合规数据的方法，结束 tidb-lightning 进程的操作，使用千兆网卡的建议，TiDB Lightning 预留空间的原因，清除与 TiDB Lightning 相关的中间数据的步骤，获取 TiDB Lightning 运行时的 goroutine 信息的方法，TiDB Lightning 不兼容 Placement Rules in SQL 的原因，使用 TiDB Lightning 和 Dumpling 复制 schema 的步骤。
-- [TiDB Lightning 并行导入](https://docs.pingcap.com/tidb/stable/tidb-lightning-distributed-import/): 本文档介绍了 TiDB Lightning 并行导入的概念、使用场景和使用方法。
-- [TiDB Lightning 快速上手](https://docs.pingcap.com/tidb/stable/get-started-with-tidb-lightning/): TiDB Lightning 可快速将 MySQL 数据导入到 TiDB 集群中。首先使用 Dumpling 导出数据，然后部署 TiDB 集群。安装最新版本的 TiDB Lightning 并启动，最后检查数据导入情况。详细功能和使用请参考 TiDB Lightning 简介。
-- [TiDB Lightning 故障处理](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-lightning/): 本文档总结了使用 TiDB Lightning 过程中常见的运行故障及解决方案。
-- [TiDB Lightning 数据源](https://docs.pingcap.com/tidb/stable/tidb-lightning-data-source/): 了解 TiDB Lightning 支持的各类型数据源。
-- [TiDB Lightning 断点续传](https://docs.pingcap.com/tidb/stable/tidb-lightning-checkpoints/): TiDB Lightning 提供了“断点续传”的功能，即使 `tidb-lightning` 崩溃，在重启时仍然接着之前的进度继续工作。断点续传可通过配置启用，存储方式包括本地文件和 MySQL 数据库。在出现不可恢复的错误时，可以使用 `tidb-lightning-ctl` 工具来控制断点的处理，包括重置断点状态、清除出错状态和移除断点。
-- [TiDB Lightning 术语表](https://docs.pingcap.com/tidb/stable/tidb-lightning-glossary/): 了解 TiDB Lightning 相关的术语及定义。
-- [TiDB Lightning 监控告警](https://docs.pingcap.com/tidb/stable/monitor-tidb-lightning/): TiDB Lightning 支持使用Prometheus采集监控指标。监控配置需手动部署，配置方法在 tidb-lightning.toml 中。Grafana 面板可用于监控速度、进度、资源使用和存储空间。监控指标包括计数器和直方图，用于计算引擎文件数量、闲置 worker、KV 编码器、处理过的表、引擎文件和 Chunks的状态，以及导入每个表所需时间等。
-- [TiDB Lightning 目标数据库要求](https://docs.pingcap.com/tidb/stable/tidb-lightning-requirements/): 了解 TiDB Lightning 运行时对目标数据库的必需条件。
-- [TiDB Lightning 简介](https://docs.pingcap.com/tidb/stable/tidb-lightning-overview/): TiDB Lightning 是用于导入 TB 级数据到 TiDB 的工具。了解 TiDB Lightning 的基本原理和使用方法。
-- [TiDB Lightning 配置参数](https://docs.pingcap.com/tidb/stable/tidb-lightning-configuration/): 使用配置文件或命令行配置 TiDB Lightning。
-- [TiDB Lightning 错误处理功能](https://docs.pingcap.com/tidb/stable/tidb-lightning-error-resolution/): 介绍了如何解决导入数据过程中的类型转换和冲突错误。
-- [TiDB OOM 故障排查](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-oom/): TiDB OOM 故障排查总结了 OOM 常见问题的解决思路、故障现象、原因、解决方法和需要收集的诊断信息。排查思路包括确认是否属于 OOM 问题和进一步排查触发 OOM 的原因。常见故障原因包括部署问题、数据库问题和客户端问题。处理 OOM 问题需要收集操作系统内存配置、数据库版本和内存配置、Grafana TiDB 内存使用情况等信息。详细排查方法请参考相关章节。
-- [TiDB Operator](https://docs.pingcap.com/tidb/stable/tidb-operator-overview/): 了解 Kubernetes 上的 TiDB 集群自动部署运维工具 TiDB Operator。
-- [TiDB Pre-GA Release Notes](https://docs.pingcap.com/tidb/stable/release-pre-ga/): TiDB Pre-GA 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 改进了 SQL 查询优化器、大量 MySQL 兼容性相关功能、支持 Natural Join、JSON 类型支持、裁剪无用数据、支持在 SQL 语句中设置优先级、完成表达式重构。PD 支持手动切换 PD 集群 Leader。TiKV 改进了 Raft Log 使用独立的 RocksDB 实例、使用 DeleteRange 加快删除副本速度、Coprocessor 支持更多运算符下推、提升性能和稳定性。TiSpark Beta Release 支持谓词下推、支持聚合下推、支持范围裁剪。
-- [TiDB RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.1/): TiDB RC1 于 2016 年 12 月 23 日发布，TiKV 提升了写入速度和稳定性，支持百 TB 级别数据，集群规模支持 200 个节点。PD 优化了调度策略框架，添加了 label 支持，提供了 PD Control。TiDB 新增了 SQL 查询优化器和更多 MySQL 内建函数，重构了 time 相关类型的实现，提升了和 MySQL 的兼容性。工具方面，Loader 兼容 Percona 的 Mydumper 数据格式，提供了多线程导入、出错重试、断点续传等功能，并且针对 TiDB 有优化。完成了一键部署工具。
-- [TiDB RC2 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.2/): TiDB RC2 版本发布，提升了 MySQL 兼容性、SQL 优化器、系统稳定性和性能。对于 OLTP 场景，读取性能提升 60%，写入性能提升 30%。新增权限管理功能，支持基本权限管理和大量 MySQL 内建函数。完善监控，修复 Bug 和内存泄漏问题。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，支持更多下推功能，加入更多统计，修复 Bug。
-- [TiDB RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.3/): TiDB RC3 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了负载均衡调度策略和流程，完善权限管理功能，DDL 速度显著提升。开源了 TiDB Ansible 项目，可以一键部署 / 升级 / 启停 TiDB 集群。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，修复 Bug。
-- [TiDB RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.4/): TiDB RC4 版本对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了写入速度，计算任务调度支持优先级，避免分析型大事务影响在线事务。SQL 优化器全新改版，查询代价估算更准确，且能自动选择 Join 物理算子。功能方面进一步 MySQL 兼容性。同时开源了 TiSpark 项目，可以通过 Spark 读取和分析 TiKV 中的数据。PD 支持通过 PD 设置 TiKV location labels，调度优化，优化数据加载，加快 failover 速度。 TiKV 支持查询优先级设置，支持 RC 隔离级别，完善 Jepsen，支持 Document Store，提升性能，提升稳定性。TiSpark Beta Release 支持谓词下推，支持聚合下推，支持范围裁剪。
+- [Scheduling 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-scheduling-configuration.md): Scheduling 配置参数可以通过命令行参数或环境变量配置。
+- [Scheduling 配置文件描述](https://docs.pingcap.com/tidb/stable/scheduling-configuration-file.md): Scheduling 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
+- [Schema 对象名](https://docs.pingcap.com/tidb/stable/schema-object-names.md): 本文介绍 TiDB SQL 语句中的模式对象名。
+- [Schema 缓存](https://docs.pingcap.com/tidb/stable/schema-cache.md): TiDB 对于 schema 信息采用基于 LRU 的缓存机制，在大量数据库和表的场景下能够显著减少 schema 信息的内存占用以及提高性能。
+- [schema_unused_indexes](https://docs.pingcap.com/tidb/stable/sys-schema-unused-indexes.md): 了解 TiDB `sys` 系统数据库中的 `schema_unused_indexes` 表。
+- [SCHEMATA](https://docs.pingcap.com/tidb/stable/information-schema-schemata.md): 了解 information_schema 表 `SCHEMATA`。
+- [SELECT](https://docs.pingcap.com/tidb/stable/sql-statement-select.md): TiDB 数据库中 SELECT 的使用概况。
+- [SEQUENCES](https://docs.pingcap.com/tidb/stable/information-schema-sequences.md): 了解 INFORMATION_SCHEMA 表 `SEQUENCES`。
+- [SESSION_CONNECT_ATTRS](https://docs.pingcap.com/tidb/stable/performance-schema-session-connect-attrs.md): 了解 performance_schema 表 `SESSION_CONNECT_ATTRS`。
+- [SESSION_VARIABLES](https://docs.pingcap.com/tidb/stable/information-schema-session-variables.md): 了解 INFORMATION_SCHEMA 表 `SESSION_VARIABLES`。
+- [SET [GLOBAL|SESSION] <variable>](https://docs.pingcap.com/tidb/stable/sql-statement-set-variable.md): TiDB 数据库中 SET [GLOBAL|SESSION] <variable> 的使用概况。
+- [SET [NAMES|CHARACTER SET]](https://docs.pingcap.com/tidb/stable/sql-statement-set-names.md): TiDB 数据库中 SET [NAMES|CHARACTER SET] 的使用概况。
+- [SET DEFAULT ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-set-default-role.md): TiDB 数据库中 SET DEFAULT ROLE 的使用概况。
+- [SET PASSWORD](https://docs.pingcap.com/tidb/stable/sql-statement-set-password.md): TiDB 数据库中 SET PASSWORD 的使用概况。
+- [SET RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-set-resource-group.md): TiDB 数据库中 SET RESOURCE GROUP 的使用概况。
+- [SET ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-set-role.md): TiDB 数据库中 SET ROLE 的使用概况。
+- [SET TRANSACTION](https://docs.pingcap.com/tidb/stable/sql-statement-set-transaction.md): TiDB 数据库中 SET TRANSACTION 的使用概况。
+- [SHARD_ROW_ID_BITS](https://docs.pingcap.com/tidb/stable/shard-row-id-bits.md): 介绍 TiDB 的 `SHARD_ROW_ID_BITS` 表属性。
+- [SHOW [BACKUPS|RESTORES]](https://docs.pingcap.com/tidb/stable/sql-statement-show-backups.md): TiDB 数据库中 SHOW [BACKUPS|RESTORES] 的使用概况。
+- [SHOW [FULL] COLUMNS FROM](https://docs.pingcap.com/tidb/stable/sql-statement-show-columns-from.md): TiDB 数据库中 SHOW [FULL] COLUMNS FROM 的使用概况。
+- [SHOW [FULL] FIELDS FROM](https://docs.pingcap.com/tidb/stable/sql-statement-show-fields-from.md): TiDB 数据库中 SHOW [FULL] FIELDS FROM 的使用概况。
+- [SHOW [FULL] PROCESSLIST](https://docs.pingcap.com/tidb/stable/sql-statement-show-processlist.md): TiDB 数据库中 SHOW [FULL] PROCESSLIST 的使用概况。
+- [SHOW [FULL] TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-show-tables.md): TiDB 数据库中 SHOW [FULL] TABLES 的使用概况。
+- [SHOW [GLOBAL|SESSION] BINDINGS](https://docs.pingcap.com/tidb/stable/sql-statement-show-bindings.md): TiDB 数据库中 SHOW [GLOBAL|SESSION] BINDINGS 的使用概况。
+- [SHOW [GLOBAL|SESSION] STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-status.md): TiDB 数据库中 SHOW [GLOBAL|SESSION] STATUS 的使用概况。
+- [SHOW [GLOBAL|SESSION] VARIABLES](https://docs.pingcap.com/tidb/stable/sql-statement-show-variables.md): TiDB 数据库中 SHOW [GLOBAL|SESSION] VARIABLES 的使用概况。
+- [SHOW ANALYZE STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-analyze-status.md): TiDB 数据库中 SHOW ANALYZE STATUS 的使用概况。
+- [SHOW BUILTINS](https://docs.pingcap.com/tidb/stable/sql-statement-show-builtins.md): TiDB 数据库中 SHOW BUILTINS 的使用概况。
+- [SHOW CHARACTER SET](https://docs.pingcap.com/tidb/stable/sql-statement-show-character-set.md): TiDB 数据库中 SHOW CHARACTER SET 的使用概况。
+- [SHOW COLLATION](https://docs.pingcap.com/tidb/stable/sql-statement-show-collation.md): TiDB 数据库中 SHOW COLLATION 的使用概况。
+- [SHOW COLUMN_STATS_USAGE](https://docs.pingcap.com/tidb/stable/sql-statement-show-column-stats-usage.md): TiDB 数据库中 SHOW COLUMN_STATS_USAGE 的使用概况。
+- [SHOW CONFIG](https://docs.pingcap.com/tidb/stable/sql-statement-show-config.md): TiDB 数据库中 SHOW CONFIG 的使用概况。
+- [SHOW CREATE DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-database.md): TiDB 数据库中 SHOW CREATE DATABASE 的使用概况。
+- [SHOW CREATE PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-placement-policy.md): TiDB 数据库中 SHOW CREATE PLACEMENT POLICY 的使用概况。
+- [SHOW CREATE RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-resource-group.md): TiDB 数据库中 SHOW CREATE RESOURCE GROUP 的使用概况。
+- [SHOW CREATE SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-sequence.md): TiDB 数据库中 SHOW CREATE SEQUENCE 的使用概况。
+- [SHOW CREATE TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-table.md): TiDB 数据库中 SHOW CREATE TABLE 的使用概况。
+- [SHOW CREATE USER](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-user.md): TiDB 数据库中 SHOW CREATE USER 的使用概况。
+- [SHOW DATABASES](https://docs.pingcap.com/tidb/stable/sql-statement-show-databases.md): TiDB 数据库中 SHOW DATABASES 的使用概况。
+- [SHOW ENGINES](https://docs.pingcap.com/tidb/stable/sql-statement-show-engines.md): TiDB 数据库中 SHOW ENGINES 的使用概况。
+- [SHOW ERRORS](https://docs.pingcap.com/tidb/stable/sql-statement-show-errors.md): TiDB 数据库中 SHOW ERRORS 的使用概况。
+- [SHOW GRANTS](https://docs.pingcap.com/tidb/stable/sql-statement-show-grants.md): TiDB 数据库中 SHOW GRANTS 的使用概况。
+- [SHOW IMPORT](https://docs.pingcap.com/tidb/stable/sql-statement-show-import-job.md): TiDB 数据库中 SHOW IMPORT 的使用概况。
+- [SHOW INDEXES [FROM|IN]](https://docs.pingcap.com/tidb/stable/sql-statement-show-indexes.md): TiDB 数据库中 SHOW INDEXES [FROM|IN] 的使用概况。
+- [SHOW MASTER STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-master-status.md): TiDB 数据库中 SHOW MASTER STATUS 的使用概况。
+- [SHOW PLACEMENT](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement.md): TiDB 数据库中 SHOW PLACEMENT 的使用概况。
+- [SHOW PLACEMENT FOR](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-for.md): TiDB 数据库中 SHOW PLACEMENT FOR 的使用概况。
+- [SHOW PLACEMENT LABELS](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-labels.md): TiDB 数据库中 SHOW PLACEMENT LABELS 的使用概况。
+- [SHOW PLUGINS](https://docs.pingcap.com/tidb/stable/sql-statement-show-plugins.md): TiDB 数据库中 SHOW PLUGINS 的使用概况。
+- [SHOW PRIVILEGES](https://docs.pingcap.com/tidb/stable/sql-statement-show-privileges.md): TiDB 数据库中 SHOW PRIVILEGES 的使用概况。
+- [SHOW PROFILES](https://docs.pingcap.com/tidb/stable/sql-statement-show-profiles.md): TiDB 数据库中 SHOW PROFILES 的使用概况。
+- [SHOW SCHEMAS](https://docs.pingcap.com/tidb/stable/sql-statement-show-schemas.md): TiDB 数据库中 SHOW SCHEMAS 的使用概况。
+- [SHOW STATS_BUCKETS](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-buckets.md): TiDB 数据库中 SHOW STATS_BUCKETS 的使用概况。
+- [SHOW STATS_HEALTHY](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-healthy.md): TiDB 数据库中 SHOW STATS_HEALTHY 的使用概况。
+- [SHOW STATS_HISTOGRAMS](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-histograms.md): TiDB 数据库中 SHOW STATS_HISTOGRAMS 语句的简单说明。
+- [SHOW STATS_LOCKED](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-locked.md): TiDB 数据库中 SHOW STATS_LOCKED 的使用概况。
+- [SHOW STATS_META](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-meta.md): TiDB 数据库中 SHOW STATS_META 语句的简单说明。
+- [SHOW STATS_TOPN](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-topn.md): TiDB 数据库中 SHOW STATS_TOPN 的使用概况。
+- [SHOW TABLE NEXT_ROW_ID](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-next-rowid.md): TiDB 数据库中 SHOW TABLE NEXT_ROW_ID 的使用概况。
+- [SHOW TABLE REGIONS](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-regions.md): 了解如何使用 TiDB 数据库中的 SHOW TABLE REGIONS。
+- [SHOW TABLE STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-status.md): TiDB 数据库中 SHOW TABLE STATUS 的使用概况。
+- [SHOW WARNINGS](https://docs.pingcap.com/tidb/stable/sql-statement-show-warnings.md): TiDB 数据库中 SHOW WARNINGS 的使用概况。
+- [SHUTDOWN](https://docs.pingcap.com/tidb/stable/sql-statement-shutdown.md): TiDB 数据库中 SHUTDOWN 的使用概况。
+- [SLOW_QUERY](https://docs.pingcap.com/tidb/stable/information-schema-slow-query.md): 了解 INFORMATION_SCHEMA 表 `SLOW_QUERY`。
+- [Split Region 使用文档](https://docs.pingcap.com/tidb/stable/sql-statement-split-region.md): TiDB 中的 Split Region 功能可以解决表数据超过默认 Region 大小限制后的热点问题。预切分 Region 可以根据指定的参数，预先为某个表切分出多个 Region，并打散到各个 TiKV 上去。使用 `SPLIT` 语句可以实现均匀切分和不均匀切分，返回结果包括新增预切分的 Region 数量和打散完成的比率。需要注意 `tidb_wait_split_region_finish` 和 `tidb_wait_split_region_timeout` 会影响 `SPLIT` 语句的行为。
+- [SQL 优化流程简介](https://docs.pingcap.com/tidb/stable/sql-optimization-concepts.md): TiDB 中的 SQL 优化流程包括查询文本解析、逻辑等价变化和最终执行计划生成。经过 parser 解析和合法性验证后，TiDB 会对查询进行逻辑上的等价变化，使得查询在逻辑执行计划上更易处理。之后根据数据分布和执行开销生成最终执行计划。同时，TiDB 在执行 PREPARE 语句时可以选择开启缓存来降低执行计划生成的开销。
+- [SQL 基本操作](https://docs.pingcap.com/tidb/stable/basic-sql-operations.md): TiDB 是一个兼容 MySQL 的数据库，可以执行 DDL、DML、DQL 和 DCL 操作。可以使用 SHOW DATABASES 查看数据库列表，使用 CREATE DATABASE 创建数据库，使用 DROP DATABASE 删除数据库。使用 CREATE TABLE 创建表，使用 SHOW CREATE TABLE 查看建表语句，使用 DROP TABLE 删除表。使用 CREATE INDEX 创建索引，使用 SHOW INDEX 查看表内所有索引，使用 DROP INDEX 删除索引。使用 INSERT 向表内插入记录，使用 UPDATE 修改记录，使用 DELETE 删除记录。使用 SELECT 检索表内数据，使用 WHERE 子句进行筛选。使用 CREATE USER 创建用户，使用 GRANT 授权用户，使用 DROP USER 删除用户。
+- [SQL 开发规范](https://docs.pingcap.com/tidb/stable/dev-guide-sql-development-specification.md): TiDB 的 SQL 开发规范。
+- [SQL 性能调优](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql.md): 介绍 TiDB 的 SQL 性能调优方案和分析办法。
+- [SQL 性能调优](https://docs.pingcap.com/tidb/stable/sql-tuning-overview.md): SQL 性能调优是重要的，TiDB 会优化 SQL 语句的执行，以最省时的方式返回结果。这个过程类似于 GPS 导航，利用统计信息和实时交通信息规划最佳路线。了解 TiDB 执行计划、SQL 优化流程和控制执行计划可以帮助提高查询性能。
+- [SQL 或事务问题](https://docs.pingcap.com/tidb/stable/dev-guide-troubleshoot-overview.md): 学习诊断在应用开发过程中可能产生的 SQL 或事务问题的方法。
+- [SQL 操作常见问题](https://docs.pingcap.com/tidb/stable/sql-faq.md): 介绍 SQL 操作相关的常见问题。
+- [SQL 模式](https://docs.pingcap.com/tidb/stable/sql-mode.md): TiDB 服务器采用不同 SQL 模式来操作，可以使用 `SET [SESSION | GLOBAL] sql_mode='modes'` 语句设置 SQL 模式。`GLOBAL` 级别的 SQL 模式需要 `SUPER` 权限，影响新连接；`SESSION` 级别的 SQL 模式只影响当前客户端。重要的 sql_mode 值包括 `ANSI`、`STRICT_TRANS_TABLES` 和 `TRADITIONAL`。SQL mode 列表包括 `PIPES_AS_CONCAT`、`ANSI_QUOTES`、`IGNORE_SPACE`、`ONLY_FULL_GROUP_BY` 等。
+- [SQL 诊断](https://docs.pingcap.com/tidb/stable/information-schema-sql-diagnostics.md): 了解 SQL 诊断功能。
+- [SQL 语句概述](https://docs.pingcap.com/tidb/stable/sql-statement-overview.md): 介绍 TiDB 支持的 SQL 语句。
+- [Stale Read](https://docs.pingcap.com/tidb/stable/dev-guide-use-stale-read.md): 使用 Stale Read 在特定情况下加速查询。
+- [Stale Read 功能的使用场景](https://docs.pingcap.com/tidb/stable/stale-read.md): 介绍 Stale Read 功能和使用场景。
+- [START TRANSACTION](https://docs.pingcap.com/tidb/stable/sql-statement-start-transaction.md): TiDB 数据库中 START TRANSACTION 的使用概况。
+- [Statement Summary Tables](https://docs.pingcap.com/tidb/stable/statement-summary-tables.md): MySQL 的 `performance_schema` 提供了 `statement summary tables`，用于监控和统计 SQL 性能。TiDB 在 `information_schema` 中提供了类似功能的系统表，包括 `statements_summary`、`statements_summary_history`、`cluster_statements_summary` 和 `cluster_statements_summary_history`。这些表用于保存 SQL 监控指标聚合后的结果，帮助用户定位 SQL 问题。同时，还提供了参数配置来控制 statement summary 的功能，如清空周期、保存历史的数量等。
+- [STATISTICS](https://docs.pingcap.com/tidb/stable/information-schema-statistics.md): 了解 information_schema 表 `STATISTICS`。
+- [Storage sink 消费程序开发指引](https://docs.pingcap.com/tidb/stable/ticdc-storage-consumer-dev-guide.md): 了解如何设计与实现一个消费程序来消费 storage sink 中的变更数据。
+- [Store Limit](https://docs.pingcap.com/tidb/stable/configure-store-limit.md): 介绍 Store Limit 功能。
+- [sync-diff-inspector 用户文档](https://docs.pingcap.com/tidb/stable/sync-diff-inspector-overview.md): sync-diff-inspector 是一个用于校验 MySQL/TiDB 中数据一致性的工具，提供修复数据的功能。它支持对比表结构和数据，生成用于修复数据的 SQL 语句。需要注意的是，在校验数据时会消耗一定的服务器资源，需要避免在业务高峰期间校验。生成的 SQL 文件仅作为修复数据的参考，需要确认后再执行这些 SQL 修复数据。
+- [sys Schema](https://docs.pingcap.com/tidb/stable/sys-schema.md): 了解 TiDB `sys` 系统数据库。
+- [TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-table.md): TiDB 数据库中 TABLE 语句的使用概况。
+- [TABLE_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-table-constraints.md): 了解 information_schema 表 `TABLE_CONSTRAINTS`。
+- [TABLE_STORAGE_STATS](https://docs.pingcap.com/tidb/stable/information-schema-table-storage-stats.md): 了解 INFORMATION_SCHEMA 表 `TABLE_STORAGE_STATS`。
+- [TABLES](https://docs.pingcap.com/tidb/stable/information-schema-tables.md): 了解 information_schema 表 `TABLES`。
+- [TiCDC Avro Protocol](https://docs.pingcap.com/tidb/stable/ticdc-avro-protocol.md): 了解 TiCDC Avro Protocol 的概念和使用方法。
+- [TiCDC Canal-JSON Protocol](https://docs.pingcap.com/tidb/stable/ticdc-canal-json.md): 了解 TiCDC Canal-JSON Protocol 的概念和使用方法。
+- [TiCDC Changefeed 命令行参数和配置参数](https://docs.pingcap.com/tidb/stable/ticdc-changefeed-config.md): 了解 TiCDC Changefeed 详细的命令行参数和配置文件定义。
+- [TiCDC CSV Protocol](https://docs.pingcap.com/tidb/stable/ticdc-csv.md): 了解 TiCDC CSV Protocol 的概念和使用方法。
+- [TiCDC Debezium Protocol](https://docs.pingcap.com/tidb/stable/ticdc-debezium.md): 了解 TiCDC Debezium Protocol 的概念和使用方法。
+- [TiCDC Open Protocol](https://docs.pingcap.com/tidb/stable/ticdc-open-protocol.md): 了解 TiCDC Open Protocol 的概念和使用方法。
+- [TiCDC OpenAPI v1](https://docs.pingcap.com/tidb/stable/ticdc-open-api.md): 了解如何使用 OpenAPI 接口来管理集群状态和数据同步。
+- [TiCDC OpenAPI v2](https://docs.pingcap.com/tidb/stable/ticdc-open-api-v2.md): 了解如何使用 OpenAPI v2 接口来管理集群状态和数据同步。
+- [TiCDC Server 配置](https://docs.pingcap.com/tidb/stable/ticdc-server-config.md): 了解 TiCDC 详细的命令行参数和配置文件定义。
+- [TiCDC Simple Protocol](https://docs.pingcap.com/tidb/stable/ticdc-simple-protocol.md): 本文介绍了 TiCDC Simple Protocol 的使用方法和数据格式实现。
+- [TiCDC 兼容性](https://docs.pingcap.com/tidb/stable/ticdc-compatibility.md): 了解 TiCDC 兼容性相关限制和问题处理。
+- [TiCDC 单行数据正确性校验](https://docs.pingcap.com/tidb/stable/ticdc-integrity-check.md): 介绍 TiCDC 数据正确性校验功能的实现原理和使用方法。
+- [TiCDC 双向复制](https://docs.pingcap.com/tidb/stable/ticdc-bidirectional-replication.md): 了解 TiCDC 双向复制的使用方法。
+- [TiCDC 基本监控指标](https://docs.pingcap.com/tidb/stable/ticdc-summary-monitor.md): 了解 TiCDC 基本的监控指标。
+- [TiCDC 安装部署与集群运维](https://docs.pingcap.com/tidb/stable/deploy-ticdc.md): 了解 TiCDC 软硬件环境要求以及如何安装部署和运维 TiCDC 集群。
+- [TiCDC 客户端鉴权](https://docs.pingcap.com/tidb/stable/ticdc-client-authentication.md): 介绍使用 TiCDC 命令行工具或通过 OpenAPI 访问 TiCDC 时，如何进行客户端鉴权。
+- [TiCDC 常见问题解答](https://docs.pingcap.com/tidb/stable/ticdc-faq.md): 了解 TiCDC 相关的常见问题。
+- [TiCDC 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/ticdc-performance-tuning-methods.md): 本文介绍了 Performance Overview 面板中的 TiCDC 部分，帮助你了解和监控 TiCDC 工作负载。
+- [TiCDC 拆分 UPDATE 事件行为说明](https://docs.pingcap.com/tidb/stable/ticdc-split-update-behavior.md): 介绍 TiCDC changefeed 拆分 UPDATE 事件的行为变更，说明变更原因以及影响范围。
+- [TiCDC 故障处理](https://docs.pingcap.com/tidb/stable/troubleshoot-ticdc.md): 了解如何解决使用 TiCDC 时经常遇到的问题。
+- [TiCDC 术语表](https://docs.pingcap.com/tidb/stable/ticdc-glossary.md): 了解 TiCDC 相关的术语及定义。
+- [TiCDC 架构设计与原理](https://docs.pingcap.com/tidb/stable/ticdc-architecture.md): 了解 TiCDC 软件的架构设计和运行原理。
+- [TiCDC 简介](https://docs.pingcap.com/tidb/stable/ticdc-overview.md): TiCDC 是一款 TiDB 增量数据同步工具，适用于多 TiDB 集群的高可用和容灾方案，以及实时同步变更数据到异构系统。其主要特性包括数据容灾复制、双向复制、低延迟的增量数据同步能力等。TiCDC 架构包括 TiKV Server、TiCDC 和 PD，支持将数据同步到 TiDB、MySQL 数据库、Kafka 以及存储服务。目前暂不支持单独使用 RawKV 的 TiKV 集群，创建 SEQUENCE 的 DDL 操作和在同步过程中对 TiCDC 正在同步的表和库进行 BR 数据恢复和 TiDB Lightning 导入。
+- [TiCDC 详细监控指标](https://docs.pingcap.com/tidb/stable/monitor-ticdc.md): 了解 TiCDC 详细的监控指标。
+- [TiCDC 部署拓扑](https://docs.pingcap.com/tidb/stable/ticdc-deployment-topology.md): 介绍 TiCDC 部署 TiDB 集群的拓扑结构。
+- [TiCDC 集群监控报警规则](https://docs.pingcap.com/tidb/stable/ticdc-alert-rules.md): 了解 TiCDC 集群监控报警规则以及处理方法。
+- [TiDB 1.0 release notes](https://docs.pingcap.com/tidb/stable/release-1.0-ga.md): TiDB 1.0 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 优化了 SQL 查询优化器、内部数据格式、MySQL 兼容性，并支持 `NO_SQL_CACHE` 语法。PD 支持基于读流量的热点调度和设置 Store 权重。TiKV 支持更多下推函数和手动触发数据 Compact。TiSpark Beta 版本支持可配置框架和 ThriftSever/JDBC 和 Spark SQL 脚本入口。感谢参与项目的企业和团队，以及提供出色开源软件/服务的组织/个人。
+- [TiDB 1.1 Alpha Release Notes](https://docs.pingcap.com/tidb/stable/release-1.1-alpha.md): TiDB 1.1 Alpha 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。包括 SQL parser 兼容更多语法，SQL 查询优化器优化统计信息、代价估算，使用 `Count-Min Sketch` 更精确地估算点查的代价，SQL 执行器重构执行器算子，优化 `INSERT IGNORE` 语句性能，下推更多类型和函数，支持更多 `SQL_MODE`，优化 `Load Data` 性能，支持对物理算子内存使用进行统计。PD 增加更多 API，支持 TLS，调度适应不同的 Region size，修复调度 bug。TiKV 支持 Raft learner，优化 Raft Snapshot，支持 TLS，优化 RocksDB 配置，优化 Coprocessor 性能，增加 Failpoint 和稳定性测试 case，解决 PD 和 TiKV 重连问题，增强数据恢复工具功能，Region 支持按 table 分裂，支持 `Delete Range` 功能，支持设置 snapshot 导致的 I/O 上限，完善流控机制。
+- [TiDB 1.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-1.1-beta.md): TiDB 1.1 Beta 版本在 MySQL 兼容性和系统稳定性方面有多项改进。TiDB 新增监控项和优化日志，兼容更多 MySQL 语法，支持显示建表时间，加快查询速度，控制 Join 产生的中间结果集大小，修复多项问题，优化 SQL 引擎查询性能。PD 新增调试接口和 metrics，提高 TiKV 宕机时数据恢复优先级和恢复速度，优化 Region heartbeat 性能，修复热点调度问题。TiKV 消除潜在的 GC 问题，支持批量 resolve lock 和并行 GC，使用 RocksDB compaction listener 更新 Region Size，设置 Raft snapshot max size，支持更多修复操作，优化有序流式聚合操作，完善 metrics，修复 bug。
+- [TiDB 2.0 RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.1.md): TiDB 2.0 RC1 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持限制单条 SQL 语句内存使用，下推流式聚合算子到 TiKV，配置文件合法性检测，HTTP API 获取参数信息。Parser 兼容更多 MySQL 语法，提升对 Navicat 的兼容性。优化器提升，提取多个 OR 条件的公共表达式，选取更优执行计划。PD 优化检查 Region 状态的代码逻辑，异常情况下日志信息输出，修复监控中 TiKV 节点磁盘空间不足统计。TiKV 修复 PD leader 切换 gRPC call 问题，增加获取 metrics 的 gRPC API，启动时检查是否使用 SSD，使用 ReadPool 优化读性能。
+- [TiDB 2.0 RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.3.md): TiDB 2.0 RC3 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 修复了 MAX/MIN 结果错误、Sort Merge Join 排序问题、uint 和 int 比较错误等。PD 支持 Region Merge 和忽略有大量 pending peer 的节点。TiKV 支持 Region Merge、Raft snapshot 通知 PD 加速调度、增加 Raw DeleteRange API 等。
+- [TiDB 2.0 RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.4.md): TiDB 2.0 RC4 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持了一些新的语法和修复了一些问题。PD 支持手动 split Region 和优化了 metrics 及代码结构。TiKV 限制了接收 snapshot 时的内存使用，支持导数据模式和改善了在被隔离的情况下的输出问题。
+- [TiDB 2.0 RC5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.5.md): TiDB 2.0 RC5 版本发布，对 MySQL 兼容性、系统稳定性和优化器做了很多改进。TiDB 修复了多个问题，并优化了性能。PD 添加了 Raft Learner 支持，优化了 Balance Region Scheduler，并修复了多个问题。TiKV 支持了更多功能，并解决了多个问题。
+- [TiDB 2.0 release notes](https://docs.pingcap.com/tidb/stable/release-2.0-ga.md): TiDB 2.0 GA 版本发布，对 MySQL 兼容性、系统稳定性、优化器和执行器做了很多改进。包括 SQL 优化器、SQL 执行引擎、Server、兼容性、DDL、PD、TiKV 和 TiSpark 的功能、性能和稳定性优化。
+- [TiDB 2.0.1 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.1.md): TiDB 2.0.1 版本对 MySQL 兼容性和系统稳定性做出了改进。TiDB 新增了实时更新 `Add Index` 进度到 DDL 任务信息中的功能，添加了 Session 变量 `tidb_auto_analyze_ratio` 控制统计信息自动更新阈值的功能。修复了事务提交失败时可能未清理所有残留状态的问题，以及其他 Bug 和兼容性问题。PD 新增了 `Scatter Range` 调度和 learner 相关的 metrics，修复了多个问题。TiKV 修复了多个问题，优化了慢查询的日志，减少了 `thread_yield` 的调用次数。
+- [TiDB 2.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.10.md): TiDB 2.0.10 版本发布，修复了系统兼容性和稳定性问题。包括取消 DDL 任务可能导致的问题，ORDER BY 和 UNION 语句无法引用带表名的列的问题，UNCOMPRESS 函数错误输入长度的问题等。PD 修复了 RaftCluster 退出时可能的死锁问题，TiKV 修复了迁移 Leader 到新节点时造成请求延时问题和多余的 Region 心跳问题。
+- [TiDB 2.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.11.md): TiDB 2.0.11 版本发布，对系统兼容性和稳定性做出改进。修复了多个问题，包括 PD 异常处理问题、Rename 行为问题、ADMIN CHECK TABLE 误报问题、前缀索引错误问题和添加列导致 UPDATE 语句 panic 问题。TiKV 修复了两个 Region merge 相关问题。
+- [TiDB 2.0.2 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.2.md): TiDB 2.0.2 版本发布，改进了系统稳定性。TiDB 修复了 Decimal 除法内置函数下推的问题，支持 `Delete` 语句中使用 `USE INDEX` 的语法，禁止在带有 `Auto-Increment` 的列中使用 `shard_row_id_bits` 特性，并增加了写入 Binlog 的超时机制。PD 使 balance leader scheduler 过滤失连节点，更改 transfer leader operator 的超时时间为 10 秒，修复 label scheduler 在集群 Regions 不健康状态下不调度的问题，修复 evict leader scheduler 调度不当的问题。TiKV 修复了 Raft 日志没有打出来的问题，支持配置更多 gRPC 相关参数，支持配置选举超时的取值范围，修复过期 learner 没有删掉的问题，修复 snapshot 中间文件被误删的问题。
+- [TiDB 2.0.3 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.3.md): TiDB 2.0.3 版本在 2.0.2 版的基础上做出了改进，包括系统兼容性和稳定性的改进。TiDB 支持在线更改日志级别和 `COM_CHANGE_USER` 命令，优化查询条件代价估算和修复多个问题。PD 修复了特定条件下的问题，TiKV 修复了错误上报和除数为 0 的问题。
+- [TiDB 2.0.4 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.4.md): TiDB 2.0.4 版本发布，改进了系统兼容性和稳定性。TiDB 支持了新的语法和变量设置，优化了监控项和查询代价估计精度。PD 改进了调度参数行为，TiKV 新增了调试接口和命令，优化了问题和修复了崩溃。
+- [TiDB 2.0.5 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.5.md): TiDB 2.0.5 版本发布，改进了系统兼容性和稳定性。新增系统变量 `tidb_disable_txn_auto_retry`，调整计算 `Selection` 代价的方式，优化查询条件匹配唯一索引或主键，修复多个 bug。PD 修复副本迁移导致 TiKV 磁盘空间耗尽和 `AdjacentRegionScheduler` 导致的崩溃问题。TiKV 修复 decimal 运算中的溢出和 merge 过程中的脏读问题。
+- [TiDB 2.0.6 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.6.md): TiDB 2.0.6 版本在系统兼容性和稳定性方面有所改进。包括日志长度精简、记录 ADD INDEX 执行过程中的慢操作、减少更新统计信息操作中的事务冲突等。此外，修复了多个 bug，包括 DROP USER 语句和 MySQL 行为不兼容、tidb_batch_insert 打开后 INSERT/LOAD DATA 语句在某些场景下 OOM 的问题等。TiKV 方面扩大了默认 scheduler slots 值以减少假冲突现象，修复了字符串转 Decimal 时出现的 crash。
+- [TiDB 2.0.7 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.7.md): TiDB 2.0.7 版本在系统兼容性和稳定性方面有改进。TiDB 新增了在 `information_schema` 中添加 `PROCESSLIST` 表的功能。还对语句执行细节进行了改进，并在 `SLOW QUERY` 日志中输出更多信息。修复了多个 bug，包括 `PRIMARY KEY` 为整数的表无法使用 `USE INDEX(PRIMARY)` 的问题，以及 `Merge Join` 和 `Index Join` 在 inner row 为 `NULL` 时输出多余结果的问题。TiKV 方面，空集群默认打开 `dynamic-level-bytes` 参数减少空间放大，并在 Region merge 之后更新 Region 的 `approximate size` 和 keys。
+- [TiDB 2.0.8 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.8.md): TiDB 2.0.8 版本在 2.0.7 版的基础上做出了改进，包括功能改进和 Bug 修复。TiKV 也修复了节点宕机时内存持续上升的问题。
+- [TiDB 2.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.9.md): TiDB 2.0.9 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括统计信息、DDL JOB、Commit 操作、Limit 值、字符集支持、内建函数、主键选择率估算、Session 变量、Union 语句、统计信息清除、事务运行时间、表创建语句、取消 DDL 任务、全局环境变量等。PD 修复了 etcd 启动失败和 pd-ctl 读取 Region key 的问题。TiKV 增加了 kv_scan 接口扫描上界的限制，废弃了 max-tasks-xxx 配置，并修复了 RocksDB CompactFiles 的问题。
+- [TiDB 2.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-beta.md): TiDB 2.1 Beta 版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。SQL 优化器优化了 Index Join 选择范围和关联子查询，下推 Filter 和扩大索引选择范围。SQL 执行引擎实现了并行 Hash Aggregate 和 Project 算子，提高了执行性能。Server 添加了 HTTP API 控制功能和支持 Server side cursor。兼容性方面支持更多 MySQL 语法和 SHOW PRIVILEGES 语句。PD 优化了 Balance Scheduler 和热点调度器，TiKV 升级了 Rust 版本和优化了性能。
+- [TiDB 2.1 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-ga.md): TiDB 2.1 GA 版本发布，对系统稳定性、性能、兼容性、易用性做了大量改进。包括 SQL 优化器、SQL 执行引擎、统计信息、表达式、Server、DDL、兼容性等方面的优化。PD (Placement Driver) 进行了可用性优化、调度器优化、API 及运维工具优化、监控和性能优化。TiKV 进行了 Coprocessor、Transaction、Raftstore、存储引擎和 tikv-ctl 方面的优化。同时支持全量数据快速导入工具 TiDB Lightning。升级兼容性说明包括存储引擎更新不支持回退至 2.0.x 或更旧版本，以及升级前需要确认集群中是否存在正在运行中的 DDL 操作。
+- [TiDB 2.1 RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.1.md): TiDB 2.1 RC1 版本于 2018 年 8 月 24 日发布。该版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、DML、DDL 等方面的改进。PD 方面新增了版本控制机制，支持集群滚动兼容升级等功能。TiKV 方面新增了支持 batch split 等新特性，以及对性能和功能进行了优化和改进。
+- [TiDB 2.1 RC2 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.2.md): TiDB 2.1 RC2 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。具体包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、表达式、DML、DDL、TiKV 和 PD 的新特性、功能改进和 Bug 修复。
+- [TiDB 2.1 RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.3.md): TiDB 2.1 RC3 版本对系统稳定性、兼容性、优化器和执行引擎做了很多改进。包括修复了多个 SQL 优化器和执行引擎的问题，增强了部分执行器的性能，修复了配置文件内存配额选项不生效的问题，支持使用 `admin show slow` 语句来获取 SLOW QUERY LOG，修复了一些兼容性问题，增加了一些内建函数的支持，修复了一些 DML 和 DDL 的问题。PD 新增了获取按大小逆序排序的 Region 列表 API，Region API 返回更详细的信息，修复了 PD 切换 leader 后可能导致 crash 的问题。TiKV 进行了性能优化，并新增了一些函数的支持，同时修复了一些 Bug。
+- [TiDB 2.1 RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.4.md): TiDB 2.1 RC4 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个 SQL 优化器和执行引擎的问题，重构了 Latch，提升了并发事务的执行性能。PD 修复了多个 TiKV 下线后的问题。TiKV 优化了 apply snapshot 导致的 RocksDB Write stall 的问题，并增加了 raftstore tick 相关 metrics。
+- [TiDB 2.1 RC5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.5.md): TiDB 2.1 RC5 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括修复了多个问题，提升了性能，增加了环境变量设置功能。PD 修复了多个问题，TiKV 优化了报错信息和接口限制。
+- [TiDB 2.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.1.md): TiDB 2.1.1 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括时间四舍五入错误、uncompress 函数未检查数据长度、PD 故障获取错误 TSO、不规范语句导致启动失败等。DDL 改变了表的默认字符集和排序规则，增加了控制添加索引速度的变量。PD 修复了配置项无法设置为 0 的问题，避免了 transfer leader 至新创建的 Peer 产生的延迟增加问题。TiKV 也避免了相同的问题。 Lightning 优化了对导入表的 analyze 机制，提升了导入速度。 TiDB Binlog 修复了 pb files 输出 bug。
+- [TiDB 2.1.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.10.md): TiDB 2.1.10 发布，修复了多个 bug 和兼容性问题，增强了安全性。PD 修复了 Leader 优先级不生效的问题。TiKV 修复了多个问题，包括 transfer leader 中可能发生的脏读问题。TiDB Lightning 新增了发送数据到 importer 失败时进行重试的功能。TiDB Binlog 优化了 Pump storage 组件 log。TiDB Ansible 更新了配置文件，新增了 tidb_lightning_ctl 脚本。
+- [TiDB 2.1.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.11.md): TiDB 2.1.11 发布，修复多表 join 删除错误 schema 问题，更新统计信息合并反馈信息，修复函数返回错误字段类型问题，修复时间计算错误问题，修复与 MySQL 8.0 不兼容问题，支持 SHOW OPEN TABLES 语句，修复 goroutine 泄露问题，修复设置 tidb_snapshot 变量时间格式解析出错问题。PD 修复热点 Region 调度问题，新增热点调度优先级配置项。TiKV 修复 leader, learner 读到空 index 问题，处理锁命令放在高优先级线程池中。TiDB Binlog 新增 GC 删数据限速功能。TiDB Ansible 新增 Drainer 参数。
+- [TiDB 2.1.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.12.md): TiDB 2.1.12 发布，修复了多个 bug，包括类型不匹配导致进程 panic、字符集改变导致类型变化、事务中的 GRANT 误报错误等问题。同时提升了与 MySQL 的兼容性，修复了 TiDB 跟 TiKV 在 gRPC 最大封包设置不一致导致的超大封包报错问题。PD 修复了极端情况下 etcd Leader 选举阻塞的问题，TiKV 修复了 Leader 迁移过程中 Region 不可用的问题和异常掉电导致丢数据的问题。
+- [TiDB 2.1.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.13.md): TiDB 2.1.13 发布，新增了列属性包含 `AUTO_INCREMENT` 时利用 `SHARD_ROW_ID_BITS` 打散行 ID 功能，优化无效 DDL 元信息存活时间，修复了在大并发场景下 OOM 的问题，新增了 `update-stats` 配置项，新增了 3 个 TiDB 特有语法，修复了某些情况下 `KILL` 语句导致的 panic 问题，增强了 `ADD_DATE` 在某些情况下跟 MySQL 的兼容性，修复了 index join 中内表过滤条件在某些情况下的选择率估计错误的问题。TiKV 修复了因迭代器未检查状态导致系统生成残缺 snapshot 的问题，新增了检查 `block-size` 配置的有效性功能。TiDB Binlog 修复了 Pump 因写入失败时未检查返回值导致偏移量错误问题，Drainer 新增了 `advertise-addr` 配置，支持容器环境中使用桥接模式。
+- [TiDB 2.1.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.14.md): TiDB 2.1.14 发布说明：修复查询结果不正确的问题，支持自动调整 Auto ID 分配的步长，新增全局系统变量 `max_execution_time`，修复内存配额超出时返回结果不正确的问题，禁用 `TRACE` 语句，新增系统表控制函数下推，优化 Raftstore 消息处理，调整无效配置项日志级别，新增 Binlog 配置项，修复 Binlog 更新失败问题，新增 Ansible 命令预检查功能。
+- [TiDB 2.1.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.15.md): TiDB 2.1.15 发布，修复了多个函数处理微秒、空值比较、插入参数、索引建立等问题，并新增了多个 SQL 语句和监控项。TiKV 统一日志格式，提高了调度准确度。PD 也统一了日志格式。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修复了导入错误问题。TiDB Ansible 新增监控项用于监测 SQL 语句解析耗时和执行计划编译耗时。
+- [TiDB 2.1.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.16.md): TiDB 2.1.16 发布，修复了 SQL 优化器和执行引擎的多个问题。TiKV 支持逆向 raw_scan 和 raw_batch_scan 接口。TiDB Binlog 和 TiDB Lightning 做了一些功能增强和 bug 修复。TiDB Ansible 也有多个 bug 修复和功能优化。
+- [TiDB 2.1.17 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.17.md): TiDB 2.1.17 发布，新增了 `SHOW TABLE REGIONS` 语法的 `WHERE` 条件子句，以及 TiKV、PD 的 `config-check` 功能。PD 优化调度流程，TiKV 优化启动流程。TiDB 慢日志中的 `start ts` 和 `Index_ids` 字段有改动。SQL 优化器和执行引擎修复了多个问题。DDL 改进了 `SPLIT TABLE` 语法的行为。TiKV 解决了一些问题并新增了 `config-check` 选项。PD 新增了 `config-check` 选项和 `remove-tombstone` 命令。Reparo 新增了配置项，用于控制恢复速率。TiDB Ansible 更新了 Spark 版本和修复了连接等待问题。
+- [TiDB 2.1.18 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.18.md): TiDB 2.1.18 发布，修复了多项 SQL 优化器和执行引擎的问题，改进了 Server、DDL 和 Monitor 功能，同时 TiDB Ansible 也有多项更新。
+- [TiDB 2.1.19 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.19.md): TiDB 2.1.19 发布，包含了对 SQL 优化器、SQL 执行引擎、Server、DDL、TiKV、PD 和 TiDB Ansible 的多项修复和优化。修复了多个查询和更新语句中可能出现的错误，提升了系统稳定性和性能。
+- [TiDB 2.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.2.md): TiDB 2.1.2 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括索引 panic、优化器执行计划、字符集检查和时间类型字段错误。PD 修复了 Region Merge 相关问题，TiKV 支持日为时间单位的配置格式，并解决了配置兼容性问题，修复了 Approximate Size Split 和两个 Region merge 相关问题。TiDB Lightning 支持最小 TiDB 集群版本为 2.1.0，修复了解析 JSON 类型数据文件内容出错和使用 checkpoint 重启后的错误。TiDB Binlog 消除了往 Kafka 写数据的瓶颈点，支持写 Kafka 版本的 TiDB Binlog。
+- [TiDB 2.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.3.md): TiDB 2.1.3 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个问题，包括 Prepared Plan Cache panic、Range 计算错误、统计信息溢出、Generated Column 在 Update 中 Panic 等。还支持了一些新特性，如对 `_tidb_rowid` 构造查询的 Range、`CASE` 子句返回 JSON 类型等。PD 修复了 Leader 选举相关的 Watch 问题，TiKV 支持了使用 HTTP 方式获取监控信息，并修复了一些问题。TiDB Binlog 也修复了一些启动或重启时的问题。
+- [TiDB 2.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.4.md): TiDB 2.1.4 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个函数处理结果不正确的问题，优化了服务器日志和 DDL 操作。TiKV 修复了关闭时可能发生重复写的问题和事件监听器处理异常的问题。工具方面优化了内存使用，减少了对 dump 文件的解析，提高了导入稳定性。数据同步对比统计支持使用 TiDB 统计信息来划分 chunk。
+- [TiDB 2.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.5.md): TiDB 2.1.5 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括优化器 / 执行器、Server、DDL、PD、TiKV 和 Tools 的改进和修复。
+- [TiDB 2.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.6.md): TiDB 2.1.6 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括索引扫描选择问题、聚合函数兼容性问题、变量设置导致的 Panic 问题等。TiKV 修复了解析 protobuf 失败导致的错误。Lightning 修复了多个导入相关的问题，并支持 CSV 格式。
+- [TiDB 2.1.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.7.md): TiDB 2.1.7 发布，修复了 DDL 取消导致升级程序启动时间变长的问题，提升了内置函数的兼容性，新增了系统表管理 Table 与 Index 之间的关系，支持在 DO 语句中使用子查询，修复了对 JSON 数据的聚合函数在计算过程中 Panic 的问题。PD 修改副本数为 1 时 balance-region 无法迁移 leader 的问题。Tools 支持 binlog 同步 generated column。TiDB Ansible 将 Prometheus 监控数据默认保留时间改成 30d。
+- [TiDB 2.1.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.8.md): TiDB 2.1.8 发布，修复了多个函数和语句的兼容性问题，优化了日志格式规范和统计信息估算准确性。PD 和 TiKV 也有多项修复和优化。工具方面，Lightning 和 Binlog Pump 等新增了多项配置和性能优化。TiDB Ansible 修改了操作系统版本限制和滚动升级版本限制。
+- [TiDB 2.1.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.9.md): TiDB 2.1.9 发布，修复了多个函数和权限检查问题，支持指定 collation 为 utf8mb4_0900_ai_ci，改进了慢日志输出和 PD 服务支持。 TiKV 修复了在 transfer leader 时的问题。 TiDB Binlog 和 TiDB Lightning 也有多个修复和改进。 TiDB Ansible 更新了文档链接和移除了一个参数。
+- [TiDB 3.0 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0-beta.md): TiDB 3.0 Beta 版本发布，新增支持 View、窗口函数、Range 分区、Hash 分区等特性。SQL 优化器做了很多改进，包括重新支持聚合消除、优化 `NOT EXISTS` 子查询、支持 Index Join 等。SQL 执行引擎优化了 Merge Join 算子、日志打印等功能。权限管理增加了对 `ANALYZE`、`USE`、`SET GLOBAL`、`SHOW PROCESSLIST` 语句的权限检查。Server 支持了 `Trace` 功能、插件框架、`unix_socket` 和 TCP 连接等功能。兼容性方面支持了 `ALLOW_INVALID_DATES` SQL mode、load data 对 CSV 文件的容错能力等。DDL 支持了快速恢复误删除的表、动态调整 ADD INDEX 的并发数等功能。Tools 方面 TiDB Lightning 大幅优化了 SQL 转 KV 的处理速度。PD 和 TiKV 也做了很多功能增加和优化。
+- [TiDB 3.0 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0-ga.md): TiDB 3.0 GA 版本于 2019 年 6 月 28 日发布，对应的 TiDB Ansible 版本为 3.0.0。V3.0.0 版本相比 V2.1 在稳定性、易用性、性能和新功能方面有重要改进。新增功能包括窗口函数、视图、分区表、插件系统、悲观锁、SQL Plan Management 等。SQL 优化器和执行引擎也有多项优化，包括对 `NOT EXISTS` 子查询、`Outer Join`、`IN` 子查询、Index Join 等的性能提升。PD 新增了从单个节点重建集群的功能，将 Region 元信息从 etcd 移至 go-leveldb 存储引擎。TiKV 新增了分布式 GC、并行 Resolve Lock、多线程 Raftstore 和 Apply 等功能，以及对 Engine、Server、RaftStore 和 Coprocessor 的优化。Tools 方面 TiDB Lightning 新增了多项功能，TiDB Binlog 新增了多项功能，sync-diff-inspector 也新增了多项功能。TiDB Ansible 升级了监控组件版本，新增了多项监控面板和功能。
+- [TiDB 3.0.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-beta.1.md): TiDB 3.0.0 Beta.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、权限管理、Server、DDL、PD、TiKV 和 Tools 的更新。
+- [TiDB 3.0.0-rc.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.1.md): TiDB 3.0.0-rc.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Tools 和 TiDB Ansible 的更新和修复。
+- [TiDB 3.0.0-rc.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.2.md): TiDB 3.0.0-rc.2 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL 和 PD 的更新。TiKV 的更新包括 Engine、Server、Raftstore 和 Coprocessor 的改进。工具方面，TiDB Binlog 增加下游同步延迟监控项，TiDB Lightning 支持数据库合并和新增 KV 写入失败重试机制。
+- [TiDB 3.0.0-rc.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.3.md): TiDB 3.0.0-rc.3 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Transaction、tikv-ctl、Misc 等方面的修复和新增功能。TiDB Ansible 新增预测集群最大 QPS 的监控项。
+- [TiDB 3.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.1.md): TiDB 3.0.1 发布，新增多项功能和修复了多个问题。TiKV 新增了对 Blob 文件大小的统计和死锁检测性能的提升。PD 优化了热点 Region 调度策略和 Region Merge 处理逻辑。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修正了导入错误的问题。TiDB Ansible 新增了预检查功能和更新了监控信息。
+- [TiDB 3.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.10.md): TiDB 3.0.10 发布，修复了多个 bug 和性能问题。TiKV 修复了 Region merge 失败导致系统 Panic 的问题。PD 自动更新 Region 缓存信息，解决缓存失效问题。TiDB Binlog 支持 relay log。TiDB Lightning 优化配置项和修复 web 界面无法打开的问题。TiDB Ansible 修复获取不到 PD Leader 导致命令执行失败的问题，并新增多个监控项。
+- [TiDB 3.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.11.md): TiDB 3.0.11 发布，包含兼容性变化、新功能和 Bug 修复。新增配置项 `max-index-length` 控制索引最大长度，显示分区表的分区元信息，以及 TiDB 集群之间数据双向复制功能。Bug 修复包括查询结果不正确、Goroutine 泄露等问题。TiKV 也进行了日志输出优化和问题修复。TiDB Ansible 修复了失效文档链接和未定义变量问题。
+- [TiDB 3.0.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.12.md): TiDB 3.0.12 发布日期为 2020 年 3 月 16 日。该版本存在一些已知问题，建议使用最新版本。兼容性变化包括修复慢日志中记录 prewrite binlog 时间计时不准确的问题。新功能包括动态加载已被替换的证书文件，添加配置项，限流功能，以及在 binlog 写入失败时 TiDB 退出。Bug 修复包括保证原子性，悲观锁加锁问题修复，建索引长度超过限制时的报错信息显示，FROM_UNIXTIME 函数小数点位数不正确的问题修复，以及其他问题的修复。
+- [TiDB 3.0.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.13.md): TiDB 3.0.13 发布日期为 2020 年 04 月 22 日。此版本修复了 TiDB 和 TiKV 中的一些 bug。其中 TiDB 修复了由于未检查 `MemBuffer`，事务内执行 `INSERT ... ON DUPLICATE KEY UPDATE` 语句插入多行重复数据可能出错的问题。TiKV 修复了重复多次执行 `Region Merge` 导致系统被阻塞的问题，阻塞期间服务不可用。
+- [TiDB 3.0.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.14.md): TiDB 3.0.14 发布日期为 2020 年 5 月 9 日。该版本兼容性变化包括 `performance_schema` 和 `metrics_schema` 由读写改为只读。重点修复的 Bug 包括 join 条件在 handle 列上存在多个等值条件时，index join 查询结果错误等问题。新功能包括 `admin show ddl jobs` 查询结果中添加库名和表名列等功能。Bug 修复包括 `WEEKEND` 函数在 SQL mode 为 `ALLOW_INVALID_DATES` 时结果与 MySQL 不兼容等问题。TiKV 也有相关 Bug 修复，如节点隔离恢复之后无法被正确删掉等问题。
+- [TiDB 3.0.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.15.md): TiDB 3.0.15 发布，新增禁止分区表查询使用 plan cache 功能、支持 admin recover index、admin check index 语句、优化统计信息 CMSketch 的内存分配机制等功能。PD 新增按照 Leader 个数调度的策略。修复了多处 Bug，包括 Hash 聚合函数中的深拷贝方式、点查整数溢出处理逻辑、CHAR() 函数查询条件处理逻辑等问题。TiKV 修复了长时间运行后碎片整理不再有效、系统意外重启后删除 snapshot 文件导致系统 panic、消息包过大导致 gRPC 连接断开的问题。
+- [TiDB 3.0.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.16.md): TiDB 3.0.16 发布，优化了 hash partition pruning 和 Region 设置，修复了多个 Bug，包括锁住的 primary key 造成的结果不一致问题和 JSON 数据中 int 和 float 类型比较的问题。TiKV 也进行了稳定性优化和 Bug 修复。PD 修复了查询 Region 报 404 错误的问题。
+- [TiDB 3.0.17 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.17.md): TiDB 3.0.17 发布，修复了多个 bug，包括查询返回错误和函数处理问题。优化了配置项和 HTTP API 访问速度。TiKV 修复了数据读取和调度问题，新增了配置支持。TiDB Lightning 解决了参数不生效的问题，并新增了更简单易用的过滤规则。
+- [TiDB 3.0.18 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.18.md): TiDB 3.0.18 发布，提升了 TiDB Binlog 工具的细粒度 Pump GC 时间支持。修复了 TiDB 中 Hash 函数对 Decimal 类型的错误处理问题，以及对 Set 和 Enum 类型的错误处理问题。还修复了 Duplicate Key 检测在悲观事务下失效的问题，以及其他执行结果错误的问题。TiKV 将 GC 的失败日志级别改为 Warning。TiDB Lightning 修复了多个命令行参数和使用 TiDB backend 时的问题。
+- [TiDB 3.0.19 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.19.md): TiDB 3.0.19 发布，兼容性变化包括更改 PD 的导入路径和版权信息。提升改进方面，缓解故障恢复对 QPS 的影响，支持调整 `union` 运算符的并发数。Bug 修复包括解决 `slow-log` 文件不存在导致查询出错的问题，添加权限检查命令，修复类型转换问题等。TiKV 修复了 status server 解析响应出错导致 panic 的问题。TiDB Lightning 修复了严格模式下 CSV 中遇到不合法 UTF 字符集没有及时退出进程的问题。
+- [TiDB 3.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.2.md): TiDB 3.0.2 发布日期为 2019 年 8 月 7 日。该版本修复了多个 SQL 优化器和执行引擎的问题，包括修复了查询结果列名称不正确、LIKE 表达式被隐式转换为 0、SHOW 语句中使用子查询等问题。此外，还修复了 TiKV panic、悲观事务下 Insert 行为不正确等问题。PD 也修复了 Scatter Region 调度器不能工作等 bug。TiDB Ansible 也有多个修复和更新，包括修复了 Disk Performance 监控单位错误、新增了 TiDB Summary Dashboard 等。
+- [TiDB 3.0.20 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.20.md): TiDB 3.0.20 发布，兼容性更改包括废弃 `enable-streaming` 配置项。改进提升包括优化 `LOAD DATA` 语句执行报错信息。Bug 修复包括缓存悲观事务提交状态问题、查询统计信息不准确问题等。TiKV 修复事务删除 key 报错问题，PD 修复启动时打印过量日志问题。
+- [TiDB 3.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.3.md): TiDB 3.0.3 发布，包含了多项 SQL 优化器和执行引擎的修复，以及 Server、DDL、Monitor、TiKV、PD、Tools 和 TiDB Ansible 的更新和修复。
+- [TiDB 3.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.4.md): TiDB 3.0.4 发布日期为 2019 年 10 月 8 日。此版本新增了系统表 `performance_schema.events_statements_summary_by_digest` 用于排查 SQL 性能问题。同时，TiDB 的 `SHOW TABLE REGIONS` 语法新增了 `WHERE` 条件子句。此外，Reparo 新增了 `worker-count` 和 `txn-batch` 配置项，用于控制恢复速率。还修复了一些问题，如特殊语法 `PRE_SPLIT_REGIONS` 没有使用注释的方式向下游同步的问题。
+- [TiDB 3.0.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.5.md): TiDB 3.0.5 发布，包含 SQL 优化器和执行引擎的多项修复和改进，支持事务 TTL 修改接口函数，以及对 Region Cache TTL 的配置修改。TiKV 新特性包括悲观事务 Cleanup 接口支持和 Raftstore 性能优化。PD 提高了 Region 占用空间的精度和 label 监控可读性。TiDB Binlog 和 TiDB Lightning 也有多项修复和功能增强。TiDB Ansible 更新了监控表达式和配置文件内容。
+- [TiDB 3.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.6.md): TiDB 3.0.6 发布，包含多项 SQL 优化器和执行引擎的修复和优化，以及 Server、DDL、TiKV、PD 和 Tools 的更新和修复。TiKV 修复了悲观锁支持和 GC worker 写入量限制等问题。PD 添加了新维度和降低日志级别。Tools 中 TiDB Binlog 和 TiDB Lightning 也有多项修复和新增配置。
+- [TiDB 3.0.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.7.md): TiDB 3.0.7 发布，修复了多个问题，包括本地时间落后导致锁的 TTL 过大、解析日期时时区不正确、整型数据转换精度丢失等问题。TiKV 也修复了死锁检测和内存泄漏问题。
+- [TiDB 3.0.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.8.md): TiDB 3.0.8 发布，修复了 SQL 优化器、SQL 执行引擎、DDL、Server、Transaction、Monitor 等方面的多个问题。TiKV 也进行了多项修复和优化。PD 新增了一些功能，并升级了 etcd 版本。TiDB Ansible 进行了配置项回滚和优化，TiSpark 版本升级到 2.1.8。
+- [TiDB 3.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.9.md): TiDB 3.0.9 发布日期为 2020 年 1 月 14 日。该版本修复了一些已知问题，并提升了性能。包括 Executor 修复了聚合函数作用于枚举和集合列时结果不正确的问题，Server 支持了系统变量 `auto_increment_increment` 和 `auto_increment_offset`，新增了监控项等。TiKV 提升了 Raft 成员变更的速度，新增了监控项用于监控 `waiter` 的生命周期等。PD 新增了一些功能和修复了一些问题。Tools 方面也有一些新增和优化。TiDB Ansible 优化了 Lightning 部署。
+- [TiDB 3.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.md): TiDB 3.1 Beta 发布说明：发版日期为 2019 年 12 月 20 日，TiDB 版本为 3.1.0-beta，TiDB Ansible 版本为 3.1.0-beta。TiDB 新增 SQL 优化器和丰富的 SQL hint 功能。另外，TiDB 还支持 Follower Read 功能。TiKV 新增支持分布式备份恢复功能和 Follower Read 功能。PD 也新增支持分布式备份恢复功能。
+- [TiDB 3.1 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.1.md): TiDB 3.1 Beta.1 发布日期为 2020 年 1 月 10 日。TiDB 版本为 3.1.0-beta.1，TiDB Ansible 版本也为 3.1.0-beta.1。TiKV 新增了备份功能和 SST 文件恢复修复。Tools 中 BR 组件修复了备份进度信息不准确的问题，并新增了自动调度 PD schedulers 功能。TiDB Ansible 新增了初始化阶段自动关闭操作系统 THP 的功能和 BR 组件的 Grafana 监控。
+- [TiDB 3.1 Beta.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.2.md): TiDB 3.1 Beta.2 发布日期为 2020 年 3 月 9 日。该版本存在已知问题，建议使用最新版本。兼容性变化包括 TiDB Lightning 配置项优化和新增命令行参数。新功能包括支持在列属性上添加 `AutoRandom` 关键字，新增通过 DDL 语句为表创建、删除列存储副本的功能等。Bug 修复包括修复静默 Region 读数据处理不当导致无法处理读请求的问题等。
+- [TiDB 3.1 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-ga.md): TiDB 3.1 GA 发布说明：兼容性变化包括支持报告状态配置项和 BR 不支持旧版 TiKV 集群恢复。新功能包括展示 coprocessor 任务信息和减少日志冗余信息。PD 优化热点 Region 调度，TiFlash 添加读写负载信息和支持函数下推。TiDB Ansible 新增 TiFlash 监控和优化配置参数。Bug 修复包括修复 merge join 和计算选择率问题。TiKV 修复 replica read 和 restore 问题，TiFlash 修复同步 schema 和数据丢失问题。TiDB Binlog 修复因 TiFlash 相关 DDL job 导致同步中断问题，BR 修复 checksum 和增量备份失败问题。
+- [TiDB 3.1 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-rc.md): TiDB 3.1 RC 发布日期为 2020 年 4 月 2 日。该版本存在已知问题，建议使用最新版本 3.1.x。新功能包括性能提升、数据恢复、TLS 证书动态更新等。Bug 修复包括信息 schema 错误、DDL 卡住、冲突检测失效等。PD 修复了数据竞争、规则未遵守等问题。工具方面优化了性能、修复了数据错误和无法恢复的问题。
+- [TiDB 3.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.1.md): TiDB 3.1.1 发布，新增了 auto_rand_base 表选项和 Feature ID 注释。TiFlash 优化了读写负载相关图表和 chunk encode decimal 数据的流程。修复了隔离读设置不生效、hash 分区表上的分区选择语法报错、update sql 中包含 view 仍然报错等问题。TiFlash 修复了非 normal 状态时读取数据错误、表名映射方式支持 recover table/flashback table、数据存储路径问题、读模型优化和特殊字符导致无法启动的问题。BR 修复了恢复带有 auto_random 属性的表后插入数据触发 duplicate entry 错误的问题。
+- [TiDB 3.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.2.md): TiDB 3.1.2 发布日期为 2020 年 6 月 4 日。此版本修复了 TiKV 和 Tools 中的一些错误，包括 S3 和 GCS 备份恢复时的错误处理问题，备份过程中的 DefaultNotFound 错误，以及 BR 在备份恢复到 S3 和 GCS 存储时的稳定性提升等问题。同时还修复了 BR 在恢复数据时出现的一些错误，并增加了备份恢复 S3 时的 AWS KMS 服务端加密支持。
+- [TiDB 4.0 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.md): TiDB 4.0 Beta 发布说明：TiDB 版本 4.0.0-beta 和 TiDB Ansible 版本 4.0.0-beta 已发布。更新内容包括性能优化、新功能支持、bug 修复等。详细信息请查阅官方发布说明。
+- [TiDB 4.0 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0-ga.md): TiDB 4.0 GA 发布日期为 2020 年 5 月 28 日。该版本包含兼容性变化、重点修复的 Bug、新功能、Bug 修复等内容。其中 TiDB 新增了多项配置项和语法支持，TiFlash 修复了多项功能不一致的问题，TiKV 修复了多个备份和系统 panic 相关的问题，PD 修复了删除调度器和 presplit 功能无法正常使用的问题，Tools 中 BR 修复了从云存储恢复数据失败的问题，TiCDC 修复了多个系统 panic 和资源泄露的问题。
+- [TiDB 4.0 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.md): TiDB 4.0 RC 发布日期为 2020 年 4 月 8 日，版本为 4.0.0-rc，TiUP 版本为 0.0.3。该版本存在已知问题，建议使用最新版本 4.0.x。兼容性变化包括 TiDB、TiKV 和 Tools 的更新。重点修复了 TiDB 的 Bug，并新增了一些功能。TiKV 修复了启用 Follower Read 功能导致系统 Panic 的问题。Tools 中 TiDB Lightning 修复了字符转换错误导致数据错误的问题，TiCDC 新增了一些功能。
+- [TiDB 4.0 RC.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.1.md): TiDB 4.0 RC.1 发布说明：TiDB 4.0.0-rc.1 版本兼容性变化包括 TiKV 默认关闭 hibernate region，TiDB Binlog 增加对 Sequence DDL 的支持。重点修复了多个 Bug，包括 TiDB 事务内执行 INSERT ... ON DUPLICATE KEY UPDATE 语句插入多行重复数据可能出错的问题等。新增功能包括 TiDB 支持发送 batch coprocessor 请求给 TiFlash 等。Bug 修复包括 TiDB 系统表由于 unsigned 列定义导致无法正确显示负数的问题等。
+- [TiDB 4.0 RC.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.2.md): TiDB 4.0 RC.2 发布说明：兼容性变化包括事务容量上限统一为 10GB，查询 CLUSTER_LOG 表需指定时间范围，CREATE TABLE 创建分区表时指定未支持的选项将创建非分区普通表。重点修复了多个 Bug。新增了备份和恢复语句，支持预检查单个 Region 提交数据量。TiKV 新增了加密存储适配和配置 gRPC 消息大小上限。PD 修复了 pd-ctl 命令错误和缺失监控的问题。TiFlash 优化了系统负载和新增了容量配置参数。Tools 方面修复了多个问题和优化了功能。
+- [TiDB 4.0.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.1.md): TiDB 4.0.0 Beta.1 发布，包含兼容性变化、新功能和 Bug 修复。兼容性变化包括配置项类型修改和默认值调整。新增慢日志系统表支持查询任意时间段的日志，SQL 性能诊断功能和 Sequence 功能。Bug 修复包括视图创建、时区修改和函数表达式问题。TiKV 和 PD 也有新增功能和 Bug 修复。TiDB Ansible 新增部署多个 Grafana/Prometheus/Alertmanager 的功能和 TiFlash 监控 Dashboard。
+- [TiDB 4.0.0 Beta.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.2.md): TiDB 4.0.0 Beta.2 发布日期为 2020 年 3 月 18 日。该版本修复了 TiDB Binlog 在配置 `disable-dispatch`、`disable-causality` 时系统直接报错并退出的问题。新增了 TiKV 和 PD 支持将动态修改配置的结果持久化存储到硬盘的功能。另外，TiDB Binlog 新增了 TiDB 集群之间数据双向复制功能，TiDB Lightning 新增了配置 TLS 功能，新增了 TiCDC 工具，提供了进程级别的高可用能力。此外，BR 开启了增量备份、支持将备份文件存储在 AWS S3 等实验性功能。TiDB Ansible 新增了将节点信息注册到 etcd 的功能，新增支持在 ARM 平台上部署 TiDB 服务的功能。修复了 TiKV、PD 和 Tools 中的多个 bug。
+- [TiDB 4.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.1.md): TiDB 4.0.1 发布日期为 2020 年 6 月 12 日。新功能包括 TiKV 添加 `--advertise-status-addr` 启动参数，PD 支持内部代理和客户端自定义超时设置，TiFlash 支持新的排序规则框架和函数下推，以及 BR 增加集群版本检查。Bug 修复方面，TiKV 修复了多个问题，PD 修复了错误配置和 panic 问题，TiFlash 修复了默认值解析和时区计算错误的问题。
+- [TiDB 4.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.10.md): TiDB 4.0.10 发布日期为 2021 年 1 月 15 日。新功能包括 PD 添加了配置项 `enable-redact-log` 和 TiFlash 添加了配置项 `security.redact_info_log`。改进提升方面，TiDB 添加了 `txn-entry-size-limit` 配置项，PD 优化了 `store-state-filter` 监控，Tools 中 TiCDC 默认开启了 old value 特性。Bug 修复方面，TiDB 修复了多个并发导致的问题，TiKV 修复了 peer 和 ready 之间的错误映射，PD 修复了 ID 分配不是单调递增的问题，TiFlash 修复了多个启动和函数调用的问题，Tools 中 TiCDC 修复了多个协议和内存问题，Dumpling 修改了默认设置的行为。 Backup & Restore (BR) 修复了多个备份和恢复问题，TiDB Binlog 修复了启用 `AMEND TRANSACTION` 特性时的问题，TiDB Lightning 修复了多个备份和使用问题。
+- [TiDB 4.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.11.md): TiDB 4.0.11 发布，新增支持 `uft8_unicode_ci` 和 `utf8mb4_unicode_ci` 排序规则。TiKV 支持 `utf8mb4_unicode_ci` 和 `cast_year_as_time` 排序规则。TiFlash 增加排队处理 Coprocessor 任务的线程池。改进包括重排由 `outer join` 简化的 `inner join` 顺序，Grafana 面板支持多集群，Bug 修复包括修复异常的 `unicode_ci` 常数传递等。PD 修复成员健康的监控显示不正确的问题。TiFlash 修复 Decimal 类型的 `min`/`max` 计算结果错误等。Tools 修复 TiCDC 服务在同时发生 `ErrTaskStatusNotExists` 和 `capture` 会话关闭的情况下的非预期的退出等。
+- [TiDB 4.0.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.12.md): TiDB 4.0.12 发布，新增 TiFlash 工具用于检测状态。优化了 EXPLAIN 语句输出信息，在 metrics 监控中记录了 PREPARE 执行失败的问题。TiKV 修复了多个问题，包括处理 JSON 向字符串转换时空格缺失的问题。PD 修复了 store 缺失 label 的隔离级别错误问题。TiFlash 修复了多个查询结果错误的问题。TiCDC 修复了多个数据丢失和资源释放问题。BR 修复了多个备份和恢复问题。TiDB Lightning 修复了多个数据错误和文件损坏问题。
+- [TiDB 4.0.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.13.md): TiDB 4.0.13 发布，新增 `AUTO_INCREMENT` 变更为 `AUTO_RANDOM` 功能，引入 `infoschema.client_errors_summary` 表。提升内存中统计信息缓存，减少 CPU 使用率。TiKV 提高 `store used size` 计算准确性，返回更多的 Region 以降低 Region miss。PD 优化 TSO 处理时间统计指标，更新 Dashboard 版本。TiFlash 自动清除过期历史数据。BR 支持备份恢复系统库，检查集群版本和备份数据版本。TiCDC 增加流程控制，清理陈旧临时文件，增加 HTTP 接口调用。修复多个 Bug。
+- [TiDB 4.0.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.14.md): TiDB 4.0.14 发布，包含兼容性更改、功能增强、改进提升和 Bug 修复。兼容性更改包括默认值修改和配置项更新。功能增强包括监控项添加和新功能支持。改进提升包括算子优化和系统变量支持。Bug 修复包括查询结果错误和函数参数错误修复。PD、TiDB Dashboard、TiFlash 和 Tools 也有相关更新和修复。
+- [TiDB 4.0.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.15.md): TiDB 4.0.15 发布，修复了执行 `SHOW VARIABLES` 速度慢的问题，以及多个 Bug 和兼容性变化。TiKV 支持动态修改 TiCDC 配置。TiDB 基于直方图的 row count 来触发 auto-analyze。TiKV 分离处理读写的 ready 状态以减少读延迟。PD 提升了同步 Region 信息的性能。BR 支持并发执行分裂和打散 Region 的操作。Dumpling 提升了 `SHOW TABLE STATUS` 的过滤效率。TiCDC 支持导入数据到带有表达式索引或带有基于虚拟生成列的索引的表中。修复了多个 Bug 和问题。
+- [TiDB 4.0.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.16.md): TiDB 4.0.16 发布，包含兼容性更改、提升改进和 Bug 修复。TiKV 改进了对非法 UTF-8 字符串的处理，Tools 中 TiCDC 改变了 Kafka Sink 默认值。TiDB 升级了 Grafana，TiKV 使用 zstd 算法压缩 SST 文件。Bug 修复包括统计信息模块的查询崩溃、`ENUM` 类型控制函数返回结果不正确等问题。TiKV 修复了多个问题，包括 Decimal 除法计算结果为负、监控项中 gRPC 平均延迟时间不准确等问题。PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了无法启动的问题。Tools 中 TiDB Binlog 修复了 Drainer 传输事务超过 1 GB 时退出的问题，TiCDC 修复了多个问题。
+- [TiDB 4.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.2.md): TiDB 4.0.2 发布，兼容性改进和新功能增加。TiDB 默认收集使用情况信息，并分享给 PingCAP 用于改善产品。新增功能包括支持 INSERT 语句中使用 MEMORY_QUOTA() hint，基于 TLS 证书 SAN 属性的登录认证，以及其他函数和表的新增配置项。Bug 修复包括执行计划不正确、运行时错误、内存统计过大等问题。PD、TiKV、TiFlash 和 TiCDC 也有相关改进和修复。Tools 中 Backup & Restore (BR) 提升了多表场景下的恢复数据性能。
+- [TiDB 4.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.3.md): TiDB 4.0.3 发布了新版本，包括 TiDB Dashboard、TiFlash、Tools 和改进提升等多个方面的更新和修复。新增功能包括 TiDB Dashboard 显示详细信息、TiFlash 支持文件加密、Tools 支持多种算法压缩备份文件等。改进提升方面包括增加全局变量控制日志记录、加速执行速度、默认打开执行信息收集等。此外，还修复了多个 Bug，包括 gRPC transportReader 异常、数据不完整、无法正确设置 safepoint 等问题。
+- [TiDB 4.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.4.md): TiDB 4.0.4 发布日期为 2020 年 7 月 31 日。此版本修复了多个 bug，包括查询 `information_schema.columns` 卡死的问题、`PointGet` 和 `BatchPointGet` 在遇到 `in(null)` 条件时出错的问题、`BatchPointGet` 算子结果不正确的问题以及 `HashJoin` 算子在遇到 `set`、`enum` 类型时查询结果不正确的问题。
+- [TiDB 4.0.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.5.md): TiDB 4.0.5 发布，兼容性变化包括修改参数和添加状态检查。新增功能包括为错误定义错误码和支持统一的 log 格式。优化提升包括减少 GC 锁扫描次数和降低统计信息对性能的影响。Bug 修复包括函数错误处理和查询结果错误等。PD 修复了 TSO 不可用和 Region 调度问题。TiFlash 修复了进程启动和升级问题。Tools 修复了恢复缓慢和同步任务问题。
+- [TiDB 4.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.6.md): TiDB 4.0.6 发布日期为 2020 年 9 月 15 日。新功能包括 TiFlash 中支持在广播 Join 中使用外连接，TiDB Dashboard 添加了多个页面和功能。TiCDC 从 v4.0.6 起成为正式功能。优化提升方面，TiDB 提升了分区表的写性能，支持调整 Union 执行算子的并发度等。Bug 修复方面，TiDB 修复了多个查询结果不正确的问题。TiKV 修复了统计信息估算错误的问题等。PD 修复了 store limit 的单位问题等。TiFlash 修复了多个启动失败和异常问题。Tools 方面也有多个问题得到解决。
+- [TiDB 4.0.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.7.md): TiDB 4.0.7 发布，新增 PD 客户端函数 `GetAllMembers` 和 TiDB Dashboard 统计指标关系图支持。TiDB 优化了 `join` 算子执行信息和协处理器缓存命中率信息，支持将 `ROUND` 函数下推至 TiFlash，并修复了多个 bug。TiKV 支持日志输出为 JSON 格式，修复了 TLS 握手失败导致 Status API 不可用的问题。PD 修复了多个问题，TiFlash 修正了 right outer join 结果错误。Backup & Restore (BR) 修复了恢复数据后导致 TiDB 配置变更的错误，Dumpling 修复了 metadata 解析失败的问题。
+- [TiDB 4.0.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.8.md): TiDB 4.0.8 发布，新增聚合函数 `APPROX_PERCENTILE` 和 `CAST` 函数下推支持。优化了索引组合计算表达式选择率的贪心算法，记录更多的 RPC 信息，提升慢查询性能。修复了多个 BUG，如分区表可能遇到非预期 Panic、外连接时 Index Merge Join 结果不正确等。 PD 修复了 TiDB Dashboard 引起 PD panic 的错误。TiFlash 修复了多个问题，如日志信息中时间戳错误、重启后可能提示数据文件损坏等。Backup & Restore (BR) 修复了 Restore 期间可能发生的 `send on closed channel` panic 问题。
+- [TiDB 4.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.9.md): TiDB 4.0.9 发布日期为 2020 年 12 月 21 日。该版本包含兼容性更改、新功能、优化提升、Bug 修复等内容。兼容性更改包括废弃配置文件中的某些配置项。新功能包括 TiFlash 支持存储引擎的新数据分布在多个硬盘上等。优化提升方面包括避免生成 (index) merge join 以得到更好的执行计划等。Bug 修复方面包括修复了前缀索引和 `OR` 条件一起使用时结果不正确的问题等。
+- [TiDB 5.0 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.0-rc.md): TiDB 5.0.0-rc 版本是 5.0 版本的前序版本。在 5.0 版本中，我们专注于帮助企业基于 TiDB 数据库快速构建应用程序，提升数据库性能、降低写入数据延迟、稳定性、可用性、容灾、SQL 语句效率等问题。新增聚簇索引、异步提交事务、Raft Joint Consensus 算法、不可见索引、`EXCEPT`/`INTERSECT` 操作符、悲观事务执行成功概率、字符集和排序规则优化、错误信息和日志信息脱敏、优化器选择索引稳定性、调度功能优化、备份与恢复、数据导入导出、`EXPLAIN` 功能优化、TiUP 增强功能等特性。
+- [TiDB 5.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.1.md): TiDB 5.0.1 发布日期为 2021 年 4 月 24 日。此版本包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括 TiDB 配置文件的默认值改变。改进提升方面，TiDB 支持 `VITESS_HASH()` 函数，TiKV 使用 `zstd` 压缩 Region Snapshot，PD 调整 Region 分数公式等。Bug 修复方面，TiDB 修复了多个查询结果可能错误的问题，TiKV 修复了多个导致问题的 Bug。Tools 方面也有多个 Bug 修复。
+- [TiDB 5.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.2.md): TiDB 5.0.2 发布日期为 2021 年 6 月 10 日。此版本包含兼容性更改、新功能、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具中的参数废弃和 TiKV 默认开启 Hibernate Region 特性。新功能包括 BR 支持 S3 兼容的存储和 TiFlash 优化锁操作。提升改进方面，TiDB 避免后台作业频繁读取表造成高 CPU 使用率，TiKV 添加背压功能和减少扫描的内存使用量。Bug 修复方面，修复了多个问题，包括索引导致的 panic、事务中的语句不正确使用、排序规则写入错误值等。
+- [TiDB 5.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.3.md): TiDB 5.0.3 发布日期为 2021 年 7 月 2 日。此版本包含兼容性更改、功能增强、提升改进和 Bug 修复。兼容性更改包括 `tidb_multi_statement_mode` 变量默认值变更和兼容 MySQL 5.7 的 noop 变量配置。功能增强方面，TiCDC 增加了 HTTP API 获取 changefeed 信息和节点健康信息。TiDB 提升了多个内置函数的支持和优化了聚合算子的代价常数。Bug 修复方面，修复了多个查询和函数使用时可能出现的问题。PD 升级了 TiDB Dashboard。TiFlash 支持了多个新功能和修复了多个问题。TiCDC、BR 和 TiDB Lightning 也进行了多项修复和优化。
+- [TiDB 5.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.4.md): TiDB 5.0.4 发布日期为 2021 年 9 月 27 日。此版本包含兼容性更改、功能增强、提升改进、Bug 修复等内容。兼容性更改包括修复了 `SHOW VARIABLES` 速度慢的问题，系统变量 `tidb_stmt_summary_max_stmt_count` 默认值修改为 `3000` 等。功能增强包括支持将系统变量 `tidb_enforce_mpp` 的值设为 `1` 以忽略优化器代价估算，强制使用 MPP 模式。提升改进包括基于直方图的 row count 来触发 auto-analyze、支持 MPP 查询的重试等。Bug 修复包括修复了查询分区表且分区键带有 `IS NULL` 条件时 TiDB 可能 panic 的问题等。
+- [TiDB 5.0.5 Release Note](https://docs.pingcap.com/tidb/stable/release-5.0.5.md): TiDB 5.0.5 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。详细信息请查看 issue
+- [TiDB 5.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.6.md): TiDB 5.0.6 发布日期为 2021 年 12 月 31 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具的错误输出改为标准错误，以及 Kafka sink 模块的默认值设置。提升改进方面，TiDB 改进了 coprocessor 遇到锁时的调试日志显示，TiKV 提高了插入 SST 文件的速度，PD 优化了调度器退出的速度。Bug 修复方面，TiDB 修复了多个问题，包括乐观事务冲突、MPP 查询相关日志、DML 和 DDL 语句并发执行等。TiKV 修复了多个节点停机导致的问题，PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了多个数据不一致的问题。TiCDC 修复了多个同步任务推进停滞的问题。Backup & Restore (BR) 修复了平均速度不准确的问题。Dumpling 修复了导出速度过慢的问题。
+- [TiDB 5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.0.md): TiDB 5.1 版本新增了许多关键特性，包括对 MySQL 8 中的公共表表达式和动态权限的支持，以及对数据表列类型的在线变更。此外，还引入了新的统计信息类型和锁视图功能，以提升查询稳定性和性能。同时，TiDB 5.1 修复了许多 Bug，包括投影消除、列包含 NULL 值时查询结果错误等问题。这些改进和修复将提升 TiDB 的性能和稳定性。
+- [TiDB 5.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.1.md): TiDB 5.1.1 发布，兼容性更改包括默认值修改和权限变更。功能增强方面新增 OIDC SSO 支持和 DAG 请求中的 `HAVING()` 函数。改进提升包括 Stale Read 成为正式功能、加快数据插入速度、稳定结果模式支持等。Bug 修复方面修复了多个问题，包括数据丢失、panic、数据不一致等。 Tools 方面也有多个修复，包括 TiCDC、Backup & Restore、TiDB Lightning。
+- [TiDB 5.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.2.md): TiDB 5.1.2 发布，包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括修复多个 Bug，改进提升包括根据直方图行数触发 auto-analyze、支持动态更改 TiCDC 配置项等。Bug 修复涉及 hash 列为 ENUM 类型时 index hash join 的结果可能出错、TiKV 从 v3.x 升级至较高版本后出现 Panic 等问题。Tools 方面的改进包括 BR 修复备份数据和恢复数据时显示的平均速度数值不准确的问题、Dumpling 修复特定 MySQL 版本下导致 dump 阶段卡死的问题等。
+- [TiDB 5.1.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.1.3.md): TiDB 5.1.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
+- [TiDB 5.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.4.md): TiDB 5.1.4 发布日期为 2022 年 2 月 22 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括系统变量 `tidb_analyze_version` 默认值修改为 `1`，以及 TiKV 在开启 `storage.enable-ttl` 后拒绝 TiDB 请求。提升改进方面，TiDB 支持在 Range 类型分区表中对 `IN` 表达式进行分区裁剪，TiKV 升级了 proc filesystem 版本。Bug 修复方面，修复了多个 TiDB 和 TiKV 的问题，包括内存泄露、配置项不生效、panic 等。Tools 方面也有多个修复和改进，包括 TiCDC、Backup & Restore、TiDB Binlog 和 TiDB Lightning。
+- [TiDB 5.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.5.md): TiDB 5.1.5 发布日期为 2022 年 12 月 28 日。此版本包含 PD 默认关闭编译 swagger server 的兼容性变更以及 TiDB、TiKV、PD、TiFlash 和 Tools 中的多项 Bug 修复。修复内容涵盖了窗口函数执行、动态模式、函数传入值计算、left join 删除数据、SQL 语句计算、连接错误、索引错误、HTTP 服务异常、并发列类型变更、空闲链接、SESSION 变量、Region 合并、KV client 连接、TiDB Binlog 错误、TiKV 运行、Raftstore 线程、Region merge、Follower Read、Async Commit、网络问题、Unified Read Pool CPU 表达式、TLS、并行聚合、查询错误、日期格式、MPP query、数据回收、逻辑运算符、备份系统表、增量扫描、Sorter 组件监控数据和 ddl schema 缓存优化。
+- [TiDB 5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.0.md): TiDB 5.2 版本于 2021 年 8 月 27 日发布。该版本新增了许多功能和改进，包括支持基于部分函数创建表达式索引、提升优化器的估算准确度、锁视图成为 GA 特性等。此外，还修复了多个 bug，提升了稳定性和性能。
+- [TiDB 5.2.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.1.md): TiDB 5.2.1 发布日期为 2021 年 9 月 9 日。此版本修复了 TiDB 在分区中下推聚合算子时的执行计划和执行报错问题。同时，TiKV 修复了 Region 迁移时出现的死锁导致 TiKV 不可用的问题。用户可通过关闭调度并重启出问题的 TiKV 来临时应对。
+- [TiDB 5.2.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.2.md): TiDB 5.2.2 发布日期为 2021 年 10 月 29 日。此版本包含了对 TiDB、TiKV、PD 和 Tools 的多项提升改进和 bug 修复。其中 TiDB 修复了多项问题，如 `plan cache` 无法感知 `unsigned` 标志变化、分区功能出现 `out of range` 时 `partition pruning` 出错等。TiKV 修复了因 Congest 错误而导致的 CDC 频繁增加 scan 重试的问题等。PD 修复了因超过副本配置数量而导致错误删除带有数据且处于 pending 状态的副本的问题等。TiFlash 修复了在部分平台上由于缺失 `nsl` 库而无法启动的问题。Tools 中的 TiCDC 也进行了多项修复，如当上游 TiDB 实例意外退出时，TiCDC 同步任务推进可能停滞的问题等。
+- [TiDB 5.2.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.2.3.md): TiDB 5.2.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
+- [TiDB 5.2.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.4.md): TiDB 5.2.4 发布日期为 2022 年 4 月 26 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB、TiKV 和 Tools 的调整。提升改进主要针对 TiKV 和 Tools 进行了优化。Bug 修复方面涉及 TiDB、TiKV、PD、TiFlash 和 Tools 的修复。
+- [TiDB 5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.0.md): TiDB 5.3.0 版本发布了许多重要的功能和改进，包括临时表、表属性设置、TiDB Dashboard 安全性提升、PD 时间戳处理流程优化、DM 同步性能提升、TiDB Lightning 分布式并行导入等。此外，还修复了许多 bug，提升了稳定性和性能。
+- [TiDB 5.3.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.1.md): TiDB 5.3.1 发布日期为 2022 年 3 月 3 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB Lightning 工具的默认值调整。提升改进包括 TiDB、TiKV 和 PD 的优化。Bug 修复包括 TiDB、TiKV、PD、TiFlash、Backup & Restore (BR)、TiCDC、TiDB Data Migration (DM) 和 TiDB Lightning 工具的问题修复。
+- [TiDB 5.3.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.2.md): TiDB 5.3.2 发布日期为 2022 年 6 月 29 日。该版本存在 bug，建议升级至 v5.3.3。兼容性变更包括修复了 auto ID 超出范围时的问题。TiKV 提升了 Raft 客户端的效率，并修复了多个 bug。TiDB 修复了多个 bug，包括 Amazon S3 数据计算错误和网络连接问题。PD 也修复了多个 bug。TiFlash 修复了存储目录配置错误和数据不一致的问题。BR 和 TiCDC 也有多个 bug 修复。DM 和 TiDB Lightning 也有 bug 修复。
+- [TiDB 5.3.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.3.3.md): TiDB 5.3.3 发布日期为 2022 年 9 月 14 日。此版本修复了 TiKV 存在的 bug，该 bug 导致在执行 SQL 语句时出现持续报错的问题。影响版本为 v5.3.2 和 v5.4.2，已在 v5.3.3 上修复。如果使用 v5.3.2 的 TiDB 集群，可以升级至 v5.3.3。除升级外，还可以重启无法向 PD 发送 Region 心跳的 TiKV 节点，直至不再有待发送的 Region 心跳为止。
+- [TiDB 5.3.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.4.md): TiDB 5.3.4 发布，提升了 TiKV 的自动 TLS 证书重新加载功能。修复了 TiDB、PD 和 TiFlash 的多个 bug，包括 Region 合并、权限清理、连接失败等问题。同时修复了工具 Dumpling 和 TiCDC 的导出数据和同步任务状态不正确的问题。
+- [TiDB 5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.0.md): TiDB 5.4.0 版本发布日期为 2022 年 2 月 15 日。此版本新增了许多功能和改进，包括支持 GBK 字符集、索引合并、有界限过期数据读取、统计信息采集配置持久化等。同时还修复了许多 bug，提升了稳定性和性能。
+- [TiDB 5.4.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.1.md): TiDB 5.4.1 发布日期为 2022 年 5 月 13 日。该版本未引入产品设计上的兼容性变化，但 Bug 修复可能带来兼容性变更。提升改进包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个方面的改进。Bug 修复方面包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个问题的修复。
+- [TiDB 5.4.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.2.md): TiDB 5.4.2 发布日期为 2022 年 7 月 8 日。该版本存在 bug，建议升级至 v5.4.3。此版本提升了 TiDB、TiKV、PD 和 Tools 的稳定性和可用性，并修复了多个 bug。
+- [TiDB 5.4.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.3.md): TiDB 5.4.3 发布，提升了 TiKV 和 Tools 的功能，修复了多个 Bug。包括 TiKV 支持更小的 RocksDB write stall 参数，TiDB 修复了多个查询和执行时可能出现的问题。PD 也修复了一些请求和权限问题。TiFlash 修复了一些函数和并行聚合的错误。Tools 中的 TiDB Lightning 修复了一些数据导入和连接问题，DM 修复了一些数据同步和连接问题，BR 修复了备份恢复和 Region 不均衡的问题，Dumpling 修复了 IPv6 的支持问题。
+- [TiDB 6.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.0.0-dmr.md): 了解 TiDB 6.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.0.md): 了解 TiDB 6.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.1.md): TiDB 6.1.1 发布日期为 2022 年 9 月 1 日。该版本兼容性变更包括大小写敏感语句不再敏感，以及默认关闭持续性能分析特性。其他变更包括新增内容和不同操作系统和 CPU 架构的支持。提升改进方面，引入了新的优化器提示和支持通过 gzip 压缩 metrics 响应减少 HTTP body 大小。Bug 修复方面，修复了多个 TiDB、TiKV、PD 和 TiFlash 的问题。 Tools 方面，TiDB Lightning 修复了多个问题，TiDB Data Migration (DM) 修复了多个问题，TiCDC 修复了多个问题，Backup & Restore (BR) 修复了多个问题，Dumpling 修复了一个问题，TiDB Binlog 修复了一个问题。
+- [TiDB 6.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.2.md): TiDB 6.1.2 发布，包括 TiDB、TiKV、Tools 和 Bug 修复。提升改进包括允许在一张表上同时设置数据放置规则和 TiFlash 副本。Bug 修复包括修复数据库级别的权限清理不正确的问题。
+- [TiDB 6.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.3.md): TiDB 6.1.3 发布日期为 2022 年 12 月 5 日。此版本兼容性变更包括 TiCDC 的默认值修改和事务拆分功能的优化。提升改进方面，PD 优化了锁的粒度，TiCDC 默认关闭 safeMode 并开启大事务拆分功能。此外，为了提升 TiDB 稳定性，Go 编译器版本从 go1.18 升级到了 go1.19。Bug 修复方面，修复了多个 TiDB、PD、TiKV、TiFlash 和 Tools 的问题。
+- [TiDB 6.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.4.md): 了解 TiDB 6.1.4 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.5.md): 了解 TiDB 6.1.5 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.6.md): 了解 TiDB 6.1.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.7.md): 了解 TiDB 6.1.7 版本的改进提升与错误修复。
+- [TiDB 6.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.2.0.md): 了解 TiDB 6.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.3.0.md): 了解 TiDB 6.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.4.0.md): 了解 TiDB 6.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.0.md): 了解 TiDB 6.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.1.md): 了解 TiDB 6.5.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.10.md): 了解 TiDB 6.5.10 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.11.md): 了解 TiDB 6.5.11 版本的改进提升和错误修复。
+- [TiDB 6.5.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.12.md): 了解 TiDB 6.5.12 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.2.md): 了解 TiDB 6.5.2 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.3.md): 了解 TiDB 6.5.3 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.4.md): 了解 TiDB 6.5.4 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.5.md): 了解 TiDB 6.5.5 版本的改进提升与错误修复。
+- [TiDB 6.5.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.6.md): 了解 TiDB 6.5.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.7.md): 了解 TiDB 6.5.7 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.8.md): 了解 TiDB 6.5.8 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.9.md): 了解 TiDB 6.5.9 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.6.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.6.0.md): 了解 TiDB 6.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.0.0.md): 了解 TiDB 7.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.0.md): 了解 TiDB 7.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.1.md): 了解 TiDB 7.1.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.2.md): 了解 TiDB 7.1.2 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.3.md): 了解 TiDB 7.1.3 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.4.md): 了解 TiDB 7.1.4 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.5.md): 了解 TiDB 7.1.5 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.6.md): 了解 TiDB 7.1.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.2.0.md): 了解 TiDB 7.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.3.0.md): 了解 TiDB 7.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.4.0.md): 了解 TiDB 7.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.0.md): 了解 TiDB 7.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.1.md): 了解 TiDB 7.5.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.2.md): 了解 TiDB 7.5.2 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.3.md): 了解 TiDB 7.5.3 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.4.md): 了解 TiDB 7.5.4 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.5.md): 了解 TiDB 7.5.5 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.6.md): 了解 TiDB 7.5.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.6.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.6.0.md): 了解 TiDB 7.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.0.0.md): 了解 TiDB 8.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.0.md): 了解 TiDB 8.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.1.md): 了解 TiDB 8.1.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.2.md): 了解 TiDB 8.1.2 版本的改进提升和错误修复。
+- [TiDB 8.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.2.0.md): 了解 TiDB 8.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.3.0.md): 了解 TiDB 8.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.4.0.md): 了解 TiDB 8.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.5.0.md): 了解 TiDB 8.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.5.1.md): 了解 TiDB 8.5.1 版本的操作系统支持变更、改进提升，以及错误修复。
+- [TiDB Control 使用说明](https://docs.pingcap.com/tidb/stable/tidb-control.md): TiDB Control 是 TiDB 的命令行工具，用于获取 TiDB 状态信息和调试。可通过 TiUP 安装或从源代码编译安装。使用介绍包括命令、选项和参数组成，以及全局参数和各子命令的功能。其中包括获取帮助信息、解码 base64 数据、解码 row key 和 value、操作 etcd、格式化日志文件，以及查询关键 key range 信息。注意：TiDB Control 主要用于诊断调试，不保证和 TiDB 未来引入的新特性完全兼容。
+- [TiDB Dashboard SQL 语句分析列表页面](https://docs.pingcap.com/tidb/stable/dashboard-statement-list.md): 查看所有 SQL 语句在集群上执行情况
+- [TiDB Dashboard SQL 语句分析执行详情页面](https://docs.pingcap.com/tidb/stable/dashboard-statement-details.md): 查看单个 SQL 语句执行的详细情况
+- [TiDB Dashboard Top SQL 页面](https://docs.pingcap.com/tidb/stable/top-sql.md): 使用 Top SQL 找到 CPU 开销较大的 SQL 语句
+- [TiDB Dashboard 介绍](https://docs.pingcap.com/tidb/stable/dashboard-intro.md): TiDB Dashboard 是 TiDB 4.0 版本后提供的图形化界面，用于监控和诊断集群。它内置于 TiDB 的 PD 组件中，无需独立部署。可以查看集群整体运行概况、组件及主机运行状态、集群读写流量分布、SQL 查询的执行信息、耗时较长的 SQL 语句执行信息、诊断集群问题并生成报告、查询所有组件日志、预估资源管控容量、收集分析各个组件的性能数据。
+- [TiDB Dashboard 实例性能分析 - 手动分析页面](https://docs.pingcap.com/tidb/stable/dashboard-profiling.md): 了解如何收集集群各个实例当前性能数据，从而分析复杂问题
+- [TiDB Dashboard 实例性能分析 - 持续分析页面](https://docs.pingcap.com/tidb/stable/continuous-profiling.md): 了解如何持续地收集 TiDB、TiKV、PD 各个实例的性能数据，缩短平均故障恢复时间
+- [TiDB Dashboard 常见问题](https://docs.pingcap.com/tidb/stable/dashboard-faq.md): TiDB Dashboard 常见问题汇总，包括访问、界面功能方面的常见问题与解决办法。若无法解决，请获取官方或社区支持。
+- [TiDB Dashboard 慢查询页面](https://docs.pingcap.com/tidb/stable/dashboard-slow-query.md): 了解如何在 TiDB Dashboard 中查看慢查询。
+- [TiDB Dashboard 日志搜索页面](https://docs.pingcap.com/tidb/stable/dashboard-log-search.md): 在集群中搜索所有节点上的日志
+- [TiDB Dashboard 概况页面](https://docs.pingcap.com/tidb/stable/dashboard-overview.md): TiDB Dashboard 概况页面显示整个集群的 QPS、查询延迟、Top SQL 语句、最近的慢查询、实例状态和监控及告警信息。登录后默认进入该页面，也可通过左侧导航条点击概况进入。包含最近一小时整个集群的 QPS 和查询延迟，以及最近一段时间内累计耗时最多的 SQL 语句和运行时间超过一定阈值的慢查询。还显示各个实例的节点数和状态，以及提供了便捷的链接方便用户查看详细监控或告警。
+- [TiDB Dashboard 流量可视化页面](https://docs.pingcap.com/tidb/stable/dashboard-key-visualizer.md): TiDB Dashboard 的流量可视化页面可用于分析 TiDB 集群的使用模式和排查流量热点。通过登录 TiDB Dashboard 或在浏览器中访问指定链接，可以查看流量可视化页面。页面展示了流量热力图，可观察到整体访问流量随时间的变化情况，以及热力图某个坐标的详细信息。流量可视化页面涉及的基本概念包括 Region、热点、热力图和 Region 压缩。使用介绍包括设置、观察时间段或 Region 范围、调整亮度、选择指标、刷新与自动刷新以及查看详情。常见热力图解读包括均衡结果、X 轴明暗交替、Y 轴明暗交替和明亮斜线。解决热点问题可参考 TiDB 高并发写入场景最佳实践。
+- [TiDB Dashboard 用户管理](https://docs.pingcap.com/tidb/stable/dashboard-user.md): 了解如何创建 SQL 用户用于访问 TiDB Dashboard
+- [TiDB Dashboard 监控关系图](https://docs.pingcap.com/tidb/stable/dashboard-metrics-relation.md): 了解 TiDB Dashboard 监控关系图
+- [TiDB Dashboard 监控页面](https://docs.pingcap.com/tidb/stable/dashboard-monitoring.md): 介绍如何通过 TiDB Dashboard 监控页面查看 Performance Overview 面板，以及如何理解面板上的关键指标项。
+- [TiDB Dashboard 诊断报告](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-report.md): TiDB Dashboard 诊断报告介绍了诊断报告的内容和查看技巧。报告包括基本信息、诊断信息、负载信息、概览信息、TiDB/PD/TiKV 监控信息和配置信息。对比报告显示两个时间段的差异，通过 DIFF_RATIO 和 Maximum Different Item 报表可以快速发现监控项的差异。
+- [TiDB Dashboard 资源管控页面](https://docs.pingcap.com/tidb/stable/dashboard-resource-manager.md): 介绍如何使用 TiDB Dashboard 的资源管控页面查看资源管控相关信息，以便预估集群容量，更好地进行资源配置。
+- [TiDB Dashboard 集群信息页面](https://docs.pingcap.com/tidb/stable/dashboard-cluster-info.md): 查看整个集群中 TiDB、TiKV、PD、TiFlash 组件的运行状态及其所在主机的运行状态
+- [TiDB Dashboard 集群诊断页面](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-access.md): TiDB Dashboard 集群诊断页面是用于诊断集群问题并生成诊断报告的工具。可以通过 TiDB Dashboard 或浏览器访问诊断页面。生成诊断报告的步骤包括设置时间范围和长度，然后点击开始。还可以生成对比报告来比较异常时间段和正常时间段的情况。已生成的报告会显示在主页列表中，可随时查看。
+- [TiDB Data Migration 1.0.x 到 2.0+ 手动升级](https://docs.pingcap.com/tidb/stable/manually-upgrade-dm-1.0-to-2.0.md): 了解如何从 TiDB Data Migration 1.0.x 手动升级到 2.0+。
+- [TiDB Data Migration Binlog 事件过滤](https://docs.pingcap.com/tidb/stable/dm-binlog-event-filter.md): 了解 DM 的关键特性 binlog 事件过滤 (Binlog event filter) 的使用方法和注意事项。
+- [TiDB Data Migration 上游数据库配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-source-configuration-file.md): TiDB Data Migration (DM) 上游数据库配置文件包括示例与配置项说明。示例配置文件包括上游数据库的配置项，如是否开启 GTID、是否开启 relay log、拉取上游 binlog 的起始文件名等。配置项说明包括全局配置、relay log 清理策略配置、任务状态检查配置和 Binlog event filter。配置项包括标识一个 MySQL 实例、是否使用 GTID 方式、是否开启 relay log、存储 relay log 的目录等。从 DM v2.0.2 开始，Binlog event filter 也可以在上游数据库配置文件中进行配置。
+- [TiDB Data Migration 任务前置检查](https://docs.pingcap.com/tidb/stable/dm-precheck.md): 了解 DM 执行数据迁移任务时将进行的前置检查。
+- [TiDB Data Migration 兼容性目录](https://docs.pingcap.com/tidb/stable/dm-compatibility-catalog.md): 了解 DM 各版本与上下游各类型数据库的兼容关系
+- [TiDB Data Migration 分库分表合并](https://docs.pingcap.com/tidb/stable/dm-shard-merge.md): 了解 DM 的分库分表合并功能。
+- [TiDB Data Migration 命令行参数](https://docs.pingcap.com/tidb/stable/dm-command-line-flags.md): 介绍 DM 各组件的主要命令行参数。
+- [TiDB Data Migration 处理告警](https://docs.pingcap.com/tidb/stable/dm-handle-alerts.md): 了解 DM 中各主要告警信息的处理方法。
+- [TiDB Data Migration 对 online DDL 工具的支持](https://docs.pingcap.com/tidb/stable/dm-online-ddl-tool-support.md): 了解 DM 对常见 online DDL 工具的支持情况，使用方法和注意事项。
+- [TiDB Data Migration 导出和导入集群的数据源和任务配置](https://docs.pingcap.com/tidb/stable/dm-export-import-config.md): 了解 TiDB Data Migration 导出和导入集群的数据源和任务配置。
+- [TiDB Data Migration 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-dm.md): 了解如何使用 TiUP Playground 快速部署试用 TiDB Data Migration 数据迁移工具。
+- [TiDB Data Migration 性能问题及处理方法](https://docs.pingcap.com/tidb/stable/dm-handle-performance-issues.md): 了解 DM 可能存在的常见性能问题及其处理方法。
+- [TiDB Data Migration 故障及处理方法](https://docs.pingcap.com/tidb/stable/dm-error-handling.md): 了解 DM 的错误系统及常见故障的处理方法。
+- [TiDB Data Migration 数据迁移任务配置向导](https://docs.pingcap.com/tidb/stable/dm-task-configuration-guide.md): 本文介绍了如何配置 TiDB Data Migration (DM) 的数据迁移任务。包括配置数据源、目标 TiDB 集群、需要迁移的表、需要过滤的操作、数据源表到目标 TiDB 表的映射以及分库分表合并等配置。详细配置规则可参考相关链接。
+- [TiDB Data Migration 日常巡检](https://docs.pingcap.com/tidb/stable/dm-daily-check.md): 了解 DM 工具的日常巡检。
+- [TiDB Data Migration 术语表](https://docs.pingcap.com/tidb/stable/dm-glossary.md): 学习 TiDB Data Migration 相关术语
+- [TiDB Data Migration 查询任务状态](https://docs.pingcap.com/tidb/stable/dm-query-status.md): 深入了解 TiDB Data Migration 如何查询数据迁移任务状态
+- [TiDB Data Migration 版本发布历史](https://docs.pingcap.com/tidb/stable/dm-release-notes.md): TiDB Data Migration 版本发布历史从 DM v5.4.0 起，TiDB Data Migration 的 Release Notes 合并入相同版本号的 TiDB Release Notes。如需阅读 v5.4.0 及之后版本的 DM Release Notes，请查看对应版本的 TiDB Release Notes 中 DM 相关的内容。如需阅读 v5.3.0 及更早版本的 DM Release Notes，请参考以下链接：5.3.0, 2.0.7, 2.0.6, 2.0.5, 2.0.4, 2.0.3, 2.0.2, 2.0.1, 2.0 GA, 2.0.0-rc.2, 2.0.0-rc, 1.0.7, 1.0.6, 1.0.5, 1.0.4, 1.0.3, 1.0.2.
+- [TiDB Data Migration 生成自签名证书](https://docs.pingcap.com/tidb/stable/dm-generate-self-signed-certificates.md): 了解如何生成自签名证书。
+- [TiDB Data Migration 简介](https://docs.pingcap.com/tidb/stable/dm-overview.md): 了解 TiDB Data Migration
+- [TiDB Data Migration 表路由](https://docs.pingcap.com/tidb/stable/dm-table-routing.md): 了解 DM 的关键特性表路由 (Table Routing) 的使用方法和注意事项。
+- [TiDB Data Migration 集群软硬件环境需求](https://docs.pingcap.com/tidb/stable/dm-hardware-and-software-requirements.md): 了解部署 DM 集群的软件和硬件要求。
+- [TiDB Data Migration 黑白名单过滤](https://docs.pingcap.com/tidb/stable/dm-block-allow-table-lists.md): 了解 DM 的关键特性黑白名单过滤 (Block & Allow List) 的使用方法和注意事项。
+- [TiDB Lightning Web 界面](https://docs.pingcap.com/tidb/stable/tidb-lightning-web-interface.md): 了解 TiDB Lightning 的服务器模式——通过 Web 界面来控制 TiDB Lightning。
+- [TiDB Lightning 前置检查](https://docs.pingcap.com/tidb/stable/tidb-lightning-prechecks.md): 本文档介绍了 TiDB Lightning 前置检查功能，确保 TiDB Lightning 能够顺利执行任务。
+- [TiDB Lightning 命令行参数](https://docs.pingcap.com/tidb/stable/tidb-lightning-command-line-full.md): 使用命令行配置 TiDB Lightning。
+- [TiDB Lightning 常见问题](https://docs.pingcap.com/tidb/stable/tidb-lightning-faq.md): TiDB Lightning 常见问题的摘要：TiDB Lightning 对TiDB/TiKV/PD 的最低版本要求，支持导入多个库，对下游数据库的账号权限要求，导数据过程中某个表报错不会影响其他表，正确重启 TiDB Lightning 的步骤，校验导入数据的正确性方法，支持的数据源格式，禁止导入不合规数据的方法，结束 tidb-lightning 进程的操作，使用千兆网卡的建议，TiDB Lightning 预留空间的原因，清除与 TiDB Lightning 相关的中间数据的步骤，获取 TiDB Lightning 运行时的 goroutine 信息的方法，TiDB Lightning 不兼容 Placement Rules in SQL 的原因，使用 TiDB Lightning 和 Dumpling 复制 schema 的步骤。
+- [TiDB Lightning 并行导入](https://docs.pingcap.com/tidb/stable/tidb-lightning-distributed-import.md): 本文档介绍了 TiDB Lightning 并行导入的概念、使用场景和使用方法。
+- [TiDB Lightning 快速上手](https://docs.pingcap.com/tidb/stable/get-started-with-tidb-lightning.md): TiDB Lightning 可快速将 MySQL 数据导入到 TiDB 集群中。首先使用 Dumpling 导出数据，然后部署 TiDB 集群。安装最新版本的 TiDB Lightning 并启动，最后检查数据导入情况。详细功能和使用请参考 TiDB Lightning 简介。
+- [TiDB Lightning 故障处理](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-lightning.md): 本文档总结了使用 TiDB Lightning 过程中常见的运行故障及解决方案。
+- [TiDB Lightning 数据源](https://docs.pingcap.com/tidb/stable/tidb-lightning-data-source.md): 了解 TiDB Lightning 支持的各类型数据源。
+- [TiDB Lightning 断点续传](https://docs.pingcap.com/tidb/stable/tidb-lightning-checkpoints.md): TiDB Lightning 提供了“断点续传”的功能，即使 `tidb-lightning` 崩溃，在重启时仍然接着之前的进度继续工作。断点续传可通过配置启用，存储方式包括本地文件和 MySQL 数据库。在出现不可恢复的错误时，可以使用 `tidb-lightning-ctl` 工具来控制断点的处理，包括重置断点状态、清除出错状态和移除断点。
+- [TiDB Lightning 术语表](https://docs.pingcap.com/tidb/stable/tidb-lightning-glossary.md): 了解 TiDB Lightning 相关的术语及定义。
+- [TiDB Lightning 监控告警](https://docs.pingcap.com/tidb/stable/monitor-tidb-lightning.md): TiDB Lightning 支持使用Prometheus采集监控指标。监控配置需手动部署，配置方法在 tidb-lightning.toml 中。Grafana 面板可用于监控速度、进度、资源使用和存储空间。监控指标包括计数器和直方图，用于计算引擎文件数量、闲置 worker、KV 编码器、处理过的表、引擎文件和 Chunks的状态，以及导入每个表所需时间等。
+- [TiDB Lightning 目标数据库要求](https://docs.pingcap.com/tidb/stable/tidb-lightning-requirements.md): 了解 TiDB Lightning 运行时对目标数据库的必需条件。
+- [TiDB Lightning 简介](https://docs.pingcap.com/tidb/stable/tidb-lightning-overview.md): TiDB Lightning 是用于导入 TB 级数据到 TiDB 的工具。了解 TiDB Lightning 的基本原理和使用方法。
+- [TiDB Lightning 配置参数](https://docs.pingcap.com/tidb/stable/tidb-lightning-configuration.md): 使用配置文件或命令行配置 TiDB Lightning。
+- [TiDB Lightning 错误处理功能](https://docs.pingcap.com/tidb/stable/tidb-lightning-error-resolution.md): 介绍了如何解决导入数据过程中的类型转换和冲突错误。
+- [TiDB OOM 故障排查](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-oom.md): TiDB OOM 故障排查总结了 OOM 常见问题的解决思路、故障现象、原因、解决方法和需要收集的诊断信息。排查思路包括确认是否属于 OOM 问题和进一步排查触发 OOM 的原因。常见故障原因包括部署问题、数据库问题和客户端问题。处理 OOM 问题需要收集操作系统内存配置、数据库版本和内存配置、Grafana TiDB 内存使用情况等信息。详细排查方法请参考相关章节。
+- [TiDB Operator](https://docs.pingcap.com/tidb/stable/tidb-operator-overview.md): 了解 Kubernetes 上的 TiDB 集群自动部署运维工具 TiDB Operator。
+- [TiDB Pre-GA Release Notes](https://docs.pingcap.com/tidb/stable/release-pre-ga.md): TiDB Pre-GA 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 改进了 SQL 查询优化器、大量 MySQL 兼容性相关功能、支持 Natural Join、JSON 类型支持、裁剪无用数据、支持在 SQL 语句中设置优先级、完成表达式重构。PD 支持手动切换 PD 集群 Leader。TiKV 改进了 Raft Log 使用独立的 RocksDB 实例、使用 DeleteRange 加快删除副本速度、Coprocessor 支持更多运算符下推、提升性能和稳定性。TiSpark Beta Release 支持谓词下推、支持聚合下推、支持范围裁剪。
+- [TiDB RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.1.md): TiDB RC1 于 2016 年 12 月 23 日发布，TiKV 提升了写入速度和稳定性，支持百 TB 级别数据，集群规模支持 200 个节点。PD 优化了调度策略框架，添加了 label 支持，提供了 PD Control。TiDB 新增了 SQL 查询优化器和更多 MySQL 内建函数，重构了 time 相关类型的实现，提升了和 MySQL 的兼容性。工具方面，Loader 兼容 Percona 的 Mydumper 数据格式，提供了多线程导入、出错重试、断点续传等功能，并且针对 TiDB 有优化。完成了一键部署工具。
+- [TiDB RC2 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.2.md): TiDB RC2 版本发布，提升了 MySQL 兼容性、SQL 优化器、系统稳定性和性能。对于 OLTP 场景，读取性能提升 60%，写入性能提升 30%。新增权限管理功能，支持基本权限管理和大量 MySQL 内建函数。完善监控，修复 Bug 和内存泄漏问题。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，支持更多下推功能，加入更多统计，修复 Bug。
+- [TiDB RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.3.md): TiDB RC3 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了负载均衡调度策略和流程，完善权限管理功能，DDL 速度显著提升。开源了 TiDB Ansible 项目，可以一键部署 / 升级 / 启停 TiDB 集群。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，修复 Bug。
+- [TiDB RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.4.md): TiDB RC4 版本对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了写入速度，计算任务调度支持优先级，避免分析型大事务影响在线事务。SQL 优化器全新改版，查询代价估算更准确，且能自动选择 Join 物理算子。功能方面进一步 MySQL 兼容性。同时开源了 TiSpark 项目，可以通过 Spark 读取和分析 TiKV 中的数据。PD 支持通过 PD 设置 TiKV location labels，调度优化，优化数据加载，加快 failover 速度。 TiKV 支持查询优先级设置，支持 RC 隔离级别，完善 Jepsen，支持 Document Store，提升性能，提升稳定性。TiSpark Beta Release 支持谓词下推，支持聚合下推，支持范围裁剪。
 - [Tidb Roadmap](https://docs.pingcap.com/zh/tidb/dev/tidb-roadmap): External documentation: https://docs.pingcap.com/zh/tidb/dev/tidb-roadmap
-- [TiDB 中的 TimeStamp Oracle (TSO)](https://docs.pingcap.com/tidb/stable/tso/): 了解 TiDB 中的 TimeStamp Oracle (TSO)。
-- [TiDB 中的各种超时](https://docs.pingcap.com/tidb/stable/dev-guide-timeouts-in-tidb/): 简单介绍 TiDB 中的各种超时，为排查错误提供依据。
-- [TiDB 乐观事务模型](https://docs.pingcap.com/tidb/stable/optimistic-transaction/): 了解 TiDB 的乐观事务模型。
-- [TiDB 事务概览](https://docs.pingcap.com/tidb/stable/transaction-overview/): 了解 TiDB 中的事务。
-- [TiDB 事务隔离级别](https://docs.pingcap.com/tidb/stable/transaction-isolation-levels/): 了解 TiDB 事务的隔离级别。
-- [TiDB 产品常见问题](https://docs.pingcap.com/tidb/stable/tidb-faq/): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理，具备水平扩容、高可用、实时 HTAP、云原生的特性。TiDB 不是基于 MySQL 开发的，而是由 PingCAP 团队完全自主开发的产品。TiDB 易用性很高，支持绝大部分 MySQL 8.0 的语法，但不支持触发器、存储过程、自定义函数等。TiDB 支持分布式事务，兼容 MySQL Client/Driver 的编程语言，支持其他存储引擎，如 TiKV、UniStore 和 MockTiKV。获取 TiDB 知识的途径包括官方文档、官方博客、AskTUG 社区论坛和 PingCAP Education。用户名长度限制为 32 个字符，最大列数为 1017，单行大小不超过 6MB。TiDB 不支持 XA，但支持对列存储引擎的高并发 INSERT 或 UPDATE 操作。
-- [TiDB 产品常见问题解答汇总](https://docs.pingcap.com/tidb/stable/faq-overview/): 汇总 TiDB 产品的常见问题解答。
-- [TiDB 使用限制](https://docs.pingcap.com/tidb/stable/tidb-limitations/): TiDB 中的使用限制包括标识符长度限制、数据库、表、视图、连接总个数限制、单个数据库和表的限制、单行限制、数据类型限制、SQL 语句限制和 TiKV 版本限制。
-- [TiDB 全局排序](https://docs.pingcap.com/tidb/stable/tidb-global-sort/): 了解 TiDB 全局排序功能的使用场景、限制、使用方法和实现原理。
-- [TiDB 内存控制文档](https://docs.pingcap.com/tidb/stable/configure-memory-usage/): TiDB 内存控制文档介绍了如何追踪和控制 SQL 查询过程中的内存使用情况，以及配置内存使用阈值和 tidb-server 实例的内存使用阈值。还介绍了使用 INFORMATION_SCHEMA 系统表查看内存使用情况，以及降低写入事务内存使用的方法。另外还介绍了流量控制和数据落盘的内存控制策略，以及通过设置环境变量 GOMEMLIMIT 缓解 OOM 问题。
-- [TiDB 分布式执行框架](https://docs.pingcap.com/tidb/stable/tidb-distributed-execution-framework/): 了解 TiDB 分布式执行框架的使用场景、限制、使用方法和实现原理。
-- [TiDB 功能概览](https://docs.pingcap.com/tidb/stable/basic-features/): 了解 TiDB 的功能概览。
-- [TiDB 增量备份与恢复使用指南](https://docs.pingcap.com/tidb/stable/br-incremental-guide/): 了解 TiDB 的增量备份与恢复功能使用。
-- [TiDB 备份与恢复功能使用概述](https://docs.pingcap.com/tidb/stable/br-use-overview/): 了解如何部署和使用 TiDB 集群的备份与恢复。
-- [TiDB 备份与恢复功能架构概述](https://docs.pingcap.com/tidb/stable/backup-and-restore-design/): 了解 TiDB 的备份与恢复功能的架构设计。
-- [TiDB 备份与恢复实践示例](https://docs.pingcap.com/tidb/stable/backup-and-restore-use-cases/): 介绍 TiDB 备份与恢复的具体使用示例，包括推荐环境配置、存储配置、备份策略及如何进行备份与恢复。
-- [TiDB 备份与恢复概述](https://docs.pingcap.com/tidb/stable/backup-and-restore-overview/): 了解不同场景下如何使用 TiDB 的备份与恢复功能，以及不同功能、版本间的兼容性。
-- [TiDB 安全配置最佳实践](https://docs.pingcap.com/tidb/stable/best-practices-for-security-configuration/): 介绍 TiDB 安全配置的最佳实践，帮助你降低潜在的安全风险。
-- [TiDB 安装部署常见问题](https://docs.pingcap.com/tidb/stable/deploy-and-maintain-faq/): 介绍 TiDB 集群安装部署的常见问题、原因及解决方法。
-- [TiDB 容灾方案概述](https://docs.pingcap.com/tidb/stable/dr-solution-introduction/): 了解 TiDB 提供的几种容灾方案，包括基于主备集群的容灾、基于多副本的单集群容灾和基于备份与恢复的容灾。
-- [TiDB 密码管理](https://docs.pingcap.com/tidb/stable/password-management/): 了解 TiDB 的用户密码管理机制。
-- [TiDB 工具下载](https://docs.pingcap.com/tidb/stable/download-ecosystem-tools/): 本文介绍如何下载 TiDB 工具包。TiDB 工具包包含常用工具如 Dumpling、TiDB Lightning、BR 等。如果部署环境能访问互联网，可直接通过 TiUP 命令一键部署所需的 TiDB 工具。操作系统需为 Linux，架构为 amd64 或 arm64。下载步骤包括访问 TiDB 社区版页面，找到 TiDB-community-toolkit 软件包并点击立即下载。注意，点击立即下载后默认下载当前 TiDB 的最新发布版本。根据要使用的工具选择安装对应的离线包。
-- [TiDB 工具功能概览](https://docs.pingcap.com/tidb/stable/ecosystem-tool-user-guide/): TiDB 提供了丰富的工具，包括部署运维工具 TiUP 和 TiDB Operator，数据管理工具如 TiDB Data Migration（DM）、Dumpling、TiDB Lightning、Backup & Restore（BR）、TiCDC、sync-diff-inspector，以及 OLAP 分析工具 TiSpark。这些工具可用于部署、数据迁移、备份恢复、数据校验等多种操作，满足不同需求。
-- [TiDB 工具的使用场景](https://docs.pingcap.com/tidb/stable/ecosystem-tool-user-case/): 本文档介绍 TiDB 工具的常见使用场景与工具选择。
-- [TiDB 快照备份与恢复使用指南](https://docs.pingcap.com/tidb/stable/br-snapshot-guide/): 了解如何使用 br 命令行工具进行 TiDB 快照备份与恢复。
-- [TiDB 快照备份与恢复功能架构](https://docs.pingcap.com/tidb/stable/br-snapshot-architecture/): 了解 TiDB 快照备份与恢复功能的架构设计。
-- [TiDB 快照备份与恢复命令行手册](https://docs.pingcap.com/tidb/stable/br-snapshot-manual/): 介绍备份与恢复 TiDB 集群快照的命令行。
-- [TiDB 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/performance-tuning-methods/): 本文介绍了基于数据库时间的系统优化方法，以及如何利用 TiDB Performance Overview 面板进行性能分析和优化。
-- [TiDB 悲观事务模式](https://docs.pingcap.com/tidb/stable/pessimistic-transaction/): 了解 TiDB 的悲观事务模式。
-- [TiDB 执行计划概览](https://docs.pingcap.com/tidb/stable/explain-overview/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划。
-- [TiDB 支持的第三方工具](https://docs.pingcap.com/tidb/stable/dev-guide-third-party-support/): TiDB 支持的第三方工具主要包括驱动、ORM 框架和 GUI。支持等级分为 Full 和 Compatible，其中 Full 表示绝大多数功能兼容性已得到支持，Compatible 表示大部分功能可使用但未经完整验证。对于支持的 Driver 或 ORM 框架并不包括应用端事务重试和错误处理。如果在使用工具连接 TiDB 时出现问题，可在 GitHub 上提交包含详细信息的 issue 以获得进展。
-- [TiDB 数据库快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-tidb/): 了解如何快速上手使用 TiDB 数据库。
-- [TiDB 数据库的存储](https://docs.pingcap.com/tidb/stable/tidb-storage/): 了解 TiDB 数据库的存储层。
-- [TiDB 数据库的计算](https://docs.pingcap.com/tidb/stable/tidb-computing/): 了解 TiDB 数据库的计算层。
-- [TiDB 数据库的调度](https://docs.pingcap.com/tidb/stable/tidb-scheduling/): TiDB 数据库的调度由 PD（Placement Driver）模块负责管理和实时调度集群数据。PD 需要收集节点和 Region 的状态信息，并根据调度策略制定调度计划，包括增加 / 删除副本、迁移 Leader 角色等基本操作。调度需满足副本数量、位置分布、负载均衡、存储空间利用等需求。PD 通过心跳包收集信息，并根据策略生成调度操作序列，但具体执行由 Region Leader 决定。
-- [TiDB 整体架构](https://docs.pingcap.com/tidb/stable/tidb-architecture/): 了解 TiDB 的整体架构。
-- [TiDB 日志备份与 PITR 使用指南](https://docs.pingcap.com/tidb/stable/br-pitr-guide/): 了解 TiDB 的日志备份与 PITR 功能使用。
-- [TiDB 日志备份与 PITR 功能架构](https://docs.pingcap.com/tidb/stable/br-log-architecture/): 了解 TiDB 的日志备份与 PITR 的架构设计。
-- [TiDB 日志备份与 PITR 命令行手册](https://docs.pingcap.com/tidb/stable/br-pitr-manual/): 介绍 TiDB 日志备份与 PITR 的命令行。
-- [TiDB 最佳实践](https://docs.pingcap.com/tidb/stable/tidb-best-practices/): TiDB 最佳实践总结了使用 TiDB 的一些优化技巧，包括 Raft 一致性协议、分布式事务、数据分片、负载均衡、SQL 到 KV 的映射方案、二级索引的实现方法等。建议阅读官方文档和知乎专栏了解更多细节。部署时推荐使用 TiUP，导入数据时可对 TiKV 参数进行调优。在写入和查询时需注意事务大小限制和并发度设置。监控系统和日志查看也是了解系统状态的重要方法。适用场景包括数据量大、不希望做 Sharding、需要事务和强一致性等。
-- [TiDB 热点问题处理](https://docs.pingcap.com/tidb/stable/troubleshoot-hot-spot-issues/): TiDB 热点问题处理：介绍定位和解决读写热点问题，包括常见热点场景、确定存在热点问题的方法、使用 TiDB Dashboard 定位热点表、使用 SHARD_ROW_ID_BITS 处理热点表、使用 AUTO_RANDOM 处理自增主键热点表、小表热点的优化、打散读热点。
-- [TiDB 版本发布历史](https://docs.pingcap.com/tidb/stable/release-notes/): 介绍 TiDB 版本发布历史。
-- [TiDB 版本发布时间线](https://docs.pingcap.com/tidb/stable/release-timeline/): 了解 TiDB 的版本发布时间线。
-- [TiDB 版本规则](https://docs.pingcap.com/tidb/stable/versioning/): 了解 TiDB 版本发布的规则。
-- [TiDB 特有的函数](https://docs.pingcap.com/tidb/stable/tidb-functions/): 学习使用 TiDB 特有的函数。
-- [TiDB 环境与系统配置检查](https://docs.pingcap.com/tidb/stable/check-before-deployment/): 了解部署 TiDB 前的环境检查操作。
-- [TiDB 用户账户管理](https://docs.pingcap.com/tidb/stable/user-account-management/): TiDB 用户账户管理主要包括用户名和密码设置、添加用户、删除用户、保留用户账户、设置资源限制、设置密码、忘记密码处理和刷新权限。用户可以通过 SQL 语句或图形化界面工具进行用户管理，同时可以使用 `FLUSH PRIVILEGES` 命令立即生效修改。 TiDB 在数据库初始化时会生成一个默认账户。
-- [TiDB 监控常见问题](https://docs.pingcap.com/tidb/stable/monitor-faq/): 介绍在监控 TiDB 集群时的常见问题、原因及解决方法。
-- [TiDB 监控指标](https://docs.pingcap.com/tidb/stable/grafana-tidb-dashboard/): 了解 Grafana Dashboard 中展示的关键指标。
-- [TiDB 监控框架概述](https://docs.pingcap.com/tidb/stable/tidb-monitoring-framework/): TiDB 使用 Prometheus 作为监控和性能指标存储，Grafana 用于可视化展示，以及 TiDB Dashboard 图形化界面用于监控及诊断 TiDB 集群。Prometheus 提供多个组件，包括 Prometheus Server、Client 代码库和 Alertmanager。Grafana 展示 TiDB 集群各组件的相关监控，分组包括备份恢复、Binlog、网络探活、磁盘性能、Kafka、TiDB Lightning 等。每个分组包含多个监控项页签，以及详细的监控指标看板。观看培训视频可快速了解监控与报警系统的体系、数据流转方式、系统管理方法和常用监控指标。
-- [TiDB 磁盘 I/O 过高的处理办法](https://docs.pingcap.com/tidb/stable/troubleshoot-high-disk-io/): 了解如何定位和处理 TiDB 存储 I/O 过高的问题。
-- [TiDB 社区荣誉列表](https://docs.pingcap.com/tidb/stable/credits/): 了解 TiDB 社区贡献者列表及角色。
-- [TiDB 离线包](https://docs.pingcap.com/tidb/stable/binary-package/): 了解 TiDB 离线包及其包含的内容。
-- [TiDB 简介](https://docs.pingcap.com/tidb/stable/overview/): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理 (HTAP)。具有水平扩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等特性。适用于高可用、强一致性要求高、数据规模大等各种应用场景。具有一键水平扩缩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等五大核心特性，以及金融行业、海量数据及高并发的 OLTP、实时 HTAP、数据汇聚、二次加工处理等四大核心应用场景。
-- [TiDB 证书鉴权使用指南](https://docs.pingcap.com/tidb/stable/certificate-authentication/): 了解使用 TiDB 的证书鉴权功能。
-- [TiDB 软件和硬件环境需求](https://docs.pingcap.com/tidb/stable/hardware-and-software-requirements/): TiDB 是一款开源的一站式实时 HTAP 数据库，支持部署在多种硬件环境和操作系统上。软件和硬件环境建议配置包括操作系统要求、编译和运行依赖库、Docker 镜像依赖、软件配置要求、服务器建议配置、网络要求、磁盘空间要求、客户端 Web 浏览器要求以及 TiFlash 存算分离架构的软硬件要求。
-- [TiDB 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tidb-configuration/): TiDB 配置参数包括启动参数和环境变量。启动参数包括 advertise-address、config、config-check、config-strict、cors 等。其中默认端口为 4000 和 10080。其他参数包括 log-file、metrics-addr、metrics-interval 等。注意配置文件的有效性和安全模式下的启动。
-- [TiDB 配置文件描述](https://docs.pingcap.com/tidb/stable/tidb-configuration-file/): 介绍未包含在命令行参数中的 TiDB 配置文件选项。
-- [TiDB 锁冲突问题处理](https://docs.pingcap.com/tidb/stable/troubleshoot-lock-conflicts/): 了解 TiDB 锁冲突问题以及处理方式。
-- [TiDB 集群报警规则](https://docs.pingcap.com/tidb/stable/alert-rules/): TiDB 集群中各组件的报警规则详解。
-- [TiDB 集群故障诊断](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-cluster/): TiDB 集群故障诊断包括收集出错信息、组件状态、日志信息、机器配置和 dmesg 中的问题。解决数据库连接问题需要确认服务是否启动，查看 tidb-server 日志并清空数据重新部署服务。解决 tidb-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 tikv-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 pd-server 启动报错需检查参数和端口占用。进程异常退出需检查是否在前台启动，使用 nohup+& 方式运行或写在脚本中。TiKV 进程异常重启需检查 OOM 信息和 panic log。连接被拒绝需确保网络参数正确。解决文件打开过多问题需确保 ulimit -n 足够大。数据库访问超时需检查拓扑结构、硬件配置、其他服务、操作、CPU 线程、网络 /IO 监控数据。
-- [TiDB 集群监控 API](https://docs.pingcap.com/tidb/stable/tidb-monitoring-api/): TiDB 提供状态接口和 Metrics 接口来监控集群状态。状态接口可获取 TiDB Server 的运行状态和存储信息，PD 的状态接口可查看整个 TiKV 集群的详细信息。Metrics 接口用于监控整个集群的状态和性能。部署 Prometheus 和 Grafana 后，配置 Grafana 即可使用 Metrics 接口。
-- [TiDB 集群管理常见问题](https://docs.pingcap.com/tidb/stable/manage-cluster-faq/): 介绍 TiDB 集群管理的常见问题、原因及解决方法。
-- [TiDB 集群问题导图](https://docs.pingcap.com/tidb/stable/tidb-troubleshooting-map/): 了解如何处理 TiDB 集群常见问题。
-- [TiDB 高并发写入场景最佳实践](https://docs.pingcap.com/tidb/stable/high-concurrency-best-practices/): 了解 TiDB 在高并发写入场景下的最佳实践。
-- [TIDB_CHECK_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-tidb-check-constraints/): 了解 INFORMATION_SCHEMA 表 `TIDB_CHECK_CONSTRAINTS`。
-- [TIDB_HOT_REGIONS](https://docs.pingcap.com/tidb/stable/information-schema-tidb-hot-regions/): 了解 information_schema 表 `TIDB_HOT_REGIONS`。
-- [TIDB_HOT_REGIONS_HISTORY](https://docs.pingcap.com/tidb/stable/information-schema-tidb-hot-regions-history/): 了解 information_schema 表 `TIDB_HOT_REGIONS_HISTORY`。
-- [TIDB_INDEX_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-tidb-index-usage/): 了解 INFORMATION_SCHEMA 表 `TIDB_INDEX_USAGE`。
-- [TIDB_INDEXES](https://docs.pingcap.com/tidb/stable/information-schema-tidb-indexes/): 了解 information_schema 表 `TIDB_INDEXES`。
-- [TIDB_SERVERS_INFO](https://docs.pingcap.com/tidb/stable/information-schema-tidb-servers-info/): 了解 INFORMATION_SCHEMA 表 `TIDB_SERVERS_INFO`。
-- [TIDB_TRX](https://docs.pingcap.com/tidb/stable/information-schema-tidb-trx/): 了解 INFORMATION_SCHEMA 表 `TIDB_TRX`。
-- [TiFlash MinTSO 调度器](https://docs.pingcap.com/tidb/stable/tiflash-mintso-scheduler/): 了解 TiFlash MinTSO 调度器的实现原理。
-- [TiFlash Pipeline Model 执行模型](https://docs.pingcap.com/tidb/stable/tiflash-pipeline-model/): 介绍 TiFlash 新的执行模型 Pipeline Model。
-- [TiFlash 兼容性说明](https://docs.pingcap.com/tidb/stable/tiflash-compatibility/): 了解与 TiFlash 不兼容的 TiDB 特性。
-- [TiFlash 升级帮助](https://docs.pingcap.com/tidb/stable/tiflash-upgrade-guide/): 了解升级 TiFlash 时的注意事项。
-- [TiFlash 命令行参数](https://docs.pingcap.com/tidb/stable/tiflash-command-line-flags/): TiFlash 的命令行启动参数包括 server --config-file、dttool migrate、dttool bench 和 dttool inspect。server --config-file 用于指定配置文件路径，dttool migrate 用于迁移 DTFile 的文件格式，dttool bench 用于提供 DTFile 的简单 IO 速度测试，dttool inspect 用于检查 DTFile 的完整性。每个命令都有对应的参数，可以根据需求进行配置。警告：TiFlash 目前只支持默认压缩等级的 LZ4 算法，自定义压缩参数并未经过大量测试。注意：为保证安全，DTTool 在迁移模式下会尝试对工作目录进行加锁。
-- [TiFlash 存算分离架构与 S3 支持](https://docs.pingcap.com/tidb/stable/tiflash-disaggregated-and-s3/): 了解 TiFlash 存算分离架构与 S3 支持。
-- [TiFlash 常见问题](https://docs.pingcap.com/tidb/stable/troubleshoot-tiflash/): 介绍 TiFlash 的常见问题、原因及解决办法。
-- [TiFlash 延迟物化](https://docs.pingcap.com/tidb/stable/tiflash-late-materialization/): 介绍通过使用 TiFlash 延迟物化的方式来加速 OLAP 场景的查询。
-- [TiFlash 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/tiflash-performance-tuning-methods/): 本文介绍了 Performance Overview 面板中 TiFlash 部分，帮助你了解和监控 TiFlash 的工作负载。
-- [TiFlash 性能调优](https://docs.pingcap.com/tidb/stable/tune-tiflash-performance/): 介绍 TiFlash 性能调优的方法，包括机器资源规划和 TiDB 参数调优。
-- [TiFlash 报警规则](https://docs.pingcap.com/tidb/stable/tiflash-alert-rules/): TiFlash 报警规则介绍了 TiFlash 集群的报警规则。包括了TiFlash_schema_error、TiFlash_schema_apply_duration、TiFlash_raft_read_index_duration 和 TiFlash_raft_wait_index_duration 四种报警规则，以及它们的规则描述和处理方法。报警规则主要用于监控TiFlash集群的运行状态，及时发现问题并联系 TiFlash 开发人员进行处理。
-- [TiFlash 支持的计算下推](https://docs.pingcap.com/tidb/stable/tiflash-supported-pushdown-calculations/): 了解 TiFlash 支持的计算下推。
-- [TiFlash 数据校验](https://docs.pingcap.com/tidb/stable/tiflash-data-validation/): 了解 TiFlash 的数据校验机制以及相关的工具。
-- [TiFlash 数据落盘](https://docs.pingcap.com/tidb/stable/tiflash-spill-disk/): 介绍 TiFlash 数据落盘功能。
-- [TiFlash 查询结果物化](https://docs.pingcap.com/tidb/stable/tiflash-results-materialization/): 介绍如何在同一个事务中保存 TiFlash 的查询结果。
-- [TiFlash 简介](https://docs.pingcap.com/tidb/stable/tiflash-overview/): TiFlash 是 TiDB HTAP 形态的关键组件，提供了良好的隔离性和强一致性。它使用列存扩展和 Raft Learner 协议异步复制，通过 Raft 校对索引配合 MVCC 实现一致性隔离级别。TiFlash 架构解决了 HTAP 场景的隔离性和列存同步问题。它提供列式存储和借助 ClickHouse 高效实现的协处理器层。TiFlash 可以兼容 TiDB 和 TiSpark，推荐与 TiKV 不同节点部署以实现 Workload 隔离。具有异步复制、一致性、智能选择和计算加速等核心特性。部署完成后需要手动指定需要同步的表。
-- [TiFlash 部署拓扑](https://docs.pingcap.com/tidb/stable/tiflash-deployment-topology/): 了解在部署最小拓扑集群的基础上，部署 TiFlash 的拓扑结构。
-- [TiFlash 配置参数](https://docs.pingcap.com/tidb/stable/tiflash-configuration/): TiFlash 配置参数包括 PD 调度参数和 TiFlash 配置参数。PD 调度参数可通过 pd-ctl 调整，包括 replica-schedule-limit 和 store-balance-rate。TiFlash 配置参数包括 tiflash.toml 和 tiflash-learner.toml，用于配置 TiFlash TCP/HTTP 服务的监听和存储路径。另外，通过拓扑 label 进行副本调度和多盘部署也是可行的。
-- [TiFlash 集群监控](https://docs.pingcap.com/tidb/stable/monitor-tiflash/): TiFlash 集群监控包括 TiFlash-Summary、TiFlash-Proxy-Summary 和 TiFlash-Proxy-Details。监控指标包括存储、内存、CPU 使用率、请求处理、错误数量、线程数、任务调度、DDL、写入、读取、Raft 等信息。注意低版本监控信息不完善，建议使用 v4.0.5 或更高版本的 TiDB 集群。
-- [TiFlash 集群运维](https://docs.pingcap.com/tidb/stable/maintain-tiflash/): TiFlash 集群运维包括查看版本、重要日志和系统表。查看版本有两种方法：通过命令或在日志中查看。重要日志包括数据同步和处理请求的信息。系统表包括数据库名、表名、副本数、位置标签、可用性和同步进度。
-- [TIFLASH_REPLICA](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-replica/): 了解 INFORMATION_SCHEMA 表 `TIFLASH_REPLICA`。
-- [TIFLASH_SEGMENTS](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-segments/): 了解 information_schema 表 `TIFLASH_SEGMENTS`。
-- [TIFLASH_TABLES](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-tables/): 了解 information_schema 表 `TIFLASH_TABLES`。
-- [TiKV Control 使用说明](https://docs.pingcap.com/tidb/stable/tikv-control/): TiKV Control（tikv-ctl）是 TiKV 的命令行工具，用于管理 TiKV 集群。它的安装目录在 `~/.tiup/components/ctl/{VERSION}/` 目录下。通过 TiUP 使用 TiKV Control，可以调用 `tikv-ctl` 工具。通用参数包括远程模式和本地模式，以及两个简单的命令 `--to-hex` 和 `--to-escaped`。其他子命令包括查看 Raft 状态机的信息、查看 Region 的大小、扫描查看给定范围的 MVCC、查看给定 key 的 MVCC、扫描 raw key、打印某个 key 的值、打印 Region 的 properties 信息、手动 compact 单个 TiKV 的数据、手动 compact 整个 TiKV 集群的数据、设置一个 Region 副本为 tombstone 状态、向 TiKV 发出 consistency-check 请求、Dump snapshot 元文件、打印 Raft 状态机出错的 Region、动态修改 TiKV 的配置、强制 Region 从多副本失败状态恢复服务、恢复损坏的 MVCC 数据、Ldb 命令、打印加密元数据、打印损坏的 SST 文件信息、获取一个 Region 的 RegionReadProgress 状态。
-- [TiKV MVCC 内存引擎](https://docs.pingcap.com/tidb/stable/tikv-in-memory-engine/): 了解内存引擎的适用场景和工作原理，使用内存引擎加速多版本记录查询。
-- [TiKV 内存参数性能调优](https://docs.pingcap.com/tidb/stable/tune-tikv-memory-performance/): TiKV 内存参数性能调优，根据机器配置情况调整参数以达到最佳性能。TiKV 使用 RocksDB 作为持久化存储，配置项包括 block-cache 大小和 write-buffer 大小。除此之外，系统内存还会被用于 page cache 和处理大查询时的数据结构生成。推荐将 TiKV 部署在 CPU 核数不低于 8 或内存不低于 32GiB 的机器上，对写入吞吐要求高时使用吞吐能力较好的磁盘，对读写延迟要求高时使用 IOPS 较高的 SSD 盘。
-- [TiKV 监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-tikv-dashboard/): TiKV 监控指标详解：TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构详见 TiDB 监控框架概述。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。对于日常运维，通过观察 TiKV-Details 面板上的指标，可以了解 TiKV 当前的状态。根据性能地图，可以检查集群的状态是否符合预期。TiKV-Details 默认的监控信息包括 Cluster、Errors、Server、gRPC、Thread CPU、PD、Raft IO、Raft process、Raft message、Raft propose、Raft admin、Local reader、Unified Read Pool、Storage、Flow Control、Scheduler 等。
-- [TiKV 简介](https://docs.pingcap.com/tidb/stable/tikv-overview/): TiKV 是一个分布式事务型的键值数据库，通过 Raft 协议保证了多副本数据一致性和高可用。整体架构采用 multi-raft-group 的副本机制，保证数据和读写负载均匀分散在各个 TiKV 上。TiKV 支持分布式事务，通过两阶段提交保证了 ACID 约束。同时，通过协处理器可以为 TiDB 分担一部分计算。
-- [TiKV 线程池性能调优](https://docs.pingcap.com/tidb/stable/tune-tikv-thread-performance/): 了解 TiKV 线程池性能调优。
-- [TiKV 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tikv-configuration/): TiKV 配置参数支持文件大小和时间的可读性好的单位转换。命令行参数包括监听地址、对外访问地址、服务状态监听端口、对外访问服务状态地址、配置文件、存储数据的容量、配置信息输出格式、数据存储路径、日志级别、日志文件、PD 地址列表。需要注意的是，PD 地址列表需要使用逗号分隔多个地址。
-- [TiKV 配置文件描述](https://docs.pingcap.com/tidb/stable/tikv-configuration-file/): 了解 TiKV 的配置文件参数。
-- [TIKV_REGION_PEERS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-region-peers/): 了解 INFORMATION_SCHEMA 表 `TIKV_REGION_PEERS`。
-- [TIKV_REGION_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-region-status/): 了解 information_schema 表 `TIKV_REGION_STATUS`。
-- [TIKV_STORE_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-store-status/): 了解 INFORMATION_SCHEMA 表 `TIKV_STORE_STATUS`。
-- [TiProxy API](https://docs.pingcap.com/tidb/stable/tiproxy-api/): 了解如何使用 TiProxy API 获取 TiProxy 的配置、健康状况和监控数据等信息。
-- [TiProxy 命令行参数](https://docs.pingcap.com/tidb/stable/tiproxy-command-line-flags/): 了解 TiProxy 的命令行参数。
-- [TiProxy 常见问题](https://docs.pingcap.com/tidb/stable/troubleshoot-tiproxy/): 介绍 TiProxy 的常见问题、原因及解决办法。
-- [TiProxy 性能测试报告](https://docs.pingcap.com/tidb/stable/tiproxy-performance-test/): TiProxy 的性能测试报告、与 HAProxy 的性能对比。
-- [TiProxy 流量回放](https://docs.pingcap.com/tidb/stable/tiproxy-traffic-replay/): 介绍 TiProxy 的流量回放的使用场景和使用步骤。
-- [TiProxy 监控指标](https://docs.pingcap.com/tidb/stable/tiproxy-grafana/): 了解 TiProxy 的监控指标。
-- [TiProxy 简介](https://docs.pingcap.com/tidb/stable/tiproxy-overview/): 介绍 TiProxy 的主要功能、安装与使用方法。
-- [TiProxy 负载均衡策略](https://docs.pingcap.com/tidb/stable/tiproxy-load-balance/): 介绍 TiProxy 的负载均衡策略及其适用场景。
-- [TiProxy 部署拓扑](https://docs.pingcap.com/tidb/stable/tiproxy-deployment-topology/): 了解在部署最小拓扑集群的基础上，部署 TiProxy 的拓扑结构。
-- [TiProxy 配置文件](https://docs.pingcap.com/tidb/stable/tiproxy-configuration/): 了解与 TiProxy 部署和使用相关的配置参数。
-- [TiSpark 用户指南](https://docs.pingcap.com/tidb/stable/tispark-overview/): 使用 TiSpark 一站式解决用户的 HTAP 需求。
-- [TiSpark 部署拓扑](https://docs.pingcap.com/tidb/stable/tispark-deployment-topology/): 介绍 TiUP 部署包含 TiSpark 组件的 TiDB 集群的拓扑结构。
-- [Titan 介绍](https://docs.pingcap.com/tidb/stable/titan-overview/): Titan 是基于 RocksDB 的高性能单机 key-value 存储引擎插件。它支持将 value 从 LSM-tree 中分离出来单独存储，以降低写放大。Titan 适合前台写入量较大的场景，但不适合范围查询或对范围查询性能敏感的情况。开启 Titan 需要考虑 value 大小、范围查询敏感性和磁盘空间。从 v7.6.0 开始，TiDB 对 Titan 性能进行了优化，并将其作为默认的存储引擎。Titan 的 GC 方式有传统 GC 和 Level Merge，而 `min-blob-size` 的大小会影响性能。
-- [Titan 配置](https://docs.pingcap.com/tidb/stable/titan-configuration/): Titan 配置介绍了如何开启、关闭 Titan、数据迁移原理、相关参数以及 Level Merge 功能。从 TiDB v7.6.0 开始，默认启用 Titan，支持宽表写入场景和 JSON。开启 Titan 方法包括使用 TiUP 部署集群、直接编辑 TiKV 配置文件、编辑 TiDB Operator 配置文件。数据迁移是逐步进行的，可以通过全量 Compaction 提高迁移速度。常用配置参数包括 `min-blob-size`、`blob-file-compression`、`blob-cache-size` 等。关闭 Titan 可通过设置 `blob-run-mode` 参数。Level Merge 是实验功能，可提升范围查询性能并降低 Titan GC 对前台写入性能的影响。
-- [tiup clean](https://docs.pingcap.com/tidb/stable/tiup-command-clean/): tiup clean 命令用于清除组件运行过程中产生的数据。可以使用 --all 选项清除所有运行记录。
-- [TiUP Cluster](https://docs.pingcap.com/tidb/stable/tiup-component-cluster/): TiUP Cluster 是使用 Golang 编写的集群管理组件，可进行部署、启动、关闭、销毁、弹性扩缩容、升级 TiDB 集群、管理参数。支持的命令有 import、template、check、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、rename、clean、destroy、audit、replay、enable、disable、meta backup、meta restore、help。
-- [tiup cluster audit](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-audit/): tiup cluster audit 命令用于查看集群执行的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息。输出包括指定的执行日志或包含 ID、时间和命令的表格。
-- [tiup cluster audit cleanup](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-audit-cleanup/): tiup cluster audit cleanup 命令用于清理 tiup cluster 产生的执行日志。--retain-days 选项用于设置执行日志保留天数，默认值为 60 天。-h, --help 选项用于输出帮助信息。执行命令后会输出 "clean audit log successfully"。
-- [tiup cluster check](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-check/): TiUP Cluster 提供了 `check` 子命令，用于检查集群的硬件和软件环境是否满足正常运行条件。检查包括操作系统版本、CPU 支持、系统时间、内核参数、磁盘挂载参数等。用户可以通过指定选项来启用 CPU 核心数、内存大小和磁盘性能测试的检查。检查结果将以表格形式输出，包括目标节点、检查项、检查结果和结果描述。
-- [tiup cluster clean](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-clean/): tiup cluster clean 命令用于在测试环境中重置集群到刚部署的状态。它会停止集群并删除数据。警告：生产环境禁止使用。语法：tiup cluster clean <cluster-name>。选项包括 --all（清理数据和日志）、--data（开启数据清理）、--log（开启日志清理）、--ignore-node（指定不清理的节点）、--ignore-role（指定不清理的角色）、-h, --help（输出帮助信息）。输出为 tiup-cluster 的执行日志。
-- [tiup cluster deploy](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-deploy/): tiup cluster deploy 命令用于部署全新集群。语法为 tiup cluster deploy <cluster-name> <version> <topology.yaml> [flags]。选项包括 -u, -i, -p, --ignore-config-check, --no-labels, --skip-create-user, -h。输出为部署日志。
-- [tiup cluster destroy](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-destroy/): tiup cluster destroy 命令用于销毁集群，包括停止集群、删除服务的日志目录、部署目录和数据目录。选项包括 --force（忽略错误）、--retain-node-data（指定保留数据的节点）、--retain-role-data（指定保留数据的角色）、-h（输出帮助信息）。执行日志将作为输出。
-- [tiup cluster disable](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-disable/): tiup cluster disable 命令用于关闭集群服务在机器重启后的自启动。使用该命令可以指定要关闭自启的集群、节点和角色。如果不指定节点和角色，则默认关闭所有节点和角色的自启动。输出为 tiup-cluster 的执行日志。
-- [tiup cluster display](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-display/): tiup cluster display 命令用于查看集群中每个组件的运行状态。可以通过指定选项来展示特定信息，如节点的 CPU 和内存使用情况，节点的 uptime 信息等。输出包括集群名称、版本、SSH 客户端类型、Dashboard 地址以及节点的 ID、角色、主机 IP、端口号、操作系统和机器架构、服务状态、数据目录和部署目录。节点服务状态包括在线、离线、已缩容下线、下线中和未知。详细状态含义可参考相关文档。
-- [tiup cluster edit-config](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-edit-config/): tiup cluster edit-config 命令用于调整部署集群后的配置。执行命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意不能增删机器，需执行 tiup cluster reload 命令来重新加载配置。语法为 tiup cluster edit-config <cluster-name>，选项包括 -h, --help。执行命令后正常情况下无输出，若修改了不能修改的字段则会报错并提示用户重新编辑。
-- [tiup cluster enable](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-enable/): tiup cluster enable 命令用于设置集群服务在机器重启后的自启动。命令会执行 systemctl enable <service> 来开启服务的自启。可以指定节点和角色来开启自启，同时可以输出帮助信息。执行日志将由 tiup-cluster 记录。
-- [tiup cluster help](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-help/): tiup-cluster 是一个命令行工具，提供丰富的帮助信息。用户可以通过 `help` 命令或 `--help` 参数获取帮助信息。`tiup cluster help <command>` 等同于 `tiup cluster <command> --help`。语法为 `tiup cluster help [command] [flags]`。使用 `-h` 或 `--help` 输出帮助信息，默认关闭。输出为 `[command]` 或 tiup-cluster 的帮助信息。
-- [tiup cluster import](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-import/): TiUP Cluster 提供了 `import` 命令，用于将 TiDB Ansible 部署的集群过渡到使用 tiup-cluster 组件管理。导入过程的日志信息将会输出。暂不支持导入启用了 TLS 加密功能、纯 KV 集群、启用了 Kafka 的集群、启用了 Spark 的集群、启用了 TiDB Lightning/Importer 的集群、仍使用老版本 `push` 的方式收集监控指标、单独为机器的 `node_exporter` / `blackbox_exporter` 设置了非默认端口的集群。如果集群中有部分节点未部署监控，应当先补充对应节点的信息，并将补充的监控组件部署完整。
-- [tiup cluster list](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-list/): tiup-cluster 支持使用同一个中控机部署多套集群。命令 `tiup cluster list` 可以查看当前登录的用户使用该中控机部署了哪些集群。输出包含 Name、User、Version、Path、PrivateKey 字段的表格。注意：部署的集群数据默认放在 `~/.tiup/storage/cluster/clusters/` 目录下，当前登录用户无法查看其他用户部署的集群。
-- [tiup cluster meta backup](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-meta-backup/): TiUP meta 文件丢失会导致无法管理集群。使用“tiup cluster meta backup”命令定期备份文件。命令语法为“tiup cluster meta backup <cluster-name>”。选项包括指定备份文件存储目录和帮助信息。输出为 tiup-cluster 的执行日志。
-- [tiup cluster meta restore](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-meta-restore/): TiUP cluster meta restore 命令用于从备份文件中恢复 TiUP meta 文件。语法为 tiup cluster meta restore <cluster-name> <backup-file>。选项包括 -h, --help，用于输出帮助信息。恢复操作会覆盖当前的 meta 文件，建议仅在 meta 文件丢失的情况下进行恢复。执行日志将作为输出。
-- [tiup cluster patch](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-patch/): tiup cluster patch 命令用于在集群运行过程中动态替换某个服务的二进制文件。它会上传替换的二进制包到目标机器，并通过 API 下线节点，停止目标服务，解压替换二进制包，最后启动目标服务。在使用命令前需要准备二进制包，包括确定组件名、版本、操作系统和平台，下载组件包，创建临时打包目录，解压原二进制包，复制要替换的文件到临时目录，最后打包所有文件。命令还包括一些选项，如 --overwrite、--transfer-timeout、-N、-R、--offline 等。
-- [tiup cluster prune](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-prune/): tiup cluster prune 命令用于在缩容集群时清理数据。对于某些组件，需要等数据调度完成后，用户手动执行该命令。选项包括 -h 或 --help，用于输出帮助信息。清理过程会生成日志。
-- [tiup cluster reload](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-reload/): tiup cluster reload 命令用于在修改集群配置后重新加载配置，使其生效。命令会将配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。可选参数包括 --force（忽略错误强制 reload）、--transfer-timeout（设置最长等待时间）、--ignore-config-check（跳过配置检查）、-N, --node（指定要重启的节点）、-R, --role（指定要重启的角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。执行日志会输出到 tiup-cluster。
-- [tiup cluster rename](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-rename/): tiup cluster rename 命令用于更改部署集群后的集群名。如果要更改集群名，可以使用 tiup cluster rename <old-cluster-name> <new-cluster-name> 命令。注意：如果配置了 grafana_servers 的 dashboard_dir 字段，需要更新本地 dashboards 目录中的 *.json 文件的 datasource 字段的值，并执行 tiup cluster reload -R grafana 命令。执行日志将输出到 tiup-cluster。
-- [tiup cluster replay](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-replay/): tiup cluster replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用 `tiup cluster audit` 查看历史命令及其 audit-id。执行命令：tiup cluster replay <audit-id>。选项：-h, --help。输出为对应命令的输出。
-- [tiup cluster restart](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-restart/): tiup cluster restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup cluster restart <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
-- [tiup cluster scale-in](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-scale-in/): tiup cluster scale-in 命令用于集群缩容，包括下线 TiKV 和 TiFlash 组件，以及其他组件。特殊处理包括通过 API 执行移除操作，并清理相关数据文件。命令语法为 tiup cluster scale-in <cluster-name>，必须指定要缩容的节点。其他选项包括 --force 用于强制移除宕机节点，--transfer-timeout 设置最长等待时间，-h 输出帮助信息。输出为缩容日志。
-- [tiup cluster scale-out](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-scale-out/): tiup cluster scale-out 命令用于集群扩容，内部逻辑与部署类似。PD 节点的扩容通过 join 方式加入集群，并更新相关服务配置；其他服务直接启动加入集群。命令语法为 tiup cluster scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user, -i, --identity_file, -p, --password, --no-labels, --skip-create-user, -h, --help。输出为扩容日志。
-- [tiup cluster start](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-start/): tiup cluster start 命令用于启动指定集群的所有或部分服务。语法为 tiup cluster start <cluster-name> [flags]。选项包括 --init（以安全方式启动集群）、-N, --node（指定要启动的节点）、-R, --role（指定要启动的角色）、-h, --help。输出为启动日志。
-- [tiup cluster stop](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-stop/): tiup cluster stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup cluster stop <cluster-name>。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
-- [tiup cluster template](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-template/): TiUP 内置了拓扑文件的模版，用户可以通过修改该模版来生成最终的拓扑文件。使用 tiup cluster template 命令可以输出 TiUP 内置的模版内容。该命令有多个选项，包括输出详细的拓扑模版、输出本地集群的简单拓扑模版以及输出多数据中心的拓扑模版。根据指定选项输出拓扑模版，可重定向到拓扑文件中用于部署。
-- [tiup cluster upgrade](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-upgrade/): tiup cluster upgrade 命令用于将指定集群升级到特定版本。命令语法为 tiup cluster upgrade <cluster-name> <version> [flags]。可使用 --force 选项忽略升级过程的错误，强制替换二进制文件并启动集群。还可通过设置 --transfer-timeout 设置最长等待时间，超时后会跳过等待直接升级服务。其他选项包括 --ignore-config-check、--ignore-version-check、--offline 等。升级服务的日志将会输出。
-- [tiup completion](https://docs.pingcap.com/tidb/stable/tiup-command-completion/): TiUP 提供了 `tiup completion` 命令，用于生成命令行自动补全的配置文件。目前支持 `bash` 和 `zsh` 两种 shell 的命令补全。安装方式包括在 macOS 上执行 `brew install bash-completion` 或 `brew install bash-completion@2`，在 Linux 上执行 `yum install bash-completion` 或 `apt install bash-completion`。使用方式包括在 `.bash_profile` 中执行 `source` 命令，并在 zsh 中执行 `tiup completion zsh > "${fpath[1]}/_tiup"`。
-- [TiUP DM](https://docs.pingcap.com/tidb/stable/tiup-component-dm/): TiUP DM 是用于对 DM 集群进行日常运维工作的管理工具，包括部署、启动、关闭、销毁、弹性扩缩容、升级、参数管理等操作。命令包括 import、template、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、destroy、audit、replay、enable、disable、help。
-- [tiup dm audit](https://docs.pingcap.com/tidb/stable/tiup-component-dm-audit/): tiup dm audit 命令用于查看所有集群上的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息，默认关闭。输出包括指定的 audit-id 对应的执行日志或包含 ID、时间和命令字段的表格。
-- [tiup dm deploy](https://docs.pingcap.com/tidb/stable/tiup-component-dm-deploy/): tiup dm deploy 命令用于部署全新的集群。语法为 tiup dm deploy <cluster-name> <version> <topology.yaml> [flags]，其中 cluster-name 表示新集群的名字，version 为要部署的 DM 集群版本号，topology.yaml 为事先编写好的拓扑文件。选项包括 -u, -i, -p, -h，分别用于指定连接目标机器的用户名、密钥文件、密码登录和输出帮助信息。输出为部署日志。
-- [tiup dm destroy](https://docs.pingcap.com/tidb/stable/tiup-component-dm-destroy/): tiup dm destroy 命令用于销毁集群，包括停止集群、删除日志目录、部署目录和数据目录。语法为 tiup dm destroy <cluster-name>。选项 -h, --help 用于输出帮助信息。输出为 tiup-dm 的执行日志。
-- [tiup dm disable](https://docs.pingcap.com/tidb/stable/tiup-component-dm-disable/): tiup dm disable 命令用于关闭集群服务重启后的自启动。语法为 tiup dm disable <cluster-name>，其中 <cluster-name> 为要关闭自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要关闭自启的节点和角色。若不指定选项，默认关闭所有节点和角色的自启。执行该命令将输出 tiup-dm 的执行日志。
-- [tiup dm display](https://docs.pingcap.com/tidb/stable/tiup-component-dm-display/): tiup-dm 提供了 `tiup dm display` 命令来高效查看集群中每个组件的运行状态。命令语法为 `tiup dm display <cluster-name>`，可指定要查询的节点和角色。输出包括集群名称、版本、SSH 客户端类型，以及节点 ID、角色、IP、端口号、操作系统、状态、数据目录和部署目录等信息。
-- [tiup dm edit-config](https://docs.pingcap.com/tidb/stable/tiup-component-dm-edit-config/): tiup dm edit-config 命令用于调整部署集群服务的配置。使用命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意：修改配置时不能增删机器，需执行 tiup dm reload 命令来重新加载配置。语法：tiup dm edit-config <cluster-name>。选项：-h, --help 输出帮助信息。输出：正常情况无输出，若修改了不能修改的字段，则保存文件时报错并提示用户重新编辑。
-- [tiup dm enable](https://docs.pingcap.com/tidb/stable/tiup-component-dm-enable/): tiup dm enable 命令用于设置集群服务在机器重启后的自启动。命令语法为 tiup dm enable <cluster-name>，其中 cluster-name 为要启用自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要开启自启的节点和角色。若不指定选项，默认开启所有节点和角色的自启。执行日志将作为输出。
-- [tiup dm help](https://docs.pingcap.com/tidb/stable/tiup-component-dm-help/): tiup-dm 提供丰富的命令行界面帮助信息，可通过 `help` 命令或 `--help` 参数获取。`tiup dm help <command>` 等同于 `tiup dm <command> --help`。语法：`tiup dm help [command] [flags]`。`[command]` 用于指定要查看的命令帮助信息，若不指定，则查看 tiup-dm 自身的帮助信息。使用 `-h, --help` 输出帮助信息，数据类型为 `BOOLEAN`，默认关闭。输出为 `[command]` 或 tiup-dm 的帮助信息。
-- [tiup dm import](https://docs.pingcap.com/tidb/stable/tiup-component-dm-import/): TiUP DM 提供了 `import` 命令，用于将 DM v1.0 集群导入到全新的 v2.0 集群。在导入前，请先停止原集群，并确认升级 TiUP DM 组件到最新版本。导入过程中会生成日志信息，不支持导入 v1.0 集群中的 DM Portal 组件。对于需要升级到 v2.0 的数据迁移任务，请不要执行 `stop-task`。具体语法和选项可以使用 `tiup dm import [flags]` 命令查看。
-- [tiup dm list](https://docs.pingcap.com/tidb/stable/tiup-component-dm-list/): tiup-dm 支持使用同一个中控机部署多套集群。命令 `tiup dm list` 可以查看当前登录的用户使用该中控机部署了哪些集群。部署的集群数据默认放在 `~/.tiup/storage/dm/clusters/` 目录下。在同一台中控机上，当前登录用户无法查看其他用户部署的集群。该命令输出含有集群名字、部署用户、集群版本、集群部署数据在中控机上的路径、连接集群的私钥所在路径的表格。
-- [tiup dm prune](https://docs.pingcap.com/tidb/stable/tiup-component-dm-prune/): tiup dm prune 命令用于在缩容集群后清理 etcd 中的少量元信息。通常情况下不会有问题，但如果需要清理，可以手动执行该命令。语法为 tiup dm prune <cluster-name>，选项包括 -h, --help，输出为清理过程的日志。
-- [tiup dm reload](https://docs.pingcap.com/tidb/stable/tiup-component-dm-reload/): tiup dm reload 命令用于在修改集群配置后重新加载配置。该命令将中控机的配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。语法为 tiup dm reload <cluster-name>。选项包括 -N, --node（重启节点）、-R, --role（重启角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。输出为 tiup-dm 的执行日志。
-- [tiup dm replay](https://docs.pingcap.com/tidb/stable/tiup-component-dm-replay/): tiup dm replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用命令时需指定要重试的命令对应的 audit-id，可通过 tiup dm audit 查看历史命令及其 audit-id。命令输出为对应命令的输出。
-- [tiup dm restart](https://docs.pingcap.com/tidb/stable/tiup-component-dm-restart/): tiup dm restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup dm restart <cluster-name> [flags]，其中 <cluster-name> 为要操作的集群名字。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
-- [tiup dm scale-in](https://docs.pingcap.com/tidb/stable/tiup-component-dm-scale-in/): tiup dm scale-in 命令用于集群缩容，即下线服务并移除指定节点和相关文件。语法为 tiup dm scale-in <cluster-name>，其中 <cluster-name> 为集群名。选项包括 -N, --node（必须非空，选择要缩容的节点），--force（强制移除宕机节点），-h, --help（输出帮助信息）。输出为缩容日志。
-- [tiup dm scale-out](https://docs.pingcap.com/tidb/stable/tiup-component-dm-scale-out/): tiup dm scale-out 命令用于集群扩容，内部逻辑与部署类似。首先建立新节点的 SSH 连接，在目标节点上创建必要的目录，然后执行部署并启动服务。命令语法为 tiup dm scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user（string，默认为当前执行命令的用户），-i, --identity_file（string，默认 ~/.ssh/id_rsa），-p, --password，-h, --help。输出为扩容日志。
-- [tiup dm start](https://docs.pingcap.com/tidb/stable/tiup-component-dm-start/): tiup dm start 命令用于启动指定集群的所有或部分服务。命令语法为 tiup dm start <cluster-name>。选项包括 -N, --node（指定要启动的节点），-R, --role（指定要启动的角色），-h, --help（输出帮助信息）。输出为启动日志。
-- [tiup dm stop](https://docs.pingcap.com/tidb/stable/tiup-component-dm-stop/): tiup dm stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup dm stop <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
-- [tiup dm template](https://docs.pingcap.com/tidb/stable/tiup-component-dm-template/): tiup dm template 命令用于输出 TiUP 内置的集群拓扑模版内容。可以通过修改模版来生成最终的拓扑文件。可选的 --full 选项输出详细的拓扑模版，带上可配置的参数。输出拓扑模版到标准输出，可重定向到拓扑文件中用于部署。
-- [tiup dm upgrade](https://docs.pingcap.com/tidb/stable/tiup-component-dm-upgrade/): tiup dm upgrade 命令用于将指定集群升级到特定版本。语法为 tiup dm upgrade <cluster-name> <version> [flags]。cluster-name 为要操作的集群名字，version 为要升级到的目标版本。选项 --offline 声明当前集群处于离线状态，-h, --help 输出帮助信息。升级服务的日志可查看。
-- [tiup env](https://docs.pingcap.com/tidb/stable/tiup-command-env/): TiUP 提供灵活的定制化接口，使用环境变量实现。命令 `tiup env` 用于查询 TiUP 支持的用户自定义环境变量及其值。若未指定环境变量，则输出"{key}"="{value}"列表。若指定了环境变量，则按顺序输出"{value}"列表。若值为空，则代表未设置环境变量的值，TiUP 会使用默认值。
-- [TiUP FAQ](https://docs.pingcap.com/tidb/stable/tiup-faq/): TiUP 支持自定义镜像源，可以使用环境变量 TIUP_MIRRORS 指定镜像源地址。开发者可以通过 tiup-publish 组件将自己编写的组件发布到 TiUP 的官方镜像仓库。TiUP Playground 用于快速搭建开发环境，而 TiUP Cluster 用于部署生产环境集群。拓扑文件样例包括两地三中心、最小部署和完整拓扑文件。同一主机可以部署多个实例，但需要配置不同的端口和目录信息。集群部署期间可能出现 ssh 连接错误，可尝试加大 ssh 默认连接数并重启 sshd 服务解决。
-- [tiup help](https://docs.pingcap.com/tidb/stable/tiup-command-help/): TiUP 命令行界面提供丰富的帮助信息，用户可通过 `help` 命令或 `--help` 参数查看。`tiup help <command>` 等同于 `tiup <command> --help`。语法为 `tiup help [command]`，若不指定命令，则查看 TiUP 自身的帮助信息。选项为无，输出为 `[command]` 或 TiUP 的帮助信息。
-- [tiup install](https://docs.pingcap.com/tidb/stable/tiup-command-install/): tiup install 命令用于从镜像仓库下载指定版本的组件包，并在本地解压。当需要运行不存在于镜像仓库中的组件时，会尝试下载并自动运行，若不存在会报错。语法为 tiup install <component1>[version] [component2...N] [flags]。输出包括组件的下载信息，若组件不存在则报错"The component "%s" not found"，若版本不存在则报错"version %s not supported by component %s"。
-- [tiup list](https://docs.pingcap.com/tidb/stable/tiup-command-list/): tiup list 命令用于查询镜像中可用的组件列表。可选的组件名称。若指定，则列出该组件的所有版本；若不指定，则列出所有组件列表。--all 显示所有组件。默认只显示非隐藏组件。--installed 只显示已经安装的组件或版本。--verbose 在组件列表中显示已安装的版本列表。若未指定组件名，输出组件名、组件管理员、组件描述构成的组件信息列表。若指定组件名，输出版本、是否已安装、发布时间、支持的平台构成的版本信息列表。
-- [tiup mirror](https://docs.pingcap.com/tidb/stable/tiup-command-mirror/): TiUP 中的镜像是一个重要概念，支持本地镜像和远程镜像。命令 `tiup mirror` 用于管理镜像，包括创建、发布、密钥管理等功能。语法为 `tiup mirror <command> [flags]`，支持的子命令包括 genkey、sign、init、set、grant、publish、modify、rotate、clone、merge。详细信息请参考 TiUP 命令清单。
-- [tiup mirror clone](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-clone/): tiup mirror clone 命令用于克隆已存在的镜像或部分组件生成新镜像。新旧镜像的组件相同，但使用的签名密钥不同。命令语法为 tiup mirror clone <target-dir> [global version] [flags]。选项包括 -f, --full, -a, --arch, -o, --os, --prefix, --{component}。
-- [tiup mirror genkey](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-genkey/): TiUP 镜像命令 genkey 用于生成私钥。管理员有 root.json、index.json、snapshot.json 和 timestamp.json 的修改权限。组件管理员有相关组件的修改权限。普通用户可以下载并使用组件。私钥名默认为 private，可以显示对应的公钥。可以将公钥信息储存为文件。输出包括私钥已存在或已写入，以及公钥内容。
-- [tiup mirror grant](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-grant/): tiup mirror grant 命令用于向当前镜像中添加组件管理员。组件管理员可以发布新组件或修改之前发布的组件。添加管理员时，需将公钥发送给镜像管理员。命令仅支持本地镜像使用。语法：tiup mirror grant <id>。选项：-k, --key（指定管理员密钥）、-n, --name（指定管理员名字）。输出：执行成功无输出，管理员 ID 重复报错，密钥被其他管理员使用报错。
-- [tiup mirror init](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-init/): tiup mirror init 命令用于初始化一个空的镜像。初始化的镜像不包含任何组件和组件管理员，仅生成一些文件。语法为 tiup mirror init <path> [flags]，其中 <path> 为本地目录路径，可以为相对路径。选项包括 -k, --key-dir（string，默认 {path}/keys）。输出包括若成功则无输出，若 <path> 不为空则输出错误信息，若 <path> 不是目录则输出错误信息。
-- [tiup mirror merge](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-merge/): tiup mirror merge 命令用于将一个或多个镜像合并到当前镜像。执行此命令需要目标镜像的管理员 ID 在当前镜像中存在，并且用户的 ${TIUP_HOME}/keys 目录中有对应的私钥。语法：tiup mirror merge <mirror-dir-1> [mirror-dir-N]。选项：无。输出：成功时无输出，否则会提示缺失管理员或私钥。
-- [tiup mirror modify](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-modify/): tiup mirror modify 命令用于修改已发布的组件。只有合法的组件管理员才能修改组件，且只能修改自己发布的组件。命令语法为 tiup mirror modify <component>[version]。选项包括 -k, --key, --yank, --hide。成功时无输出，无权限时会有相应错误提示。
-- [tiup mirror publish](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-publish/): tiup mirror publish 命令用于发布新组件或已有组件的新版本。只有有权限的组件管理员才可以发布组件。命令语法为 tiup mirror publish <comp-name> <version> <tarball> <entry> [flags]。其中各参数含义为组件名、版本号、tarball 包路径、组件可执行文件位置。命令还包含选项 -k, --key, --arch, --os, --desc, --hide。成功时无输出，无权限时会有相应错误提示。
-- [tiup mirror rotate](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-rotate/): TiUP 的镜像中有一个重要文件 root.json，记录了系统需要使用的公钥和信任链基础。包含管理员签名、用于验证的公钥和过期时间。更新 root.json 需要管理员重新签名，使用命令 `tiup mirror rotate` 自动化更新流程。需要确保 TiUP 客户端升级到 v1.5.0 或以上版本。命令启动编辑器修改内容，等待管理员签名。选项包括临时服务器监听地址。输出为各个镜像管理员当前的签名状态。
-- [tiup mirror set](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-set/): tiup mirror set 命令用于切换当前镜像，支持本地文件系统和远程网络两种镜像。命令语法为 tiup mirror set <mirror-addr> [flags]，其中 <mirror-addr> 为镜像地址，可以是网络地址或本地文件路径。选项 -r, --root 用于指定根证书。输出为无。
-- [tiup mirror sign](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-sign/): tiup mirror sign 命令用于对镜像中定义的元信息文件进行签名。语法为 tiup mirror sign <manifest-file>。选项包括 -k, --key 和 --timeout。输出包括成功、文件已被指定的 key 签名过和文件不是合法的 manifest。
-- [tiup status](https://docs.pingcap.com/tidb/stable/tiup-command-status/): tiup status 命令用于查看组件的运行信息，包括组件名称、进程 ID、运行状态、启动时间、数据目录、二进制文件路径和启动参数。组件可能处于在线、离线、无法访问、已缩容下线、下线中或未知状态。这些状态来自于 PD 的调度信息。
-- [tiup telemetry](https://docs.pingcap.com/tidb/stable/tiup-command-telemetry/): TiUP 遥测功能在 v1.11.3 及以上版本默认关闭，以下版本默认开启。开启后会分享使用情况信息给 PingCAP，包括遥测标示符、命令执行情况、部署情况等。不会分享集群准确名字、拓扑结构、配置文件。使用命令 `tiup telemetry` 控制遥测，支持 status、reset、enable、disable 命令。
-- [tiup uninstall](https://docs.pingcap.com/tidb/stable/tiup-command-uninstall/): tiup uninstall 命令用于卸载已安装的组件。语法为 tiup uninstall <component1> <version> [component2...N] [flags]。选项包括 --all 用于卸载指定组件的全部已安装版本，--self 用于卸载 TiUP 自身。正常退出时会显示"Uninstalled component "%s" successfully!"，若未指定 <version> 也未指定 --all 则会报错"Use "tiup uninstall tidbx --all" if you want to remove all versions."。
-- [tiup update](https://docs.pingcap.com/tidb/stable/tiup-command-update/): tiup update 命令用于升级已安装的组件或自身。语法为 tiup update [组件名] [版本]，可指定多个组件或版本。选项包括 --all（升级所有组件）、--force（强制升级已安装版本）、--nightly（升级到 nightly 版本）、--self（升级 TiUP 自身）。
-- [TiUP 命令概览](https://docs.pingcap.com/tidb/stable/tiup-reference/): TiUP 是 TiDB 生态的包管理器，管理着诸如 TiDB、PD、TiKV 等组件。它支持执行命令和运行组件，可以通过 `--help` 获取命令信息。选项包括打印二进制文件路径、指定组件路径、指定组件 tag、打印版本和帮助信息。TiUP 包含众多命令和子命令，以及组件清单。
-- [TiUP 常见运维操作](https://docs.pingcap.com/tidb/stable/maintain-tidb-using-tiup/): TiUP 是用于管理 TiDB 集群的工具，可以进行查看集群列表、启动、关闭、修改配置参数、查看状态等常见运维操作。操作简单方便，适合用于 TiDB 集群的管理。
-- [TiUP 故障排查](https://docs.pingcap.com/tidb/stable/tiup-troubleshooting-guide/): TiUP 故障排查包括命令故障排查和集群组件故障排查。命令故障包括强制刷新组件列表和版本信息，网络中断导致的下载问题，以及 checksum 错误。集群组件故障包括 SSH 私钥问题，升级中断和缺失组件文件的解决方法。可通过 Github Issues 或 AskTUG 求助。
-- [TiUP 文档地图](https://docs.pingcap.com/tidb/stable/tiup-documentation-guide/): TiUP 文档地图包括使用文档和资源两部分。使用文档包括 TiUP 概览、TiUP 术语、TiUP 组件管理、TiUP FAQ、TiUP 故障排查和 TiUP 参考手册。资源包括 TiUP 版本发布说明、AskTUG TiUP 主题和 TiUP Issues。
-- [TiUP 术语及核心概念](https://docs.pingcap.com/tidb/stable/tiup-terminology-and-concepts/): TiUP 是一个用于下载、更新、卸载组件的程序，通过各种组件来扩展其功能。组件是可以运行的程序或脚本，通过 tiup <component> 命令来运行。TiUP 组件可以从镜像仓库下载，用户可以通过设置 TIUP_MIRRORS 环境变量来自定义镜像仓库。
-- [TiUP 简介](https://docs.pingcap.com/tidb/stable/tiup-overview/): TiUP 是 TiDB 生态中的包管理工具，简化了软件的安装和升级维护工作。安装 TiUP 十分简洁，只需执行一行命令即可完成。TiUP 的愿景是降低 TiDB 生态中所有工具的使用门槛，通过命令和组件来实现包管理和操作。
-- [TiUP 镜像参考指南](https://docs.pingcap.com/tidb/stable/tiup-mirror-reference/): TiUP 镜像是存放 TiUP 组件和元信息的仓库。镜像存在两种形式：本地镜像和远程镜像。镜像可通过命令创建和更新。镜像目录结构包括根证书、索引、组件、快照和时间戳。客户端通过逻辑保证下载文件安全。
-- [TopN 和 Limit 下推](https://docs.pingcap.com/tidb/stable/topn-limit-push-down/): TiDB 中的 LIMIT 子句对应 Limit 算子节点，ORDER BY 子句对应 Sort 算子节点。相邻的 Limit 和 Sort 算子组合成 TopN 算子节点，表示按排序规则提取记录的前 N 项。TopN 下推将尽可能下推到数据源附近，减少数据传输或计算的开销。可参考 [优化规则及表达式下推的黑名单](/blocklist-control-plan.md) 中的关闭方法。TopN 可下推到存储层 Coprocessor，减少计算开销。TopN 无法下推过 Join，排序规则仅依赖于外表列时可下推。TopN 也可转换成 Limit，简化排序操作。
-- [TRACE](https://docs.pingcap.com/tidb/stable/sql-statement-trace/): TiDB 数据库中 TRACE 的使用概况。
-- [TRUNCATE](https://docs.pingcap.com/tidb/stable/sql-statement-truncate/): TiDB 数据库中 TRUNCATE 的使用概况。
-- [TSO 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tso-configuration/): TSO 配置参数可以通过命令行参数或环境变量配置。
-- [TSO 配置文件描述](https://docs.pingcap.com/tidb/stable/tso-configuration-file/): TSO 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
-- [UNLOCK STATS](https://docs.pingcap.com/tidb/stable/sql-statement-unlock-stats/): TiDB 数据库中 UNLOCK STATS 的使用概况。
-- [UPDATE](https://docs.pingcap.com/tidb/stable/sql-statement-update/): TiDB 数据库中 UPDATE 的使用概况。
+- [TiDB 中的 TimeStamp Oracle (TSO)](https://docs.pingcap.com/tidb/stable/tso.md): 了解 TiDB 中的 TimeStamp Oracle (TSO)。
+- [TiDB 中的各种超时](https://docs.pingcap.com/tidb/stable/dev-guide-timeouts-in-tidb.md): 简单介绍 TiDB 中的各种超时，为排查错误提供依据。
+- [TiDB 乐观事务模型](https://docs.pingcap.com/tidb/stable/optimistic-transaction.md): 了解 TiDB 的乐观事务模型。
+- [TiDB 事务概览](https://docs.pingcap.com/tidb/stable/transaction-overview.md): 了解 TiDB 中的事务。
+- [TiDB 事务隔离级别](https://docs.pingcap.com/tidb/stable/transaction-isolation-levels.md): 了解 TiDB 事务的隔离级别。
+- [TiDB 产品常见问题](https://docs.pingcap.com/tidb/stable/tidb-faq.md): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理，具备水平扩容、高可用、实时 HTAP、云原生的特性。TiDB 不是基于 MySQL 开发的，而是由 PingCAP 团队完全自主开发的产品。TiDB 易用性很高，支持绝大部分 MySQL 8.0 的语法，但不支持触发器、存储过程、自定义函数等。TiDB 支持分布式事务，兼容 MySQL Client/Driver 的编程语言，支持其他存储引擎，如 TiKV、UniStore 和 MockTiKV。获取 TiDB 知识的途径包括官方文档、官方博客、AskTUG 社区论坛和 PingCAP Education。用户名长度限制为 32 个字符，最大列数为 1017，单行大小不超过 6MB。TiDB 不支持 XA，但支持对列存储引擎的高并发 INSERT 或 UPDATE 操作。
+- [TiDB 产品常见问题解答汇总](https://docs.pingcap.com/tidb/stable/faq-overview.md): 汇总 TiDB 产品的常见问题解答。
+- [TiDB 使用限制](https://docs.pingcap.com/tidb/stable/tidb-limitations.md): TiDB 中的使用限制包括标识符长度限制、数据库、表、视图、连接总个数限制、单个数据库和表的限制、单行限制、数据类型限制、SQL 语句限制和 TiKV 版本限制。
+- [TiDB 全局排序](https://docs.pingcap.com/tidb/stable/tidb-global-sort.md): 了解 TiDB 全局排序功能的使用场景、限制、使用方法和实现原理。
+- [TiDB 内存控制文档](https://docs.pingcap.com/tidb/stable/configure-memory-usage.md): TiDB 内存控制文档介绍了如何追踪和控制 SQL 查询过程中的内存使用情况，以及配置内存使用阈值和 tidb-server 实例的内存使用阈值。还介绍了使用 INFORMATION_SCHEMA 系统表查看内存使用情况，以及降低写入事务内存使用的方法。另外还介绍了流量控制和数据落盘的内存控制策略，以及通过设置环境变量 GOMEMLIMIT 缓解 OOM 问题。
+- [TiDB 分布式执行框架](https://docs.pingcap.com/tidb/stable/tidb-distributed-execution-framework.md): 了解 TiDB 分布式执行框架的使用场景、限制、使用方法和实现原理。
+- [TiDB 功能概览](https://docs.pingcap.com/tidb/stable/basic-features.md): 了解 TiDB 的功能概览。
+- [TiDB 增量备份与恢复使用指南](https://docs.pingcap.com/tidb/stable/br-incremental-guide.md): 了解 TiDB 的增量备份与恢复功能使用。
+- [TiDB 备份与恢复功能使用概述](https://docs.pingcap.com/tidb/stable/br-use-overview.md): 了解如何部署和使用 TiDB 集群的备份与恢复。
+- [TiDB 备份与恢复功能架构概述](https://docs.pingcap.com/tidb/stable/backup-and-restore-design.md): 了解 TiDB 的备份与恢复功能的架构设计。
+- [TiDB 备份与恢复实践示例](https://docs.pingcap.com/tidb/stable/backup-and-restore-use-cases.md): 介绍 TiDB 备份与恢复的具体使用示例，包括推荐环境配置、存储配置、备份策略及如何进行备份与恢复。
+- [TiDB 备份与恢复概述](https://docs.pingcap.com/tidb/stable/backup-and-restore-overview.md): 了解不同场景下如何使用 TiDB 的备份与恢复功能，以及不同功能、版本间的兼容性。
+- [TiDB 安全配置最佳实践](https://docs.pingcap.com/tidb/stable/best-practices-for-security-configuration.md): 介绍 TiDB 安全配置的最佳实践，帮助你降低潜在的安全风险。
+- [TiDB 安装部署常见问题](https://docs.pingcap.com/tidb/stable/deploy-and-maintain-faq.md): 介绍 TiDB 集群安装部署的常见问题、原因及解决方法。
+- [TiDB 容灾方案概述](https://docs.pingcap.com/tidb/stable/dr-solution-introduction.md): 了解 TiDB 提供的几种容灾方案，包括基于主备集群的容灾、基于多副本的单集群容灾和基于备份与恢复的容灾。
+- [TiDB 密码管理](https://docs.pingcap.com/tidb/stable/password-management.md): 了解 TiDB 的用户密码管理机制。
+- [TiDB 工具下载](https://docs.pingcap.com/tidb/stable/download-ecosystem-tools.md): 本文介绍如何下载 TiDB 工具包。TiDB 工具包包含常用工具如 Dumpling、TiDB Lightning、BR 等。如果部署环境能访问互联网，可直接通过 TiUP 命令一键部署所需的 TiDB 工具。操作系统需为 Linux，架构为 amd64 或 arm64。下载步骤包括访问 TiDB 社区版页面，找到 TiDB-community-toolkit 软件包并点击立即下载。注意，点击立即下载后默认下载当前 TiDB 的最新发布版本。根据要使用的工具选择安装对应的离线包。
+- [TiDB 工具功能概览](https://docs.pingcap.com/tidb/stable/ecosystem-tool-user-guide.md): TiDB 提供了丰富的工具，包括部署运维工具 TiUP 和 TiDB Operator，数据管理工具如 TiDB Data Migration（DM）、Dumpling、TiDB Lightning、Backup & Restore（BR）、TiCDC、sync-diff-inspector，以及 OLAP 分析工具 TiSpark。这些工具可用于部署、数据迁移、备份恢复、数据校验等多种操作，满足不同需求。
+- [TiDB 工具的使用场景](https://docs.pingcap.com/tidb/stable/ecosystem-tool-user-case.md): 本文档介绍 TiDB 工具的常见使用场景与工具选择。
+- [TiDB 快照备份与恢复使用指南](https://docs.pingcap.com/tidb/stable/br-snapshot-guide.md): 了解如何使用 br 命令行工具进行 TiDB 快照备份与恢复。
+- [TiDB 快照备份与恢复功能架构](https://docs.pingcap.com/tidb/stable/br-snapshot-architecture.md): 了解 TiDB 快照备份与恢复功能的架构设计。
+- [TiDB 快照备份与恢复命令行手册](https://docs.pingcap.com/tidb/stable/br-snapshot-manual.md): 介绍备份与恢复 TiDB 集群快照的命令行。
+- [TiDB 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/performance-tuning-methods.md): 本文介绍了基于数据库时间的系统优化方法，以及如何利用 TiDB Performance Overview 面板进行性能分析和优化。
+- [TiDB 悲观事务模式](https://docs.pingcap.com/tidb/stable/pessimistic-transaction.md): 了解 TiDB 的悲观事务模式。
+- [TiDB 执行计划概览](https://docs.pingcap.com/tidb/stable/explain-overview.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划。
+- [TiDB 支持的第三方工具](https://docs.pingcap.com/tidb/stable/dev-guide-third-party-support.md): TiDB 支持的第三方工具主要包括驱动、ORM 框架和 GUI。支持等级分为 Full 和 Compatible，其中 Full 表示绝大多数功能兼容性已得到支持，Compatible 表示大部分功能可使用但未经完整验证。对于支持的 Driver 或 ORM 框架并不包括应用端事务重试和错误处理。如果在使用工具连接 TiDB 时出现问题，可在 GitHub 上提交包含详细信息的 issue 以获得进展。
+- [TiDB 数据库快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-tidb.md): 了解如何快速上手使用 TiDB 数据库。
+- [TiDB 数据库的存储](https://docs.pingcap.com/tidb/stable/tidb-storage.md): 了解 TiDB 数据库的存储层。
+- [TiDB 数据库的计算](https://docs.pingcap.com/tidb/stable/tidb-computing.md): 了解 TiDB 数据库的计算层。
+- [TiDB 数据库的调度](https://docs.pingcap.com/tidb/stable/tidb-scheduling.md): TiDB 数据库的调度由 PD（Placement Driver）模块负责管理和实时调度集群数据。PD 需要收集节点和 Region 的状态信息，并根据调度策略制定调度计划，包括增加 / 删除副本、迁移 Leader 角色等基本操作。调度需满足副本数量、位置分布、负载均衡、存储空间利用等需求。PD 通过心跳包收集信息，并根据策略生成调度操作序列，但具体执行由 Region Leader 决定。
+- [TiDB 整体架构](https://docs.pingcap.com/tidb/stable/tidb-architecture.md): 了解 TiDB 的整体架构。
+- [TiDB 日志备份与 PITR 使用指南](https://docs.pingcap.com/tidb/stable/br-pitr-guide.md): 了解 TiDB 的日志备份与 PITR 功能使用。
+- [TiDB 日志备份与 PITR 功能架构](https://docs.pingcap.com/tidb/stable/br-log-architecture.md): 了解 TiDB 的日志备份与 PITR 的架构设计。
+- [TiDB 日志备份与 PITR 命令行手册](https://docs.pingcap.com/tidb/stable/br-pitr-manual.md): 介绍 TiDB 日志备份与 PITR 的命令行。
+- [TiDB 最佳实践](https://docs.pingcap.com/tidb/stable/tidb-best-practices.md): TiDB 最佳实践总结了使用 TiDB 的一些优化技巧，包括 Raft 一致性协议、分布式事务、数据分片、负载均衡、SQL 到 KV 的映射方案、二级索引的实现方法等。建议阅读官方文档和知乎专栏了解更多细节。部署时推荐使用 TiUP，导入数据时可对 TiKV 参数进行调优。在写入和查询时需注意事务大小限制和并发度设置。监控系统和日志查看也是了解系统状态的重要方法。适用场景包括数据量大、不希望做 Sharding、需要事务和强一致性等。
+- [TiDB 热点问题处理](https://docs.pingcap.com/tidb/stable/troubleshoot-hot-spot-issues.md): TiDB 热点问题处理：介绍定位和解决读写热点问题，包括常见热点场景、确定存在热点问题的方法、使用 TiDB Dashboard 定位热点表、使用 SHARD_ROW_ID_BITS 处理热点表、使用 AUTO_RANDOM 处理自增主键热点表、小表热点的优化、打散读热点。
+- [TiDB 版本发布历史](https://docs.pingcap.com/tidb/stable/release-notes.md): 介绍 TiDB 版本发布历史。
+- [TiDB 版本发布时间线](https://docs.pingcap.com/tidb/stable/release-timeline.md): 了解 TiDB 的版本发布时间线。
+- [TiDB 版本规则](https://docs.pingcap.com/tidb/stable/versioning.md): 了解 TiDB 版本发布的规则。
+- [TiDB 特有的函数](https://docs.pingcap.com/tidb/stable/tidb-functions.md): 学习使用 TiDB 特有的函数。
+- [TiDB 环境与系统配置检查](https://docs.pingcap.com/tidb/stable/check-before-deployment.md): 了解部署 TiDB 前的环境检查操作。
+- [TiDB 用户账户管理](https://docs.pingcap.com/tidb/stable/user-account-management.md): TiDB 用户账户管理主要包括用户名和密码设置、添加用户、删除用户、保留用户账户、设置资源限制、设置密码、忘记密码处理和刷新权限。用户可以通过 SQL 语句或图形化界面工具进行用户管理，同时可以使用 `FLUSH PRIVILEGES` 命令立即生效修改。 TiDB 在数据库初始化时会生成一个默认账户。
+- [TiDB 监控常见问题](https://docs.pingcap.com/tidb/stable/monitor-faq.md): 介绍在监控 TiDB 集群时的常见问题、原因及解决方法。
+- [TiDB 监控指标](https://docs.pingcap.com/tidb/stable/grafana-tidb-dashboard.md): 了解 Grafana Dashboard 中展示的关键指标。
+- [TiDB 监控框架概述](https://docs.pingcap.com/tidb/stable/tidb-monitoring-framework.md): TiDB 使用 Prometheus 作为监控和性能指标存储，Grafana 用于可视化展示，以及 TiDB Dashboard 图形化界面用于监控及诊断 TiDB 集群。Prometheus 提供多个组件，包括 Prometheus Server、Client 代码库和 Alertmanager。Grafana 展示 TiDB 集群各组件的相关监控，分组包括备份恢复、Binlog、网络探活、磁盘性能、Kafka、TiDB Lightning 等。每个分组包含多个监控项页签，以及详细的监控指标看板。观看培训视频可快速了解监控与报警系统的体系、数据流转方式、系统管理方法和常用监控指标。
+- [TiDB 磁盘 I/O 过高的处理办法](https://docs.pingcap.com/tidb/stable/troubleshoot-high-disk-io.md): 了解如何定位和处理 TiDB 存储 I/O 过高的问题。
+- [TiDB 社区荣誉列表](https://docs.pingcap.com/tidb/stable/credits.md): 了解 TiDB 社区贡献者列表及角色。
+- [TiDB 离线包](https://docs.pingcap.com/tidb/stable/binary-package.md): 了解 TiDB 离线包及其包含的内容。
+- [TiDB 简介](https://docs.pingcap.com/tidb/stable/overview.md): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理 (HTAP)。具有水平扩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等特性。适用于高可用、强一致性要求高、数据规模大等各种应用场景。具有一键水平扩缩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等五大核心特性，以及金融行业、海量数据及高并发的 OLTP、实时 HTAP、数据汇聚、二次加工处理等四大核心应用场景。
+- [TiDB 证书鉴权使用指南](https://docs.pingcap.com/tidb/stable/certificate-authentication.md): 了解使用 TiDB 的证书鉴权功能。
+- [TiDB 软件和硬件环境需求](https://docs.pingcap.com/tidb/stable/hardware-and-software-requirements.md): TiDB 是一款开源的一站式实时 HTAP 数据库，支持部署在多种硬件环境和操作系统上。软件和硬件环境建议配置包括操作系统要求、编译和运行依赖库、Docker 镜像依赖、软件配置要求、服务器建议配置、网络要求、磁盘空间要求、客户端 Web 浏览器要求以及 TiFlash 存算分离架构的软硬件要求。
+- [TiDB 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tidb-configuration.md): TiDB 配置参数包括启动参数和环境变量。启动参数包括 advertise-address、config、config-check、config-strict、cors 等。其中默认端口为 4000 和 10080。其他参数包括 log-file、metrics-addr、metrics-interval 等。注意配置文件的有效性和安全模式下的启动。
+- [TiDB 配置文件描述](https://docs.pingcap.com/tidb/stable/tidb-configuration-file.md): 介绍未包含在命令行参数中的 TiDB 配置文件选项。
+- [TiDB 锁冲突问题处理](https://docs.pingcap.com/tidb/stable/troubleshoot-lock-conflicts.md): 了解 TiDB 锁冲突问题以及处理方式。
+- [TiDB 集群报警规则](https://docs.pingcap.com/tidb/stable/alert-rules.md): TiDB 集群中各组件的报警规则详解。
+- [TiDB 集群故障诊断](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-cluster.md): TiDB 集群故障诊断包括收集出错信息、组件状态、日志信息、机器配置和 dmesg 中的问题。解决数据库连接问题需要确认服务是否启动，查看 tidb-server 日志并清空数据重新部署服务。解决 tidb-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 tikv-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 pd-server 启动报错需检查参数和端口占用。进程异常退出需检查是否在前台启动，使用 nohup+& 方式运行或写在脚本中。TiKV 进程异常重启需检查 OOM 信息和 panic log。连接被拒绝需确保网络参数正确。解决文件打开过多问题需确保 ulimit -n 足够大。数据库访问超时需检查拓扑结构、硬件配置、其他服务、操作、CPU 线程、网络 /IO 监控数据。
+- [TiDB 集群监控 API](https://docs.pingcap.com/tidb/stable/tidb-monitoring-api.md): TiDB 提供状态接口和 Metrics 接口来监控集群状态。状态接口可获取 TiDB Server 的运行状态和存储信息，PD 的状态接口可查看整个 TiKV 集群的详细信息。Metrics 接口用于监控整个集群的状态和性能。部署 Prometheus 和 Grafana 后，配置 Grafana 即可使用 Metrics 接口。
+- [TiDB 集群管理常见问题](https://docs.pingcap.com/tidb/stable/manage-cluster-faq.md): 介绍 TiDB 集群管理的常见问题、原因及解决方法。
+- [TiDB 集群问题导图](https://docs.pingcap.com/tidb/stable/tidb-troubleshooting-map.md): 了解如何处理 TiDB 集群常见问题。
+- [TiDB 高并发写入场景最佳实践](https://docs.pingcap.com/tidb/stable/high-concurrency-best-practices.md): 了解 TiDB 在高并发写入场景下的最佳实践。
+- [TIDB_CHECK_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-tidb-check-constraints.md): 了解 INFORMATION_SCHEMA 表 `TIDB_CHECK_CONSTRAINTS`。
+- [TIDB_HOT_REGIONS](https://docs.pingcap.com/tidb/stable/information-schema-tidb-hot-regions.md): 了解 information_schema 表 `TIDB_HOT_REGIONS`。
+- [TIDB_HOT_REGIONS_HISTORY](https://docs.pingcap.com/tidb/stable/information-schema-tidb-hot-regions-history.md): 了解 information_schema 表 `TIDB_HOT_REGIONS_HISTORY`。
+- [TIDB_INDEX_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-tidb-index-usage.md): 了解 INFORMATION_SCHEMA 表 `TIDB_INDEX_USAGE`。
+- [TIDB_INDEXES](https://docs.pingcap.com/tidb/stable/information-schema-tidb-indexes.md): 了解 information_schema 表 `TIDB_INDEXES`。
+- [TIDB_SERVERS_INFO](https://docs.pingcap.com/tidb/stable/information-schema-tidb-servers-info.md): 了解 INFORMATION_SCHEMA 表 `TIDB_SERVERS_INFO`。
+- [TIDB_TRX](https://docs.pingcap.com/tidb/stable/information-schema-tidb-trx.md): 了解 INFORMATION_SCHEMA 表 `TIDB_TRX`。
+- [TiFlash MinTSO 调度器](https://docs.pingcap.com/tidb/stable/tiflash-mintso-scheduler.md): 了解 TiFlash MinTSO 调度器的实现原理。
+- [TiFlash Pipeline Model 执行模型](https://docs.pingcap.com/tidb/stable/tiflash-pipeline-model.md): 介绍 TiFlash 新的执行模型 Pipeline Model。
+- [TiFlash 兼容性说明](https://docs.pingcap.com/tidb/stable/tiflash-compatibility.md): 了解与 TiFlash 不兼容的 TiDB 特性。
+- [TiFlash 升级帮助](https://docs.pingcap.com/tidb/stable/tiflash-upgrade-guide.md): 了解升级 TiFlash 时的注意事项。
+- [TiFlash 命令行参数](https://docs.pingcap.com/tidb/stable/tiflash-command-line-flags.md): TiFlash 的命令行启动参数包括 server --config-file、dttool migrate、dttool bench 和 dttool inspect。server --config-file 用于指定配置文件路径，dttool migrate 用于迁移 DTFile 的文件格式，dttool bench 用于提供 DTFile 的简单 IO 速度测试，dttool inspect 用于检查 DTFile 的完整性。每个命令都有对应的参数，可以根据需求进行配置。警告：TiFlash 目前只支持默认压缩等级的 LZ4 算法，自定义压缩参数并未经过大量测试。注意：为保证安全，DTTool 在迁移模式下会尝试对工作目录进行加锁。
+- [TiFlash 存算分离架构与 S3 支持](https://docs.pingcap.com/tidb/stable/tiflash-disaggregated-and-s3.md): 了解 TiFlash 存算分离架构与 S3 支持。
+- [TiFlash 常见问题](https://docs.pingcap.com/tidb/stable/troubleshoot-tiflash.md): 介绍 TiFlash 的常见问题、原因及解决办法。
+- [TiFlash 延迟物化](https://docs.pingcap.com/tidb/stable/tiflash-late-materialization.md): 介绍通过使用 TiFlash 延迟物化的方式来加速 OLAP 场景的查询。
+- [TiFlash 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/tiflash-performance-tuning-methods.md): 本文介绍了 Performance Overview 面板中 TiFlash 部分，帮助你了解和监控 TiFlash 的工作负载。
+- [TiFlash 性能调优](https://docs.pingcap.com/tidb/stable/tune-tiflash-performance.md): 介绍 TiFlash 性能调优的方法，包括机器资源规划和 TiDB 参数调优。
+- [TiFlash 报警规则](https://docs.pingcap.com/tidb/stable/tiflash-alert-rules.md): TiFlash 报警规则介绍了 TiFlash 集群的报警规则。包括了TiFlash_schema_error、TiFlash_schema_apply_duration、TiFlash_raft_read_index_duration 和 TiFlash_raft_wait_index_duration 四种报警规则，以及它们的规则描述和处理方法。报警规则主要用于监控TiFlash集群的运行状态，及时发现问题并联系 TiFlash 开发人员进行处理。
+- [TiFlash 支持的计算下推](https://docs.pingcap.com/tidb/stable/tiflash-supported-pushdown-calculations.md): 了解 TiFlash 支持的计算下推。
+- [TiFlash 数据校验](https://docs.pingcap.com/tidb/stable/tiflash-data-validation.md): 了解 TiFlash 的数据校验机制以及相关的工具。
+- [TiFlash 数据落盘](https://docs.pingcap.com/tidb/stable/tiflash-spill-disk.md): 介绍 TiFlash 数据落盘功能。
+- [TiFlash 查询结果物化](https://docs.pingcap.com/tidb/stable/tiflash-results-materialization.md): 介绍如何在同一个事务中保存 TiFlash 的查询结果。
+- [TiFlash 简介](https://docs.pingcap.com/tidb/stable/tiflash-overview.md): TiFlash 是 TiDB HTAP 形态的关键组件，提供了良好的隔离性和强一致性。它使用列存扩展和 Raft Learner 协议异步复制，通过 Raft 校对索引配合 MVCC 实现一致性隔离级别。TiFlash 架构解决了 HTAP 场景的隔离性和列存同步问题。它提供列式存储和借助 ClickHouse 高效实现的协处理器层。TiFlash 可以兼容 TiDB 和 TiSpark，推荐与 TiKV 不同节点部署以实现 Workload 隔离。具有异步复制、一致性、智能选择和计算加速等核心特性。部署完成后需要手动指定需要同步的表。
+- [TiFlash 部署拓扑](https://docs.pingcap.com/tidb/stable/tiflash-deployment-topology.md): 了解在部署最小拓扑集群的基础上，部署 TiFlash 的拓扑结构。
+- [TiFlash 配置参数](https://docs.pingcap.com/tidb/stable/tiflash-configuration.md): TiFlash 配置参数包括 PD 调度参数和 TiFlash 配置参数。PD 调度参数可通过 pd-ctl 调整，包括 replica-schedule-limit 和 store-balance-rate。TiFlash 配置参数包括 tiflash.toml 和 tiflash-learner.toml，用于配置 TiFlash TCP/HTTP 服务的监听和存储路径。另外，通过拓扑 label 进行副本调度和多盘部署也是可行的。
+- [TiFlash 集群监控](https://docs.pingcap.com/tidb/stable/monitor-tiflash.md): TiFlash 集群监控包括 TiFlash-Summary、TiFlash-Proxy-Summary 和 TiFlash-Proxy-Details。监控指标包括存储、内存、CPU 使用率、请求处理、错误数量、线程数、任务调度、DDL、写入、读取、Raft 等信息。注意低版本监控信息不完善，建议使用 v4.0.5 或更高版本的 TiDB 集群。
+- [TiFlash 集群运维](https://docs.pingcap.com/tidb/stable/maintain-tiflash.md): TiFlash 集群运维包括查看版本、重要日志和系统表。查看版本有两种方法：通过命令或在日志中查看。重要日志包括数据同步和处理请求的信息。系统表包括数据库名、表名、副本数、位置标签、可用性和同步进度。
+- [TIFLASH_REPLICA](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-replica.md): 了解 INFORMATION_SCHEMA 表 `TIFLASH_REPLICA`。
+- [TIFLASH_SEGMENTS](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-segments.md): 了解 information_schema 表 `TIFLASH_SEGMENTS`。
+- [TIFLASH_TABLES](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-tables.md): 了解 information_schema 表 `TIFLASH_TABLES`。
+- [TiKV Control 使用说明](https://docs.pingcap.com/tidb/stable/tikv-control.md): TiKV Control（tikv-ctl）是 TiKV 的命令行工具，用于管理 TiKV 集群。它的安装目录在 `~/.tiup/components/ctl/{VERSION}/` 目录下。通过 TiUP 使用 TiKV Control，可以调用 `tikv-ctl` 工具。通用参数包括远程模式和本地模式，以及两个简单的命令 `--to-hex` 和 `--to-escaped`。其他子命令包括查看 Raft 状态机的信息、查看 Region 的大小、扫描查看给定范围的 MVCC、查看给定 key 的 MVCC、扫描 raw key、打印某个 key 的值、打印 Region 的 properties 信息、手动 compact 单个 TiKV 的数据、手动 compact 整个 TiKV 集群的数据、设置一个 Region 副本为 tombstone 状态、向 TiKV 发出 consistency-check 请求、Dump snapshot 元文件、打印 Raft 状态机出错的 Region、动态修改 TiKV 的配置、强制 Region 从多副本失败状态恢复服务、恢复损坏的 MVCC 数据、Ldb 命令、打印加密元数据、打印损坏的 SST 文件信息、获取一个 Region 的 RegionReadProgress 状态。
+- [TiKV MVCC 内存引擎](https://docs.pingcap.com/tidb/stable/tikv-in-memory-engine.md): 了解内存引擎的适用场景和工作原理，使用内存引擎加速多版本记录查询。
+- [TiKV 内存参数性能调优](https://docs.pingcap.com/tidb/stable/tune-tikv-memory-performance.md): TiKV 内存参数性能调优，根据机器配置情况调整参数以达到最佳性能。TiKV 使用 RocksDB 作为持久化存储，配置项包括 block-cache 大小和 write-buffer 大小。除此之外，系统内存还会被用于 page cache 和处理大查询时的数据结构生成。推荐将 TiKV 部署在 CPU 核数不低于 8 或内存不低于 32GiB 的机器上，对写入吞吐要求高时使用吞吐能力较好的磁盘，对读写延迟要求高时使用 IOPS 较高的 SSD 盘。
+- [TiKV 监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-tikv-dashboard.md): TiKV 监控指标详解：TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构详见 TiDB 监控框架概述。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。对于日常运维，通过观察 TiKV-Details 面板上的指标，可以了解 TiKV 当前的状态。根据性能地图，可以检查集群的状态是否符合预期。TiKV-Details 默认的监控信息包括 Cluster、Errors、Server、gRPC、Thread CPU、PD、Raft IO、Raft process、Raft message、Raft propose、Raft admin、Local reader、Unified Read Pool、Storage、Flow Control、Scheduler 等。
+- [TiKV 简介](https://docs.pingcap.com/tidb/stable/tikv-overview.md): TiKV 是一个分布式事务型的键值数据库，通过 Raft 协议保证了多副本数据一致性和高可用。整体架构采用 multi-raft-group 的副本机制，保证数据和读写负载均匀分散在各个 TiKV 上。TiKV 支持分布式事务，通过两阶段提交保证了 ACID 约束。同时，通过协处理器可以为 TiDB 分担一部分计算。
+- [TiKV 线程池性能调优](https://docs.pingcap.com/tidb/stable/tune-tikv-thread-performance.md): 了解 TiKV 线程池性能调优。
+- [TiKV 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tikv-configuration.md): TiKV 配置参数支持文件大小和时间的可读性好的单位转换。命令行参数包括监听地址、对外访问地址、服务状态监听端口、对外访问服务状态地址、配置文件、存储数据的容量、配置信息输出格式、数据存储路径、日志级别、日志文件、PD 地址列表。需要注意的是，PD 地址列表需要使用逗号分隔多个地址。
+- [TiKV 配置文件描述](https://docs.pingcap.com/tidb/stable/tikv-configuration-file.md): 了解 TiKV 的配置文件参数。
+- [TIKV_REGION_PEERS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-region-peers.md): 了解 INFORMATION_SCHEMA 表 `TIKV_REGION_PEERS`。
+- [TIKV_REGION_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-region-status.md): 了解 information_schema 表 `TIKV_REGION_STATUS`。
+- [TIKV_STORE_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-store-status.md): 了解 INFORMATION_SCHEMA 表 `TIKV_STORE_STATUS`。
+- [TiProxy API](https://docs.pingcap.com/tidb/stable/tiproxy-api.md): 了解如何使用 TiProxy API 获取 TiProxy 的配置、健康状况和监控数据等信息。
+- [TiProxy 命令行参数](https://docs.pingcap.com/tidb/stable/tiproxy-command-line-flags.md): 了解 TiProxy 的命令行参数。
+- [TiProxy 常见问题](https://docs.pingcap.com/tidb/stable/troubleshoot-tiproxy.md): 介绍 TiProxy 的常见问题、原因及解决办法。
+- [TiProxy 性能测试报告](https://docs.pingcap.com/tidb/stable/tiproxy-performance-test.md): TiProxy 的性能测试报告、与 HAProxy 的性能对比。
+- [TiProxy 流量回放](https://docs.pingcap.com/tidb/stable/tiproxy-traffic-replay.md): 介绍 TiProxy 的流量回放的使用场景和使用步骤。
+- [TiProxy 监控指标](https://docs.pingcap.com/tidb/stable/tiproxy-grafana.md): 了解 TiProxy 的监控指标。
+- [TiProxy 简介](https://docs.pingcap.com/tidb/stable/tiproxy-overview.md): 介绍 TiProxy 的主要功能、安装与使用方法。
+- [TiProxy 负载均衡策略](https://docs.pingcap.com/tidb/stable/tiproxy-load-balance.md): 介绍 TiProxy 的负载均衡策略及其适用场景。
+- [TiProxy 部署拓扑](https://docs.pingcap.com/tidb/stable/tiproxy-deployment-topology.md): 了解在部署最小拓扑集群的基础上，部署 TiProxy 的拓扑结构。
+- [TiProxy 配置文件](https://docs.pingcap.com/tidb/stable/tiproxy-configuration.md): 了解与 TiProxy 部署和使用相关的配置参数。
+- [TiSpark 用户指南](https://docs.pingcap.com/tidb/stable/tispark-overview.md): 使用 TiSpark 一站式解决用户的 HTAP 需求。
+- [TiSpark 部署拓扑](https://docs.pingcap.com/tidb/stable/tispark-deployment-topology.md): 介绍 TiUP 部署包含 TiSpark 组件的 TiDB 集群的拓扑结构。
+- [Titan 介绍](https://docs.pingcap.com/tidb/stable/titan-overview.md): Titan 是基于 RocksDB 的高性能单机 key-value 存储引擎插件。它支持将 value 从 LSM-tree 中分离出来单独存储，以降低写放大。Titan 适合前台写入量较大的场景，但不适合范围查询或对范围查询性能敏感的情况。开启 Titan 需要考虑 value 大小、范围查询敏感性和磁盘空间。从 v7.6.0 开始，TiDB 对 Titan 性能进行了优化，并将其作为默认的存储引擎。Titan 的 GC 方式有传统 GC 和 Level Merge，而 `min-blob-size` 的大小会影响性能。
+- [Titan 配置](https://docs.pingcap.com/tidb/stable/titan-configuration.md): Titan 配置介绍了如何开启、关闭 Titan、数据迁移原理、相关参数以及 Level Merge 功能。从 TiDB v7.6.0 开始，默认启用 Titan，支持宽表写入场景和 JSON。开启 Titan 方法包括使用 TiUP 部署集群、直接编辑 TiKV 配置文件、编辑 TiDB Operator 配置文件。数据迁移是逐步进行的，可以通过全量 Compaction 提高迁移速度。常用配置参数包括 `min-blob-size`、`blob-file-compression`、`blob-cache-size` 等。关闭 Titan 可通过设置 `blob-run-mode` 参数。Level Merge 是实验功能，可提升范围查询性能并降低 Titan GC 对前台写入性能的影响。
+- [tiup clean](https://docs.pingcap.com/tidb/stable/tiup-command-clean.md): tiup clean 命令用于清除组件运行过程中产生的数据。可以使用 --all 选项清除所有运行记录。
+- [TiUP Cluster](https://docs.pingcap.com/tidb/stable/tiup-component-cluster.md): TiUP Cluster 是使用 Golang 编写的集群管理组件，可进行部署、启动、关闭、销毁、弹性扩缩容、升级 TiDB 集群、管理参数。支持的命令有 import、template、check、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、rename、clean、destroy、audit、replay、enable、disable、meta backup、meta restore、help。
+- [tiup cluster audit](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-audit.md): tiup cluster audit 命令用于查看集群执行的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息。输出包括指定的执行日志或包含 ID、时间和命令的表格。
+- [tiup cluster audit cleanup](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-audit-cleanup.md): tiup cluster audit cleanup 命令用于清理 tiup cluster 产生的执行日志。--retain-days 选项用于设置执行日志保留天数，默认值为 60 天。-h, --help 选项用于输出帮助信息。执行命令后会输出 "clean audit log successfully"。
+- [tiup cluster check](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-check.md): TiUP Cluster 提供了 `check` 子命令，用于检查集群的硬件和软件环境是否满足正常运行条件。检查包括操作系统版本、CPU 支持、系统时间、内核参数、磁盘挂载参数等。用户可以通过指定选项来启用 CPU 核心数、内存大小和磁盘性能测试的检查。检查结果将以表格形式输出，包括目标节点、检查项、检查结果和结果描述。
+- [tiup cluster clean](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-clean.md): tiup cluster clean 命令用于在测试环境中重置集群到刚部署的状态。它会停止集群并删除数据。警告：生产环境禁止使用。语法：tiup cluster clean <cluster-name>。选项包括 --all（清理数据和日志）、--data（开启数据清理）、--log（开启日志清理）、--ignore-node（指定不清理的节点）、--ignore-role（指定不清理的角色）、-h, --help（输出帮助信息）。输出为 tiup-cluster 的执行日志。
+- [tiup cluster deploy](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-deploy.md): tiup cluster deploy 命令用于部署全新集群。语法为 tiup cluster deploy <cluster-name> <version> <topology.yaml> [flags]。选项包括 -u, -i, -p, --ignore-config-check, --no-labels, --skip-create-user, -h。输出为部署日志。
+- [tiup cluster destroy](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-destroy.md): tiup cluster destroy 命令用于销毁集群，包括停止集群、删除服务的日志目录、部署目录和数据目录。选项包括 --force（忽略错误）、--retain-node-data（指定保留数据的节点）、--retain-role-data（指定保留数据的角色）、-h（输出帮助信息）。执行日志将作为输出。
+- [tiup cluster disable](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-disable.md): tiup cluster disable 命令用于关闭集群服务在机器重启后的自启动。使用该命令可以指定要关闭自启的集群、节点和角色。如果不指定节点和角色，则默认关闭所有节点和角色的自启动。输出为 tiup-cluster 的执行日志。
+- [tiup cluster display](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-display.md): tiup cluster display 命令用于查看集群中每个组件的运行状态。可以通过指定选项来展示特定信息，如节点的 CPU 和内存使用情况，节点的 uptime 信息等。输出包括集群名称、版本、SSH 客户端类型、Dashboard 地址以及节点的 ID、角色、主机 IP、端口号、操作系统和机器架构、服务状态、数据目录和部署目录。节点服务状态包括在线、离线、已缩容下线、下线中和未知。详细状态含义可参考相关文档。
+- [tiup cluster edit-config](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-edit-config.md): tiup cluster edit-config 命令用于调整部署集群后的配置。执行命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意不能增删机器，需执行 tiup cluster reload 命令来重新加载配置。语法为 tiup cluster edit-config <cluster-name>，选项包括 -h, --help。执行命令后正常情况下无输出，若修改了不能修改的字段则会报错并提示用户重新编辑。
+- [tiup cluster enable](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-enable.md): tiup cluster enable 命令用于设置集群服务在机器重启后的自启动。命令会执行 systemctl enable <service> 来开启服务的自启。可以指定节点和角色来开启自启，同时可以输出帮助信息。执行日志将由 tiup-cluster 记录。
+- [tiup cluster help](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-help.md): tiup-cluster 是一个命令行工具，提供丰富的帮助信息。用户可以通过 `help` 命令或 `--help` 参数获取帮助信息。`tiup cluster help <command>` 等同于 `tiup cluster <command> --help`。语法为 `tiup cluster help [command] [flags]`。使用 `-h` 或 `--help` 输出帮助信息，默认关闭。输出为 `[command]` 或 tiup-cluster 的帮助信息。
+- [tiup cluster import](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-import.md): TiUP Cluster 提供了 `import` 命令，用于将 TiDB Ansible 部署的集群过渡到使用 tiup-cluster 组件管理。导入过程的日志信息将会输出。暂不支持导入启用了 TLS 加密功能、纯 KV 集群、启用了 Kafka 的集群、启用了 Spark 的集群、启用了 TiDB Lightning/Importer 的集群、仍使用老版本 `push` 的方式收集监控指标、单独为机器的 `node_exporter` / `blackbox_exporter` 设置了非默认端口的集群。如果集群中有部分节点未部署监控，应当先补充对应节点的信息，并将补充的监控组件部署完整。
+- [tiup cluster list](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-list.md): tiup-cluster 支持使用同一个中控机部署多套集群。命令 `tiup cluster list` 可以查看当前登录的用户使用该中控机部署了哪些集群。输出包含 Name、User、Version、Path、PrivateKey 字段的表格。注意：部署的集群数据默认放在 `~/.tiup/storage/cluster/clusters/` 目录下，当前登录用户无法查看其他用户部署的集群。
+- [tiup cluster meta backup](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-meta-backup.md): TiUP meta 文件丢失会导致无法管理集群。使用“tiup cluster meta backup”命令定期备份文件。命令语法为“tiup cluster meta backup <cluster-name>”。选项包括指定备份文件存储目录和帮助信息。输出为 tiup-cluster 的执行日志。
+- [tiup cluster meta restore](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-meta-restore.md): TiUP cluster meta restore 命令用于从备份文件中恢复 TiUP meta 文件。语法为 tiup cluster meta restore <cluster-name> <backup-file>。选项包括 -h, --help，用于输出帮助信息。恢复操作会覆盖当前的 meta 文件，建议仅在 meta 文件丢失的情况下进行恢复。执行日志将作为输出。
+- [tiup cluster patch](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-patch.md): tiup cluster patch 命令用于在集群运行过程中动态替换某个服务的二进制文件。它会上传替换的二进制包到目标机器，并通过 API 下线节点，停止目标服务，解压替换二进制包，最后启动目标服务。在使用命令前需要准备二进制包，包括确定组件名、版本、操作系统和平台，下载组件包，创建临时打包目录，解压原二进制包，复制要替换的文件到临时目录，最后打包所有文件。命令还包括一些选项，如 --overwrite、--transfer-timeout、-N、-R、--offline 等。
+- [tiup cluster prune](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-prune.md): tiup cluster prune 命令用于在缩容集群时清理数据。对于某些组件，需要等数据调度完成后，用户手动执行该命令。选项包括 -h 或 --help，用于输出帮助信息。清理过程会生成日志。
+- [tiup cluster reload](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-reload.md): tiup cluster reload 命令用于在修改集群配置后重新加载配置，使其生效。命令会将配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。可选参数包括 --force（忽略错误强制 reload）、--transfer-timeout（设置最长等待时间）、--ignore-config-check（跳过配置检查）、-N, --node（指定要重启的节点）、-R, --role（指定要重启的角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。执行日志会输出到 tiup-cluster。
+- [tiup cluster rename](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-rename.md): tiup cluster rename 命令用于更改部署集群后的集群名。如果要更改集群名，可以使用 tiup cluster rename <old-cluster-name> <new-cluster-name> 命令。注意：如果配置了 grafana_servers 的 dashboard_dir 字段，需要更新本地 dashboards 目录中的 *.json 文件的 datasource 字段的值，并执行 tiup cluster reload -R grafana 命令。执行日志将输出到 tiup-cluster。
+- [tiup cluster replay](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-replay.md): tiup cluster replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用 `tiup cluster audit` 查看历史命令及其 audit-id。执行命令：tiup cluster replay <audit-id>。选项：-h, --help。输出为对应命令的输出。
+- [tiup cluster restart](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-restart.md): tiup cluster restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup cluster restart <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
+- [tiup cluster scale-in](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-scale-in.md): tiup cluster scale-in 命令用于集群缩容，包括下线 TiKV 和 TiFlash 组件，以及其他组件。特殊处理包括通过 API 执行移除操作，并清理相关数据文件。命令语法为 tiup cluster scale-in <cluster-name>，必须指定要缩容的节点。其他选项包括 --force 用于强制移除宕机节点，--transfer-timeout 设置最长等待时间，-h 输出帮助信息。输出为缩容日志。
+- [tiup cluster scale-out](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-scale-out.md): tiup cluster scale-out 命令用于集群扩容，内部逻辑与部署类似。PD 节点的扩容通过 join 方式加入集群，并更新相关服务配置；其他服务直接启动加入集群。命令语法为 tiup cluster scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user, -i, --identity_file, -p, --password, --no-labels, --skip-create-user, -h, --help。输出为扩容日志。
+- [tiup cluster start](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-start.md): tiup cluster start 命令用于启动指定集群的所有或部分服务。语法为 tiup cluster start <cluster-name> [flags]。选项包括 --init（以安全方式启动集群）、-N, --node（指定要启动的节点）、-R, --role（指定要启动的角色）、-h, --help。输出为启动日志。
+- [tiup cluster stop](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-stop.md): tiup cluster stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup cluster stop <cluster-name>。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
+- [tiup cluster template](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-template.md): TiUP 内置了拓扑文件的模版，用户可以通过修改该模版来生成最终的拓扑文件。使用 tiup cluster template 命令可以输出 TiUP 内置的模版内容。该命令有多个选项，包括输出详细的拓扑模版、输出本地集群的简单拓扑模版以及输出多数据中心的拓扑模版。根据指定选项输出拓扑模版，可重定向到拓扑文件中用于部署。
+- [tiup cluster upgrade](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-upgrade.md): tiup cluster upgrade 命令用于将指定集群升级到特定版本。命令语法为 tiup cluster upgrade <cluster-name> <version> [flags]。可使用 --force 选项忽略升级过程的错误，强制替换二进制文件并启动集群。还可通过设置 --transfer-timeout 设置最长等待时间，超时后会跳过等待直接升级服务。其他选项包括 --ignore-config-check、--ignore-version-check、--offline 等。升级服务的日志将会输出。
+- [tiup completion](https://docs.pingcap.com/tidb/stable/tiup-command-completion.md): TiUP 提供了 `tiup completion` 命令，用于生成命令行自动补全的配置文件。目前支持 `bash` 和 `zsh` 两种 shell 的命令补全。安装方式包括在 macOS 上执行 `brew install bash-completion` 或 `brew install bash-completion@2`，在 Linux 上执行 `yum install bash-completion` 或 `apt install bash-completion`。使用方式包括在 `.bash_profile` 中执行 `source` 命令，并在 zsh 中执行 `tiup completion zsh > "${fpath[1]}/_tiup"`。
+- [TiUP DM](https://docs.pingcap.com/tidb/stable/tiup-component-dm.md): TiUP DM 是用于对 DM 集群进行日常运维工作的管理工具，包括部署、启动、关闭、销毁、弹性扩缩容、升级、参数管理等操作。命令包括 import、template、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、destroy、audit、replay、enable、disable、help。
+- [tiup dm audit](https://docs.pingcap.com/tidb/stable/tiup-component-dm-audit.md): tiup dm audit 命令用于查看所有集群上的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息，默认关闭。输出包括指定的 audit-id 对应的执行日志或包含 ID、时间和命令字段的表格。
+- [tiup dm deploy](https://docs.pingcap.com/tidb/stable/tiup-component-dm-deploy.md): tiup dm deploy 命令用于部署全新的集群。语法为 tiup dm deploy <cluster-name> <version> <topology.yaml> [flags]，其中 cluster-name 表示新集群的名字，version 为要部署的 DM 集群版本号，topology.yaml 为事先编写好的拓扑文件。选项包括 -u, -i, -p, -h，分别用于指定连接目标机器的用户名、密钥文件、密码登录和输出帮助信息。输出为部署日志。
+- [tiup dm destroy](https://docs.pingcap.com/tidb/stable/tiup-component-dm-destroy.md): tiup dm destroy 命令用于销毁集群，包括停止集群、删除日志目录、部署目录和数据目录。语法为 tiup dm destroy <cluster-name>。选项 -h, --help 用于输出帮助信息。输出为 tiup-dm 的执行日志。
+- [tiup dm disable](https://docs.pingcap.com/tidb/stable/tiup-component-dm-disable.md): tiup dm disable 命令用于关闭集群服务重启后的自启动。语法为 tiup dm disable <cluster-name>，其中 <cluster-name> 为要关闭自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要关闭自启的节点和角色。若不指定选项，默认关闭所有节点和角色的自启。执行该命令将输出 tiup-dm 的执行日志。
+- [tiup dm display](https://docs.pingcap.com/tidb/stable/tiup-component-dm-display.md): tiup-dm 提供了 `tiup dm display` 命令来高效查看集群中每个组件的运行状态。命令语法为 `tiup dm display <cluster-name>`，可指定要查询的节点和角色。输出包括集群名称、版本、SSH 客户端类型，以及节点 ID、角色、IP、端口号、操作系统、状态、数据目录和部署目录等信息。
+- [tiup dm edit-config](https://docs.pingcap.com/tidb/stable/tiup-component-dm-edit-config.md): tiup dm edit-config 命令用于调整部署集群服务的配置。使用命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意：修改配置时不能增删机器，需执行 tiup dm reload 命令来重新加载配置。语法：tiup dm edit-config <cluster-name>。选项：-h, --help 输出帮助信息。输出：正常情况无输出，若修改了不能修改的字段，则保存文件时报错并提示用户重新编辑。
+- [tiup dm enable](https://docs.pingcap.com/tidb/stable/tiup-component-dm-enable.md): tiup dm enable 命令用于设置集群服务在机器重启后的自启动。命令语法为 tiup dm enable <cluster-name>，其中 cluster-name 为要启用自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要开启自启的节点和角色。若不指定选项，默认开启所有节点和角色的自启。执行日志将作为输出。
+- [tiup dm help](https://docs.pingcap.com/tidb/stable/tiup-component-dm-help.md): tiup-dm 提供丰富的命令行界面帮助信息，可通过 `help` 命令或 `--help` 参数获取。`tiup dm help <command>` 等同于 `tiup dm <command> --help`。语法：`tiup dm help [command] [flags]`。`[command]` 用于指定要查看的命令帮助信息，若不指定，则查看 tiup-dm 自身的帮助信息。使用 `-h, --help` 输出帮助信息，数据类型为 `BOOLEAN`，默认关闭。输出为 `[command]` 或 tiup-dm 的帮助信息。
+- [tiup dm import](https://docs.pingcap.com/tidb/stable/tiup-component-dm-import.md): TiUP DM 提供了 `import` 命令，用于将 DM v1.0 集群导入到全新的 v2.0 集群。在导入前，请先停止原集群，并确认升级 TiUP DM 组件到最新版本。导入过程中会生成日志信息，不支持导入 v1.0 集群中的 DM Portal 组件。对于需要升级到 v2.0 的数据迁移任务，请不要执行 `stop-task`。具体语法和选项可以使用 `tiup dm import [flags]` 命令查看。
+- [tiup dm list](https://docs.pingcap.com/tidb/stable/tiup-component-dm-list.md): tiup-dm 支持使用同一个中控机部署多套集群。命令 `tiup dm list` 可以查看当前登录的用户使用该中控机部署了哪些集群。部署的集群数据默认放在 `~/.tiup/storage/dm/clusters/` 目录下。在同一台中控机上，当前登录用户无法查看其他用户部署的集群。该命令输出含有集群名字、部署用户、集群版本、集群部署数据在中控机上的路径、连接集群的私钥所在路径的表格。
+- [tiup dm prune](https://docs.pingcap.com/tidb/stable/tiup-component-dm-prune.md): tiup dm prune 命令用于在缩容集群后清理 etcd 中的少量元信息。通常情况下不会有问题，但如果需要清理，可以手动执行该命令。语法为 tiup dm prune <cluster-name>，选项包括 -h, --help，输出为清理过程的日志。
+- [tiup dm reload](https://docs.pingcap.com/tidb/stable/tiup-component-dm-reload.md): tiup dm reload 命令用于在修改集群配置后重新加载配置。该命令将中控机的配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。语法为 tiup dm reload <cluster-name>。选项包括 -N, --node（重启节点）、-R, --role（重启角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。输出为 tiup-dm 的执行日志。
+- [tiup dm replay](https://docs.pingcap.com/tidb/stable/tiup-component-dm-replay.md): tiup dm replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用命令时需指定要重试的命令对应的 audit-id，可通过 tiup dm audit 查看历史命令及其 audit-id。命令输出为对应命令的输出。
+- [tiup dm restart](https://docs.pingcap.com/tidb/stable/tiup-component-dm-restart.md): tiup dm restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup dm restart <cluster-name> [flags]，其中 <cluster-name> 为要操作的集群名字。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
+- [tiup dm scale-in](https://docs.pingcap.com/tidb/stable/tiup-component-dm-scale-in.md): tiup dm scale-in 命令用于集群缩容，即下线服务并移除指定节点和相关文件。语法为 tiup dm scale-in <cluster-name>，其中 <cluster-name> 为集群名。选项包括 -N, --node（必须非空，选择要缩容的节点），--force（强制移除宕机节点），-h, --help（输出帮助信息）。输出为缩容日志。
+- [tiup dm scale-out](https://docs.pingcap.com/tidb/stable/tiup-component-dm-scale-out.md): tiup dm scale-out 命令用于集群扩容，内部逻辑与部署类似。首先建立新节点的 SSH 连接，在目标节点上创建必要的目录，然后执行部署并启动服务。命令语法为 tiup dm scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user（string，默认为当前执行命令的用户），-i, --identity_file（string，默认 ~/.ssh/id_rsa），-p, --password，-h, --help。输出为扩容日志。
+- [tiup dm start](https://docs.pingcap.com/tidb/stable/tiup-component-dm-start.md): tiup dm start 命令用于启动指定集群的所有或部分服务。命令语法为 tiup dm start <cluster-name>。选项包括 -N, --node（指定要启动的节点），-R, --role（指定要启动的角色），-h, --help（输出帮助信息）。输出为启动日志。
+- [tiup dm stop](https://docs.pingcap.com/tidb/stable/tiup-component-dm-stop.md): tiup dm stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup dm stop <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
+- [tiup dm template](https://docs.pingcap.com/tidb/stable/tiup-component-dm-template.md): tiup dm template 命令用于输出 TiUP 内置的集群拓扑模版内容。可以通过修改模版来生成最终的拓扑文件。可选的 --full 选项输出详细的拓扑模版，带上可配置的参数。输出拓扑模版到标准输出，可重定向到拓扑文件中用于部署。
+- [tiup dm upgrade](https://docs.pingcap.com/tidb/stable/tiup-component-dm-upgrade.md): tiup dm upgrade 命令用于将指定集群升级到特定版本。语法为 tiup dm upgrade <cluster-name> <version> [flags]。cluster-name 为要操作的集群名字，version 为要升级到的目标版本。选项 --offline 声明当前集群处于离线状态，-h, --help 输出帮助信息。升级服务的日志可查看。
+- [tiup env](https://docs.pingcap.com/tidb/stable/tiup-command-env.md): TiUP 提供灵活的定制化接口，使用环境变量实现。命令 `tiup env` 用于查询 TiUP 支持的用户自定义环境变量及其值。若未指定环境变量，则输出"{key}"="{value}"列表。若指定了环境变量，则按顺序输出"{value}"列表。若值为空，则代表未设置环境变量的值，TiUP 会使用默认值。
+- [TiUP FAQ](https://docs.pingcap.com/tidb/stable/tiup-faq.md): TiUP 支持自定义镜像源，可以使用环境变量 TIUP_MIRRORS 指定镜像源地址。开发者可以通过 tiup-publish 组件将自己编写的组件发布到 TiUP 的官方镜像仓库。TiUP Playground 用于快速搭建开发环境，而 TiUP Cluster 用于部署生产环境集群。拓扑文件样例包括两地三中心、最小部署和完整拓扑文件。同一主机可以部署多个实例，但需要配置不同的端口和目录信息。集群部署期间可能出现 ssh 连接错误，可尝试加大 ssh 默认连接数并重启 sshd 服务解决。
+- [tiup help](https://docs.pingcap.com/tidb/stable/tiup-command-help.md): TiUP 命令行界面提供丰富的帮助信息，用户可通过 `help` 命令或 `--help` 参数查看。`tiup help <command>` 等同于 `tiup <command> --help`。语法为 `tiup help [command]`，若不指定命令，则查看 TiUP 自身的帮助信息。选项为无，输出为 `[command]` 或 TiUP 的帮助信息。
+- [tiup install](https://docs.pingcap.com/tidb/stable/tiup-command-install.md): tiup install 命令用于从镜像仓库下载指定版本的组件包，并在本地解压。当需要运行不存在于镜像仓库中的组件时，会尝试下载并自动运行，若不存在会报错。语法为 tiup install <component1>[version] [component2...N] [flags]。输出包括组件的下载信息，若组件不存在则报错"The component "%s" not found"，若版本不存在则报错"version %s not supported by component %s"。
+- [tiup list](https://docs.pingcap.com/tidb/stable/tiup-command-list.md): tiup list 命令用于查询镜像中可用的组件列表。可选的组件名称。若指定，则列出该组件的所有版本；若不指定，则列出所有组件列表。--all 显示所有组件。默认只显示非隐藏组件。--installed 只显示已经安装的组件或版本。--verbose 在组件列表中显示已安装的版本列表。若未指定组件名，输出组件名、组件管理员、组件描述构成的组件信息列表。若指定组件名，输出版本、是否已安装、发布时间、支持的平台构成的版本信息列表。
+- [tiup mirror](https://docs.pingcap.com/tidb/stable/tiup-command-mirror.md): TiUP 中的镜像是一个重要概念，支持本地镜像和远程镜像。命令 `tiup mirror` 用于管理镜像，包括创建、发布、密钥管理等功能。语法为 `tiup mirror <command> [flags]`，支持的子命令包括 genkey、sign、init、set、grant、publish、modify、rotate、clone、merge。详细信息请参考 TiUP 命令清单。
+- [tiup mirror clone](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-clone.md): tiup mirror clone 命令用于克隆已存在的镜像或部分组件生成新镜像。新旧镜像的组件相同，但使用的签名密钥不同。命令语法为 tiup mirror clone <target-dir> [global version] [flags]。选项包括 -f, --full, -a, --arch, -o, --os, --prefix, --{component}。
+- [tiup mirror genkey](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-genkey.md): TiUP 镜像命令 genkey 用于生成私钥。管理员有 root.json、index.json、snapshot.json 和 timestamp.json 的修改权限。组件管理员有相关组件的修改权限。普通用户可以下载并使用组件。私钥名默认为 private，可以显示对应的公钥。可以将公钥信息储存为文件。输出包括私钥已存在或已写入，以及公钥内容。
+- [tiup mirror grant](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-grant.md): tiup mirror grant 命令用于向当前镜像中添加组件管理员。组件管理员可以发布新组件或修改之前发布的组件。添加管理员时，需将公钥发送给镜像管理员。命令仅支持本地镜像使用。语法：tiup mirror grant <id>。选项：-k, --key（指定管理员密钥）、-n, --name（指定管理员名字）。输出：执行成功无输出，管理员 ID 重复报错，密钥被其他管理员使用报错。
+- [tiup mirror init](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-init.md): tiup mirror init 命令用于初始化一个空的镜像。初始化的镜像不包含任何组件和组件管理员，仅生成一些文件。语法为 tiup mirror init <path> [flags]，其中 <path> 为本地目录路径，可以为相对路径。选项包括 -k, --key-dir（string，默认 {path}/keys）。输出包括若成功则无输出，若 <path> 不为空则输出错误信息，若 <path> 不是目录则输出错误信息。
+- [tiup mirror merge](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-merge.md): tiup mirror merge 命令用于将一个或多个镜像合并到当前镜像。执行此命令需要目标镜像的管理员 ID 在当前镜像中存在，并且用户的 ${TIUP_HOME}/keys 目录中有对应的私钥。语法：tiup mirror merge <mirror-dir-1> [mirror-dir-N]。选项：无。输出：成功时无输出，否则会提示缺失管理员或私钥。
+- [tiup mirror modify](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-modify.md): tiup mirror modify 命令用于修改已发布的组件。只有合法的组件管理员才能修改组件，且只能修改自己发布的组件。命令语法为 tiup mirror modify <component>[version]。选项包括 -k, --key, --yank, --hide。成功时无输出，无权限时会有相应错误提示。
+- [tiup mirror publish](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-publish.md): tiup mirror publish 命令用于发布新组件或已有组件的新版本。只有有权限的组件管理员才可以发布组件。命令语法为 tiup mirror publish <comp-name> <version> <tarball> <entry> [flags]。其中各参数含义为组件名、版本号、tarball 包路径、组件可执行文件位置。命令还包含选项 -k, --key, --arch, --os, --desc, --hide。成功时无输出，无权限时会有相应错误提示。
+- [tiup mirror rotate](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-rotate.md): TiUP 的镜像中有一个重要文件 root.json，记录了系统需要使用的公钥和信任链基础。包含管理员签名、用于验证的公钥和过期时间。更新 root.json 需要管理员重新签名，使用命令 `tiup mirror rotate` 自动化更新流程。需要确保 TiUP 客户端升级到 v1.5.0 或以上版本。命令启动编辑器修改内容，等待管理员签名。选项包括临时服务器监听地址。输出为各个镜像管理员当前的签名状态。
+- [tiup mirror set](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-set.md): tiup mirror set 命令用于切换当前镜像，支持本地文件系统和远程网络两种镜像。命令语法为 tiup mirror set <mirror-addr> [flags]，其中 <mirror-addr> 为镜像地址，可以是网络地址或本地文件路径。选项 -r, --root 用于指定根证书。输出为无。
+- [tiup mirror sign](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-sign.md): tiup mirror sign 命令用于对镜像中定义的元信息文件进行签名。语法为 tiup mirror sign <manifest-file>。选项包括 -k, --key 和 --timeout。输出包括成功、文件已被指定的 key 签名过和文件不是合法的 manifest。
+- [tiup status](https://docs.pingcap.com/tidb/stable/tiup-command-status.md): tiup status 命令用于查看组件的运行信息，包括组件名称、进程 ID、运行状态、启动时间、数据目录、二进制文件路径和启动参数。组件可能处于在线、离线、无法访问、已缩容下线、下线中或未知状态。这些状态来自于 PD 的调度信息。
+- [tiup telemetry](https://docs.pingcap.com/tidb/stable/tiup-command-telemetry.md): TiUP 遥测功能在 v1.11.3 及以上版本默认关闭，以下版本默认开启。开启后会分享使用情况信息给 PingCAP，包括遥测标示符、命令执行情况、部署情况等。不会分享集群准确名字、拓扑结构、配置文件。使用命令 `tiup telemetry` 控制遥测，支持 status、reset、enable、disable 命令。
+- [tiup uninstall](https://docs.pingcap.com/tidb/stable/tiup-command-uninstall.md): tiup uninstall 命令用于卸载已安装的组件。语法为 tiup uninstall <component1> <version> [component2...N] [flags]。选项包括 --all 用于卸载指定组件的全部已安装版本，--self 用于卸载 TiUP 自身。正常退出时会显示"Uninstalled component "%s" successfully!"，若未指定 <version> 也未指定 --all 则会报错"Use "tiup uninstall tidbx --all" if you want to remove all versions."。
+- [tiup update](https://docs.pingcap.com/tidb/stable/tiup-command-update.md): tiup update 命令用于升级已安装的组件或自身。语法为 tiup update [组件名] [版本]，可指定多个组件或版本。选项包括 --all（升级所有组件）、--force（强制升级已安装版本）、--nightly（升级到 nightly 版本）、--self（升级 TiUP 自身）。
+- [TiUP 命令概览](https://docs.pingcap.com/tidb/stable/tiup-reference.md): TiUP 是 TiDB 生态的包管理器，管理着诸如 TiDB、PD、TiKV 等组件。它支持执行命令和运行组件，可以通过 `--help` 获取命令信息。选项包括打印二进制文件路径、指定组件路径、指定组件 tag、打印版本和帮助信息。TiUP 包含众多命令和子命令，以及组件清单。
+- [TiUP 常见运维操作](https://docs.pingcap.com/tidb/stable/maintain-tidb-using-tiup.md): TiUP 是用于管理 TiDB 集群的工具，可以进行查看集群列表、启动、关闭、修改配置参数、查看状态等常见运维操作。操作简单方便，适合用于 TiDB 集群的管理。
+- [TiUP 故障排查](https://docs.pingcap.com/tidb/stable/tiup-troubleshooting-guide.md): TiUP 故障排查包括命令故障排查和集群组件故障排查。命令故障包括强制刷新组件列表和版本信息，网络中断导致的下载问题，以及 checksum 错误。集群组件故障包括 SSH 私钥问题，升级中断和缺失组件文件的解决方法。可通过 Github Issues 或 AskTUG 求助。
+- [TiUP 文档地图](https://docs.pingcap.com/tidb/stable/tiup-documentation-guide.md): TiUP 文档地图包括使用文档和资源两部分。使用文档包括 TiUP 概览、TiUP 术语、TiUP 组件管理、TiUP FAQ、TiUP 故障排查和 TiUP 参考手册。资源包括 TiUP 版本发布说明、AskTUG TiUP 主题和 TiUP Issues。
+- [TiUP 术语及核心概念](https://docs.pingcap.com/tidb/stable/tiup-terminology-and-concepts.md): TiUP 是一个用于下载、更新、卸载组件的程序，通过各种组件来扩展其功能。组件是可以运行的程序或脚本，通过 tiup <component> 命令来运行。TiUP 组件可以从镜像仓库下载，用户可以通过设置 TIUP_MIRRORS 环境变量来自定义镜像仓库。
+- [TiUP 简介](https://docs.pingcap.com/tidb/stable/tiup-overview.md): TiUP 是 TiDB 生态中的包管理工具，简化了软件的安装和升级维护工作。安装 TiUP 十分简洁，只需执行一行命令即可完成。TiUP 的愿景是降低 TiDB 生态中所有工具的使用门槛，通过命令和组件来实现包管理和操作。
+- [TiUP 镜像参考指南](https://docs.pingcap.com/tidb/stable/tiup-mirror-reference.md): TiUP 镜像是存放 TiUP 组件和元信息的仓库。镜像存在两种形式：本地镜像和远程镜像。镜像可通过命令创建和更新。镜像目录结构包括根证书、索引、组件、快照和时间戳。客户端通过逻辑保证下载文件安全。
+- [TopN 和 Limit 下推](https://docs.pingcap.com/tidb/stable/topn-limit-push-down.md): TiDB 中的 LIMIT 子句对应 Limit 算子节点，ORDER BY 子句对应 Sort 算子节点。相邻的 Limit 和 Sort 算子组合成 TopN 算子节点，表示按排序规则提取记录的前 N 项。TopN 下推将尽可能下推到数据源附近，减少数据传输或计算的开销。可参考 [优化规则及表达式下推的黑名单](/blocklist-control-plan.md) 中的关闭方法。TopN 可下推到存储层 Coprocessor，减少计算开销。TopN 无法下推过 Join，排序规则仅依赖于外表列时可下推。TopN 也可转换成 Limit，简化排序操作。
+- [TRACE](https://docs.pingcap.com/tidb/stable/sql-statement-trace.md): TiDB 数据库中 TRACE 的使用概况。
+- [TRUNCATE](https://docs.pingcap.com/tidb/stable/sql-statement-truncate.md): TiDB 数据库中 TRUNCATE 的使用概况。
+- [TSO 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tso-configuration.md): TSO 配置参数可以通过命令行参数或环境变量配置。
+- [TSO 配置文件描述](https://docs.pingcap.com/tidb/stable/tso-configuration-file.md): TSO 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
+- [UNLOCK STATS](https://docs.pingcap.com/tidb/stable/sql-statement-unlock-stats.md): TiDB 数据库中 UNLOCK STATS 的使用概况。
+- [UPDATE](https://docs.pingcap.com/tidb/stable/sql-statement-update.md): TiDB 数据库中 UPDATE 的使用概况。
 - [Upgrade A Tidb Cluster](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster
-- [USE](https://docs.pingcap.com/tidb/stable/sql-statement-use/): TiDB 数据库中 USE 的使用概况。
-- [USER_ATTRIBUTES](https://docs.pingcap.com/tidb/stable/information-schema-user-attributes/): 了解 INFORMATION_SCHEMA 表 `USER_ATTRIBUTES`。
-- [USER_PRIVILEGES](https://docs.pingcap.com/tidb/stable/information-schema-user-privileges/): 了解 INFORMATION_SCHEMA 表 `USER_PRIVILEGES`。
-- [UUID 最佳实践](https://docs.pingcap.com/tidb/stable/uuid/): 了解在 TiDB 中使用 UUID 的最佳实践和策略。
-- [VARIABLES_INFO](https://docs.pingcap.com/tidb/stable/information-schema-variables-info/): 了解 information_schema 表 `VARIABLES_INFO`。
-- [VIEWS](https://docs.pingcap.com/tidb/stable/information-schema-views/): 了解 INFORMATION_SCHEMA 表 `VIEWS`。
-- [What's New in TiDB 5.0](https://docs.pingcap.com/tidb/stable/release-5.0.0/): TiDB 5.0 版本新增了许多功能和优化，包括 MPP 架构、聚簇索引、异步提交事务、Raft Joint Consensus 算法等。此外，还优化了系统变量、配置文件参数、性能、稳定性和数据迁移功能。TiUP 工具也进行了多项优化，包括部署操作逻辑、升级稳定性、升级时长和运维功能。遥测方面新增了集群使用指标的收集。
-- [WITH](https://docs.pingcap.com/tidb/stable/sql-statement-with/): TiDB 数据库中 WITH (公共表表达式) 的使用概况。
+- [USE](https://docs.pingcap.com/tidb/stable/sql-statement-use.md): TiDB 数据库中 USE 的使用概况。
+- [USER_ATTRIBUTES](https://docs.pingcap.com/tidb/stable/information-schema-user-attributes.md): 了解 INFORMATION_SCHEMA 表 `USER_ATTRIBUTES`。
+- [USER_PRIVILEGES](https://docs.pingcap.com/tidb/stable/information-schema-user-privileges.md): 了解 INFORMATION_SCHEMA 表 `USER_PRIVILEGES`。
+- [UUID 最佳实践](https://docs.pingcap.com/tidb/stable/uuid.md): 了解在 TiDB 中使用 UUID 的最佳实践和策略。
+- [VARIABLES_INFO](https://docs.pingcap.com/tidb/stable/information-schema-variables-info.md): 了解 information_schema 表 `VARIABLES_INFO`。
+- [VIEWS](https://docs.pingcap.com/tidb/stable/information-schema-views.md): 了解 INFORMATION_SCHEMA 表 `VIEWS`。
+- [What's New in TiDB 5.0](https://docs.pingcap.com/tidb/stable/release-5.0.0.md): TiDB 5.0 版本新增了许多功能和优化，包括 MPP 架构、聚簇索引、异步提交事务、Raft Joint Consensus 算法等。此外，还优化了系统变量、配置文件参数、性能、稳定性和数据迁移功能。TiUP 工具也进行了多项优化，包括部署操作逻辑、升级稳定性、升级时长和运维功能。遥测方面新增了集群使用指标的收集。
+- [WITH](https://docs.pingcap.com/tidb/stable/sql-statement-with.md): TiDB 数据库中 WITH (公共表表达式) 的使用概况。
 - [Zh](https://docs.pingcap.com/zh): External documentation: https://docs.pingcap.com/zh
-- [三节点混合部署最佳实践](https://docs.pingcap.com/tidb/stable/three-nodes-hybrid-deployment/): 了解三节点混合部署最佳实践。
-- [上游使用 pt-osc/gh-ost 工具的持续同步场景](https://docs.pingcap.com/tidb/stable/migrate-with-pt-ghost/): 介绍在使用 DM 持续增量数据同步，上游使用 pt-osc/gh-ost 工具进行在线 DDL 变更时 DM 的处理方式和注意事项。
-- [下推到 TiKV 的表达式列表](https://docs.pingcap.com/tidb/stable/expressions-pushed-down/): TiDB 中下推到 TiKV 的表达式列表及相关设置。
-- [下推计算结果缓存](https://docs.pingcap.com/tidb/stable/coprocessor-cache/): TiDB 4.0 支持下推计算结果缓存，配置位于 `tikv-client.copr-cache`，缓存仅存储在 TiDB 内存中，不共享缓存，对 Region 写入会导致缓存失效。缓存命中率可通过 `EXPLAIN ANALYZE` 或 Grafana 监控面板查看。
-- [下游存在更多列的迁移场景](https://docs.pingcap.com/tidb/stable/migrate-with-more-columns-downstream/): 介绍下游存在更多列的迁移场景。
-- [不同库名或表名的数据校验](https://docs.pingcap.com/tidb/stable/route-diff/): TiDB DM 等同步工具可以使用 route-rules 设置数据同步到下游指定表中。sync-diff-inspector 通过设置 rules 提供了校验不同库名、表名的表的功能。可以通过 rules 设置映射关系来简化配置，校验大量的不同库名或者表名的表。表路由的初始化和示例包括规则中存在 target-schema/target-table 表名为 schema.table 的行为，规则中只存在 target-schema 的行为，以及规则中不存在 target-schema.target-table 的行为。
-- [与 Apache Kafka 和 Apache Flink 进行数据集成](https://docs.pingcap.com/tidb/stable/replicate-data-to-kafka/): 了解如何使用 TiCDC 从 TiDB 同步数据至 Apache Kafka 和 Apache Flink。
-- [与 Confluent Cloud 和 Snowflake 进行数据集成](https://docs.pingcap.com/tidb/stable/integrate-confluent-using-ticdc/): 了解如何使用 TiCDC 从 TiDB 同步数据至 Confluent Cloud 以及 Snowflake、ksqlDB、SQL Server。
-- [与 MySQL 兼容性对比](https://docs.pingcap.com/tidb/stable/mysql-compatibility/): 本文对 TiDB 和 MySQL 二者之间从语法和功能特性上做出详细的对比。
-- [与 MySQL 安全特性差异](https://docs.pingcap.com/tidb/stable/security-compatibility-with-mysql/): TiDB 支持与 MySQL 5.7 类似的安全特性，同时也支持 MySQL 8.0 的部分安全特性。然而，在实现上存在一些差异，包括不支持列级别权限设置和部分权限属性。此外，TiDB 的密码过期策略和密码复杂度策略与 MySQL 存在一些差异。另外，TiDB 支持多种身份验证方式，包括 TLS 证书和 JWT。
-- [临时表](https://docs.pingcap.com/tidb/stable/dev-guide-use-temporary-tables/): 介绍 TiDB 临时表创建、删除、限制。
-- [临时表](https://docs.pingcap.com/tidb/stable/temporary-tables/): 了解 TiDB 中的临时表功能，使用临时表存储业务中间数据，减少表管理开销，并提升性能。
-- [为 DM 的连接开启加密传输](https://docs.pingcap.com/tidb/stable/dm-enable-tls/): 了解如何为 DM 的连接开启加密传输。
-- [为 TiDB 客户端服务端间通信开启加密传输](https://docs.pingcap.com/tidb/stable/enable-tls-between-clients-and-servers/): TiDB 服务端与客户端间默认采用非加密连接，容易造成信息泄露。建议使用加密连接确保安全性。要开启 TLS 加密传输，需要在服务端配置开启 TLS 支持，并在客户端应用程序中配置使用 TLS 加密连接。可以通过配置系统变量或在创建 / 修改用户时指定要求加密连接。可通过命令检查当前连接是否是加密连接。TLS 版本为 TLSv1.2 和 TLSv1.3，支持的加密算法包括 AES 和 CHACHA20_POLY1305。
-- [为 TiDB 组件间通信开启加密传输](https://docs.pingcap.com/tidb/stable/enable-tls-between-components/): 了解如何为 TiDB 集群内各组件间开启加密传输。
-- [为 TiDB 落盘文件开启加密](https://docs.pingcap.com/tidb/stable/enable-disk-spill-encrypt/): 了解如何为 TiDB 落盘文件开启加密。
-- [主从集群一致性读和数据校验](https://docs.pingcap.com/tidb/stable/ticdc-upstream-downstream-check/): TiCDC 提供了 Syncpoint 功能，通过利用 TiDB 的 snapshot 特性，在同步过程中维护了一个上下游具有一致性 snapshot 的 `ts-map`。启用 Syncpoint 功能后，可以进行一致性快照读和数据一致性校验。要开启 Syncpoint 功能，只需在创建同步任务时把 TiCDC 的配置项 `enable-sync-point` 设置为 `true`。通过配置 `snapshot` 可以对 TiDB 主从集群的数据进行校验。
-- [乐观事务和悲观事务](https://docs.pingcap.com/tidb/stable/dev-guide-optimistic-and-pessimistic-transaction/): 介绍 TiDB 中的乐观事务和悲观事务，乐观事务的重试等。
-- [乐观事务模型下写写冲突问题排查](https://docs.pingcap.com/tidb/stable/troubleshoot-write-conflicts/): 介绍 TiDB 中乐观锁下写写冲突出现的原因以及解决方案。
-- [乐观模式下分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge-optimistic/): 介绍 DM 提供的乐观模式下分库分表的合并迁移功能。
-- [事务概览](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-overview/): 简单介绍 TiDB 中的事务。
-- [事务错误处理](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-troubleshoot/): 介绍 TiDB 中的事务错误处理办法。
-- [事务限制](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-restraints/): 介绍 TiDB 中的事务限制。
-- [从 Amazon Aurora 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-aurora-to-tidb/): 介绍如何使用快照从 Amazon Aurora 迁移数据到 TiDB。
-- [从 CSV 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-csv-files-to-tidb/): 介绍如何从 CSV 等文件迁移数据到 TiDB。
-- [从 MariaDB 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-mariadb/): 介绍如何将数据从 MariaDB 文件迁移数据到 TiDB。
-- [从 Parquet 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-parquet-files-to-tidb/): 介绍如何使用 TiDB Lightning 从 Parquet 文件迁移数据到 TiDB。
-- [从 SQL 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-sql-files-to-tidb/): 介绍如何使用 TiDB Lightning 从 MySQL SQL 文件迁移数据到 TiDB。
-- [从 TiDB 集群迁移数据至兼容 MySQL 的数据库](https://docs.pingcap.com/tidb/stable/migrate-from-tidb-to-mysql/): 了解如何将数据从 TiDB 集群迁移至与 MySQL 兼容的数据库。
-- [从 TiDB 集群迁移数据至另一 TiDB 集群](https://docs.pingcap.com/tidb/stable/migrate-from-tidb-to-tidb/): 了解如何将数据从一个 TiDB 集群迁移至另一 TiDB 集群。
-- [从 Vitess 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-vitess/): 介绍从 Vitess 迁移数据到 TiDB 所使用的工具。
-- [从大数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-large-mysql-to-tidb/): 介绍如何从大数据量 MySQL 迁移数据到 TiDB。
-- [从大数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-large-mysql-shards-to-tidb/): 使用 Dumpling 和 TiDB Lightning 合并导入分表数据到 TiDB，以及如何使用 DM 持续增量复制数据。本文介绍的方法适用于导入数据总量大于 1 TiB 的场景。
-- [从小数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-small-mysql-to-tidb/): 介绍如何从小数据量 MySQL 迁移数据到 TiDB。
-- [从小数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-small-mysql-shards-to-tidb/): 介绍如何从 TB 级以下分库分表 MySQL 迁移数据到 TiDB。
-- [从窗口函数中推导 TopN 或 Limit](https://docs.pingcap.com/tidb/stable/derive-topn-from-window/): 介绍从窗口函数中推导 TopN 或 Limit 的优化规则，以及如何开启该规则。
-- [代价模型](https://docs.pingcap.com/tidb/stable/cost-model/): 介绍 TiDB 进行物理优化时所使用的代价模型的原理。
-- [优化向量搜索性能](https://docs.pingcap.com/tidb/stable/vector-search-improve-performance/): 了解优化 TiDB 向量搜索性能的最佳实践。
-- [优化规则与表达式下推的黑名单](https://docs.pingcap.com/tidb/stable/blocklist-control-plan/): 了解优化规则与表达式下推的黑名单。
-- [位函数和操作符](https://docs.pingcap.com/tidb/stable/bit-functions-and-operators/): TiDB 支持 MySQL 8.0 中的所有位函数和操作符。
-- [使用 AS OF TIMESTAMP 语法读取历史数据](https://docs.pingcap.com/tidb/stable/as-of-timestamp/): 了解如何使用 AS OF TIMESTAMP 语法读取历史数据。
-- [使用 Django 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-django/): 了解如何使用 Django 连接到 TiDB。本文提供了使用 Django 与 TiDB 交互的 Python 示例代码片段。
-- [使用 DM binary 部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-binary/): 本文介绍了如何使用 DM binary 快速部署 DM 集群。首先需要下载 DM 安装包，然后在五台服务器上部署两个 DM-worker 实例和三个 DM-master 实例。对于 DM-master 的部署，可以使用命令行参数或配置文件两种方式。而对于 DM-worker 的部署，也可以使用命令行参数或配置文件两种方式。部署完成后，需要确保各组件间端口可正常连通。
-- [使用 DM 迁移数据](https://docs.pingcap.com/tidb/stable/migrate-data-using-dm/): 本文介绍如何使用 DM 工具迁移数据。首先部署 DM 集群，然后检查集群信息和创建数据源。配置任务后，启动任务并查询任务状态。最后，停止任务并监控任务与查看日志。
-- [使用 dmctl 运维 TiDB Data Migration 集群](https://docs.pingcap.com/tidb/stable/dmctl-introduction/): 了解如何使用 dmctl 运维 DM 集群。
-- [使用 Dumpling 和 TiDB Lightning 备份与恢复](https://docs.pingcap.com/tidb/stable/backup-and-restore-using-dumpling-lightning/): 了解如何使用 Dumpling 和 TiDB Lightning 备份与恢复集群数据。
-- [使用 Dumpling 导出数据](https://docs.pingcap.com/tidb/stable/dumpling-overview/): 使用 Dumpling 从 TiDB 导出数据。
-- [使用 EXPLAIN 解读执行计划](https://docs.pingcap.com/tidb/stable/explain-walkthrough/): 通过示例了解如何使用 EXPLAIN 分析执行计划。
-- [使用 FastScan 功能](https://docs.pingcap.com/tidb/stable/use-fastscan/): 介绍通过使用 FastScan 来加速 OLAP 场景的查询的方法。
-- [使用 Go-MySQL-Driver 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-golang-sql-driver/): 了解如何使用 Go-MySQL-Driver 连接到 TiDB。本文提供了使用 Go-MySQL-Driver 与 TiDB 交互的 Golang 示例代码片段。
-- [使用 GORM 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-golang-gorm/): 了解如何使用 GORM 连接到 TiDB。本文提供了使用 GORM 与 TiDB 交互的 Golang 示例代码片段。
-- [使用 Grafana 监控 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/grafana-monitor-best-practices/): 了解高效利用 Grafana 监控 TiDB 的七个技巧。
-- [使用 Hibernate 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-hibernate/): 了解如何使用 Hibernate 连接到 TiDB。本文提供了使用 Hibernate 与 TiDB 交互的 Java 示例代码片段。
-- [使用 JDBC 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-jdbc/): 了解如何使用 JDBC 连接到 TiDB。本文提供了使用 JDBC 与 TiDB 交互的 Java 示例代码片段。
-- [使用 MPP 模式](https://docs.pingcap.com/tidb/stable/use-tiflash-mpp-mode/): 了解如何使用 MPP 模式。
-- [使用 MyBatis 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-mybatis/): 了解如何使用 MyBatis 连接到 TiDB。本文提供了使用 MyBatis 与 TiDB 交互的 Java 示例代码片段。
-- [使用 MySQL Connector/Python 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-mysql-connector/): 了解如何使用 MySQL Connector/Python 连接到 TiDB。本文提供了使用 MySQL Connector/Python 与 TiDB 交互的 Python 示例代码片段。
-- [使用 MySQL Workbench 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-gui-mysql-workbench/): 了解如何使用 MySQL Workbench 连接到 TiDB。
-- [使用 mysql.js 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-mysqljs/): 本文描述了 TiDB 和 mysql.js 的连接步骤，并给出了简单示例代码片段。
-- [使用 mysql2 连接 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-ruby-mysql2/): 本文描述了 TiDB 和 mysql2 的连接步骤，并给出了使用 mysql2 gem 连接 TiDB 的简单示例代码片段。
-- [使用 mysqlclient 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-mysqlclient/): 了解如何使用 mysqlclient 连接到 TiDB。本文提供了使用 mysqlclient 与 TiDB 交互的 Python 示例代码片段。
-- [使用 Navicat 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-gui-navicat/): 了解如何使用 Navicat 连接到 TiDB。
-- [使用 node-mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-mysql2/): 本文描述了 TiDB 和 node-mysql2 的连接步骤，并给出了简单示例代码片段。
-- [使用 OpenAPI 运维 TiDB Data Migration 集群](https://docs.pingcap.com/tidb/stable/dm-open-api/): 了解如何使用 OpenAPI 接口来管理 DM 集群状态和数据同步。
-- [使用 peewee 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-peewee/): 了解如何使用 peewee 连接到 TiDB。本文提供了使用 peewee 与 TiDB 交互的 Python 示例代码片段。
-- [使用 PingCAP Clinic Diag 采集 SQL 查询计划信息](https://docs.pingcap.com/tidb/stable/clinic-collect-sql-query-plan/): 了解如何使用 PingCAP Clinic Diag 采集 TiUP 部署集群的 SQL 查询计划信息。
-- [使用 PingCAP Clinic 生成诊断报告](https://docs.pingcap.com/tidb/stable/clinic-report/): 介绍 PingCAP Clinic 诊断报告的使用场景、方法以及如何解读报告。
-- [使用 PingCAP Clinic 诊断集群](https://docs.pingcap.com/tidb/stable/clinic-user-guide-for-tiup/): 详细介绍在使用 TiUP 部署的 TiDB 集群或 DM 集群上如何通过 PingCAP Clinic 诊断服务远程定位集群问题和本地快速检查集群状态。
-- [使用 PLAN REPLAYER 保存和恢复集群现场信息](https://docs.pingcap.com/tidb/stable/sql-plan-replayer/): 了解如何使用 PLAN REPLAY 命令保存和恢复集群现场信息。
-- [使用 Prisma 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-prisma/): 本文描述了 TiDB 和 Prisma 的连接步骤，并给出了简单示例代码片段。
-- [使用 PyMySQL 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-pymysql/): 了解如何使用 PyMySQL 连接到 TiDB。本文提供了使用 PyMySQL 与 TiDB 交互的 Python 示例代码片段。
-- [使用 Python 开始向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-get-started-using-python/): 了解如何使用 Python 和 TiDB 向量搜索快速开发可执行语义搜索的人工智能应用程序。
-- [使用 Rails 框架和 ActiveRecord ORM 连接 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-ruby-rails/): 本文描述了 TiDB 和 Rails 框架的连接步骤，并给出了使用 Rails 框架和 ActiveRecord ORM 连接 TiDB 的简单示例代码片段。
-- [使用 Sequelize 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-sequelize/): 本文描述了 TiDB 和 Sequelize 的连接步骤，并给出了简单示例代码片段。
-- [使用 Spring Boot 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-spring-boot/): 了解如何使用 Spring Boot 连接到 TiDB。本文提供了使用 Spring Boot 与 TiDB 交互的 Java 示例代码片段。
-- [使用 SQL 开始向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-get-started-using-sql/): 了解如何在 TiDB 中使用 SQL 语句快速开始向量搜索，从而为你的生成式 AI 应用提供支持。
-- [使用 SQLAlchemy 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-sqlalchemy/): 了解如何使用 SQLAlchemy 连接到 TiDB。本文提供了使用 SQLAlchemy 与 TiDB 交互的 Python 示例代码片段。
-- [使用 TiDB Cloud Serverless 构建 TiDB 集群](https://docs.pingcap.com/tidb/stable/dev-guide-build-cluster-in-cloud/): 使用 TiDB Cloud Serverless 构建 TiDB 集群，并连接 TiDB Cloud Serverless 集群。
-- [使用 TiDB Dashboard 诊断报告定位问题](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-usage/): 本文介绍了使用 TiDB Dashboard 诊断报告定位问题的方法。通过对比两个时间段的监控项差异来帮助 DBA 定位问题。示例中展示了大查询/写入导致 QPS 抖动或延迟上升的诊断方法，以及如何用对比报告定位问题。对比报告可以帮助 DBA 更快速地定位问题，例如通过查看监控项的差异大小排序来发现异常。通过对比报告定位问题，可以更准确地诊断可能的慢查询和影响查询执行的负载。
-- [使用 TiDB Data Migration 处理出错的 DDL 语句](https://docs.pingcap.com/tidb/stable/handle-failed-ddl-statements/): 了解在使用 TiDB Data Migration 迁移数据时，如何处理出错的 DDL 语句。
-- [使用 TiDB 的增删改查 SQL](https://docs.pingcap.com/tidb/stable/dev-guide-tidb-crud-sql/): 简单介绍 TiDB 的增删改查 SQL。
-- [使用 TiDB 读取 TiFlash](https://docs.pingcap.com/tidb/stable/use-tidb-to-read-tiflash/): 了解如何使用 TiDB 读取 TiFlash 副本。
-- [使用 TiSpark 读取 TiFlash](https://docs.pingcap.com/tidb/stable/use-tispark-to-read-tiflash/): 了解如何使用 TiSpark 读取 TiFlash。
-- [使用 TiUP bench 组件压测 TiDB](https://docs.pingcap.com/tidb/stable/tiup-bench/): TiUP bench 组件集成了多种压测 workloads，包括 TPC-C、TPC-H、CH-benCHmark、YCSB 和自定义 SQL 文件。每种压测都有对应的命令和参数，可以通过 TiUP 运行。TPC-C 测试包括准备数据、运行测试、检查一致性和清理数据等步骤。TPC-H 测试也有类似的步骤，包括准备数据、运行测试和清理数据。YCSB 测试可以分别针对 TiDB 和 TiKV 节点进行，包括准备数据和运行测试。此外，还可以通过 RawSQL 文件进行测试，包括准备数据和执行查询。
-- [使用 TiUP no-sudo 模式部署运维 TiDB 线上集群](https://docs.pingcap.com/tidb/stable/tiup-cluster-no-sudo-mode/): 了解如何使用 TiUP no-sudo 模式部署运维 TiDB 线上集群。
-- [使用 TiUP 升级 TiDB](https://docs.pingcap.com/tidb/stable/upgrade-tidb-using-tiup/): TiUP 可用于 TiDB 升级。升级过程中需注意不支持 TiFlash 组件从 5.3 之前的老版本在线升级至 5.3 及之后的版本，只能采用停机升级。在升级过程中，不要执行 DDL 语句，避免出现行为未定义的问题。升级前需查看集群中是否有正在进行的 DDL Job，并等待其完成或取消后再进行升级。升级完成后，可使用 TiUP 安装对应版本的 `ctl` 组件来更新相关工具版本。
-- [使用 TiUP 命令管理组件](https://docs.pingcap.com/tidb/stable/tiup-component-management/): TiUP 是一个用于管理组件的命令行工具。它提供了一系列命令来查询组件列表、安装、升级、运行、查看状态、清理实例和卸载组件。此外，还可以使用实验性的 `link` 和 `unlink` 命令来将组件的二进制符号链接到可执行文件目录。
-- [使用 TiUP 扩容缩容 PD 微服务节点](https://docs.pingcap.com/tidb/stable/scale-microservices-using-tiup/): 介绍如何使用 TiUP 扩容缩容集群中的 PD 微服务节点，以及如何切换 PD 工作模式。
-- [使用 TiUP 扩容缩容 TiDB 集群](https://docs.pingcap.com/tidb/stable/scale-tidb-using-tiup/): TiUP 可以在不中断线上服务的情况下扩容和缩容 TiDB 集群。使用 `tiup cluster list` 查看当前集群名称列表。扩容 TiDB/PD/TiKV 节点需要编写扩容拓扑配置，并执行扩容命令。扩容后，使用 `tiup cluster display <cluster-name>` 检查集群状态。缩容 TiDB/PD/TiKV 节点需要查看节点 ID 信息，执行缩容操作，然后检查集群状态。缩容 TiFlash/TiCDC 节点也需要执行相似的操作。
-- [使用 TiUP 离线镜像部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-tiup-offline/): 学习如何使用 TiUP DM 组件来离线部署 TiDB Data Migration 工具。
-- [使用 TiUP 运维 DM 集群](https://docs.pingcap.com/tidb/stable/maintain-dm-using-tiup/): 学习如何使用 TiUP 运维 DM 集群。
-- [使用 TiUP 部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-tiup/): 学习如何使用 TiUP DM 组件来部署 TiDB Data Migration 工具。
-- [使用 TiUP 部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/production-deployment-using-tiup/): 了解如何使用 TiUP 部署 TiDB 集群。
-- [使用 TiUP 部署运维 TiDB 线上集群](https://docs.pingcap.com/tidb/stable/tiup-cluster/): 使用 TiUP 的 cluster 组件可以快速部署生产集群，并提供强大的生产集群管理功能，包括升级、缩容、扩容、操作、审计等。部署集群的命令为 tiup cluster deploy，部署完成后可以通过 tiup cluster list 查看集群列表。启动集群的命令为 tiup cluster start，查看集群状态的命令为 tiup cluster display。可以使用 tiup cluster scale-in 进行集群缩容，tiup cluster scale-out 进行集群扩容。另外，还可以使用 tiup cluster upgrade 进行滚动升级，使用 tiup cluster edit-config 进行配置更新。最后，可以使用 tiup cluster exec 在集群节点机器上执行命令。
-- [使用 TTL (Time to Live) 定期删除过期数据](https://docs.pingcap.com/tidb/stable/time-to-live/): Time to Live (TTL) 提供了行级别的生命周期控制策略。本篇文档介绍如何通过 TTL (Time to Live) 来管理表数据的生命周期。
-- [使用 TypeORM 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-typeorm/): 本文描述了 TiDB 和 TypeORM 的连接步骤，并给出了简单示例代码片段。
-- [使用 WebUI 管理 DM 迁移任务](https://docs.pingcap.com/tidb/stable/dm-webui-guide/): 学习如何使用 WebUI 来方便的管理数据迁移任务。
-- [使用物理导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-physical-import-mode-usage/): 了解如何使用 TiDB Lightning 的物理导入模式。
-- [使用资源管控 (Resource Control) 实现资源组限制和流控](https://docs.pingcap.com/tidb/stable/tidb-resource-control-ru-groups/): 介绍如何通过资源管控能力来实现对应用资源消耗的控制和有效调度。
-- [使用资源管控 (Resource Control) 管理后台任务](https://docs.pingcap.com/tidb/stable/tidb-resource-control-background-tasks/): 介绍如何通过资源管控 (Resource Control) 控制后台任务。
-- [使用逻辑导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-logical-import-mode-usage/): 了解在 TiDB Lightning 的逻辑导入模式下，如何编写数据导入任务的配置文件，如何进行性能调优等。
-- [信息函数](https://docs.pingcap.com/tidb/stable/information-functions/): TiDB 支持 MySQL 8.0 中提供的大部分信息函数。
-- [修改 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-modify/): 了解修改 JSON 值的 JSON 函数。
-- [停止 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-stop-task/): 了解 TiDB Data Migration 如何停止数据迁移任务。
-- [元数据锁](https://docs.pingcap.com/tidb/stable/metadata-lock/): 介绍 TiDB 中元数据锁的概念、原理、实现和影响。
-- [公共表表达式 (CTE)](https://docs.pingcap.com/tidb/stable/dev-guide-use-common-table-expression/): 介绍 TiDB 公共表表达式能力，用以简化 SQL。
-- [关联子查询去关联](https://docs.pingcap.com/tidb/stable/correlated-subquery-optimization/): 了解如何给关联子查询解除关联。
-- [关键字](https://docs.pingcap.com/tidb/stable/keywords/): 本文介绍 TiDB 的关键字。
-- [其他函数](https://docs.pingcap.com/tidb/stable/miscellaneous-functions/): TiDB 支持使用 MySQL 8.0 中提供的大部分其他函数。
-- [函数和操作符概述](https://docs.pingcap.com/tidb/stable/functions-and-operators-overview/): TiDB 中的函数和操作符使用方法与 MySQL 基本一致。在 SQL 语句中，表达式可用于诸如 SELECT 语句的 ORDER BY 或 HAVING 子句，SELECT/DELETE/UPDATE 语句的 WHERE 子句，或 SET 语句之类的地方。可使用字面值，列名，NULL，内置函数，操作符等来书写表达式。其中有些表达式下推到 TiKV 上执行，详见下推到 TiKV 的表达式列表。
-- [分享 TiDB Dashboard 会话](https://docs.pingcap.com/tidb/stable/dashboard-session-share/): 了解如何将当前的 TiDB Dashboard 会话分享给其他用户访问。
-- [分区表](https://docs.pingcap.com/tidb/stable/partitioned-table/): 了解如何使用 TiDB 的分区表。
-- [分区裁剪](https://docs.pingcap.com/tidb/stable/partition-pruning/): 了解 TiDB 分区裁剪的使用场景。
-- [分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge/): DM 提供了分库分表的合并迁移功能，可将上游 MySQL/MariaDB 实例中的表迁移到下游 TiDB 的同一个表中。支持悲观协调和乐观协调两种模式。悲观模式保证数据不出错，但可能会阻塞迁移；乐观模式处理 DDL 时不会阻塞数据迁移，但可能导致数据不一致。
-- [分库分表场景下的数据校验](https://docs.pingcap.com/tidb/stable/shard-diff/): sync-diff-inspector 支持对分库分表场景进行数据校验。使用 Datasource config 进行配置，设置对应 rules，配置上游表与下游表的映射关系。当上游分表较多且符合一定规则时，可以使用 table-rules 进行配置。注意事项：如果上游数据库有 test.table-0 也会被下游数据库匹配到。
-- [分析慢查询](https://docs.pingcap.com/tidb/stable/analyze-slow-queries/): 学习如何定位和分析慢查询。
-- [分表合并数据迁移最佳实践](https://docs.pingcap.com/tidb/stable/shard-merge-best-practices/): 使用 DM 对分库分表进行合并迁移时的最佳实践。
-- [分页查询](https://docs.pingcap.com/tidb/stable/dev-guide-paginate-results/): 介绍 TiDB 的分页查询功能。
-- [切换 DM-worker 与上游 MySQL 实例的连接](https://docs.pingcap.com/tidb/stable/usage-scenario-master-slave-switch/): 了解如何切换 DM-worker 与上游 MySQL 实例的连接。
-- [列裁剪](https://docs.pingcap.com/tidb/stable/column-pruning/): 列裁剪是优化器在优化过程中删除不需要的列的基本思想。这样可以减少 I/O 资源占用并为后续优化带来便利。TiDB 会在逻辑优化阶段进行列裁剪，减少资源浪费。该扫描过程称作“列裁剪”，对应逻辑优化规则中的 columnPruner。如果要关闭这个规则，可以参照优化规则及表达式下推的黑名单中的关闭方法。
-- [创建 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-create/): 了解创建 JSON 值的 JSON 函数。
-- [创建 TiDB Data Migration 数据源](https://docs.pingcap.com/tidb/stable/quick-start-create-source/): 了解如何为 DM 创建数据源。
-- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-create-task/): 了解 TiDB Data Migration 如何创建数据迁移任务。
-- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/quick-start-create-task/): 了解在部署 DM 集群后，如何快速创建数据迁移任务。
-- [创建二级索引](https://docs.pingcap.com/tidb/stable/dev-guide-create-secondary-indexes/): 创建二级索引的方法、规范及例子。
-- [创建数据库](https://docs.pingcap.com/tidb/stable/dev-guide-create-database/): 创建数据库的方法、规范及例子。
-- [创建表](https://docs.pingcap.com/tidb/stable/dev-guide-create-table/): 创建表的方法、规范及例子。
-- [删除数据](https://docs.pingcap.com/tidb/stable/dev-guide-delete-data/): 删除数据、批量删除数据的方法、最佳实践及例子。
-- [加密和压缩函数](https://docs.pingcap.com/tidb/stable/encryption-and-compression-functions/): TiDB 支持 MySQL 8.0 中提供的大部分加密和压缩函数。
-- [升级与升级后常见问题](https://docs.pingcap.com/tidb/stable/upgrade-faq/): TiDB 升级与升级后的常见问题与解决办法。
-- [升级集群监控组件](https://docs.pingcap.com/tidb/stable/upgrade-monitoring-services/): 介绍如何升级 TiDB 集群监控组件 Prometheus、Grafana 和 Alertmanager。
-- [单区域双 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/two-data-centers-in-one-city-deployment/): 了解单个区域两个可用区自适应同步模式部署方式。
-- [单区域多 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/multi-data-centers-in-one-city-deployment/): 本文档介绍单个区域多个可用区部署 TiDB 的方案。
-- [单表查询](https://docs.pingcap.com/tidb/stable/dev-guide-get-data-from-single-table/): 介绍 TiDB 中的单表查询功能。
-- [双区域多 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/three-data-centers-in-two-cities-deployment/): 介绍在两个区域多个可用区部署 TiDB 的方式。
-- [只读存储节点最佳实践](https://docs.pingcap.com/tidb/stable/readonly-nodes/): 介绍如何通过使用只读存储节点，达到物理隔离部分流量的目的。
-- [同步数据到 Kafka](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-kafka/): 了解如何使用 TiCDC 将数据同步到 Kafka。
-- [同步数据到 MySQL 兼容数据库](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-mysql/): 了解如何使用 TiCDC 将数据同步到 TiDB 或 MySQL
-- [同步数据到 Pulsar](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-pulsar/): 了解如何使用 TiCDC 将数据同步到 Pulsar。
-- [同步数据到存储服务](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-cloud-storage/): 了解如何使用 TiCDC 将数据同步到存储服务，以及数据变更记录的存储路径。
-- [向量函数和操作符](https://docs.pingcap.com/tidb/stable/vector-search-functions-and-operators/): 本文介绍 TiDB 的向量相关函数和操作。
-- [向量搜索概述](https://docs.pingcap.com/tidb/stable/vector-search-overview/): 介绍 TiDB 向量搜索功能。TiDB 向量搜索可以对文档、图像、音频和视频等多种数据类型进行语义搜索。
-- [向量搜索索引](https://docs.pingcap.com/tidb/stable/vector-search-index/): 了解如何在 TiDB 中构建并使用向量搜索索引加速 K 近邻 (K-Nearest Neighbors, KNN) 查询。
-- [向量搜索限制](https://docs.pingcap.com/tidb/stable/vector-search-limitations/): 了解 TiDB 向量搜索功能的限制。
-- [向量搜索集成概览](https://docs.pingcap.com/tidb/stable/vector-search-integration-overview/): 介绍 TiDB 向量搜索支持的 AI 框架、嵌入模型和 ORM 库。
-- [向量数据类型](https://docs.pingcap.com/tidb/stable/vector-search-data-types/): 本文介绍 TiDB 的向量数据类型。
-- [唯一序列号生成方案](https://docs.pingcap.com/tidb/stable/dev-guide-unique-serial-number-generation/): 唯一序列号生成方案，为自行生成唯一 ID 的开发者提供帮助。
-- [在 AWS Lambda 函数中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-aws-lambda/): 本文介绍如何在 AWS Lambda 函数中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
-- [在 Django ORM 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-django-orm/): 了解如何在 Django ORM 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
-- [在 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/tidb-in-kubernetes/): 你可以使用 TiDB Operator 在 Kubernetes 上部署 TiDB。TiDB Operator 是 Kubernetes 上的 TiDB 集群自动运维系统，提供部署、升级、扩缩容、备份恢复、配置变更的 TiDB 全生命周期管理。借助 TiDB Operator，TiDB 可以无缝运行在公有云或自托管的 Kubernetes 集群上。TiDB Operator 的文档目前独立于 TiDB 文档。要查看如何在 Kubernetes 上部署 TiDB 的详细步骤，请参阅对应版本的 TiDB Operator 文档。
-- [在 LangChain 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-langchain/): 展示如何在 LangChain 中使用 TiDB 向量搜索
-- [在 LlamaIndex 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-llamaindex/): 了解如何在 LlamaIndex 中使用 TiDB 向量搜索。
-- [在 Next.js 中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nextjs/): 本文介绍了如何在 Next.js 中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
-- [在 peewee 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-peewee/): 了解如何在 peewee 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
-- [在 SQLAlchemy 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-sqlalchemy/): 了解如何在 SQLAlchemy 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
-- [在三数据中心下就近读取数据](https://docs.pingcap.com/tidb/stable/three-dc-local-read/): 了解通过 Stale Read 功能在三数据中心下就近读取数据，减少跨数据中心请求。
-- [在公有云上部署 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/best-practices-on-public-cloud/): 了解在公有云上部署 TiDB 的最佳实践。
-- [在线修改集群配置](https://docs.pingcap.com/tidb/stable/dynamic-config/): 介绍在线修改集群配置的功能。
-- [在线应用 Hotfix 到 DM 集群](https://docs.pingcap.com/tidb/stable/tiup-component-dm-patch/): 了解如何应用 hotfix 补丁包到 DM 集群。
-- [基于 Avro 的 TiCDC 行数据 Checksum 校验](https://docs.pingcap.com/tidb/stable/ticdc-avro-checksum-verification/): 介绍 TiCDC 行数据 Checksum 校验的具体实现。
-- [基于 DM 同步场景下的数据校验](https://docs.pingcap.com/tidb/stable/dm-diff/): 了解如何使用 TiDB DM 拉取指定配置进行数据校验。
-- [基于主备集群的容灾方案](https://docs.pingcap.com/tidb/stable/dr-secondary-cluster/): 了解如何使用 TiCDC 构建主备集群进行容灾。
-- [基于备份与恢复的容灾方案](https://docs.pingcap.com/tidb/stable/dr-backup-restore/): 了解如何基于 TiDB 的备份与恢复功能实现容灾。
-- [基于多副本的单集群容灾方案](https://docs.pingcap.com/tidb/stable/dr-multi-replica/): 了解 TiDB 提供的基于多副本的单集群容灾方案。
-- [基于角色的访问控制](https://docs.pingcap.com/tidb/stable/role-based-access-control/): TiDB 的基于角色的访问控制 (RBAC) 系统类似于 MySQL 8.0 的 RBAC 系统。用户可以创建、删除和授予角色权限，也可以将角色授予其他用户。角色需要在用户启用后才能生效。用户可以通过 `SHOW GRANTS` 查看角色权限，也可以设置默认启用角色。角色授权具有原子性，失败会回滚。除了角色授权外，还有用户管理和权限管理相关操作。
-- [备份与恢复 RawKV 数据](https://docs.pingcap.com/tidb/stable/rawkv-backup-and-restore/): 了解如何使用 tikv-br 命令行工具备份和恢复 RawKV 数据。
-- [备份与恢复常见问题](https://docs.pingcap.com/tidb/stable/backup-and-restore-faq/): 了解备份恢复相关的常见问题以及解决方法。
-- [备份存储](https://docs.pingcap.com/tidb/stable/backup-and-restore-storages/): 了解 BR 支持的备份存储服务的 URI 格式、鉴权方案和使用方式。
-- [备份恢复监控告警](https://docs.pingcap.com/tidb/stable/br-monitoring-and-alert/): 了解备份恢复的监控告警。
-- [备份自动调节](https://docs.pingcap.com/tidb/stable/br-auto-tune/): 了解 TiDB 的自动调节备份功能，在集群资源占用率较高的情况下，BR 会自动限制备份使用的资源以求减少对集群的影响。
-- [外部存储服务的 URI 格式](https://docs.pingcap.com/tidb/stable/external-storage-uri/): 介绍了外部存储服务 Amazon S3、GCS、和 Azure Blob Storage 的 URI 格式。
-- [外键约束](https://docs.pingcap.com/tidb/stable/foreign-key/): TiDB 数据库中外键约束的使用概况。
-- [多表连接查询](https://docs.pingcap.com/tidb/stable/dev-guide-join-tables/): 介绍 TiDB 中的多表连接查询功能。
-- [如何对 TiDB 进行 CH-benCHmark 测试](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-ch/): 本文介绍如何对 TiDB 进行 CH-benCHmark 测试。
-- [如何对 TiDB 进行 TPC-C 测试](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-tpcc/): 本文介绍了如何对 TiDB 进行 TPC-C 测试。TPC-C 是一个对 OLTP 系统进行测试的规范，使用商品销售模型对系统进行测试，包含五类事务：NewOrder、Payment、OrderStatus、Delivery、StockLevel。测试使用 tpmC 值衡量系统最大有效吞吐量，以 NewOrder Transaction 为准。使用 go-tpc 进行测试实现，通过 TiUP 命令下载测试程序。测试包括数据导入、运行测试和清理测试数据。
-- [如何用 Sysbench 测试 TiDB](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-sysbench/): 使用 Sysbench 1.0 或更新版本测试 TiDB 性能。调整 TiDB 和 TiKV 的日志级别以提高性能。配置 RocksDB 的 block cache 以充分利用内存。调整 Sysbench 配置文件并导入数据。进行数据预热和统计信息收集。执行 Point select、Update index 和 Read-only 测试命令。解决可能出现的性能问题。
-- [如何过滤 binlog 事件](https://docs.pingcap.com/tidb/stable/filter-binlog-event/): 介绍如何过滤 binlog 事件。
-- [如何通过 SQL 表达式过滤 DML](https://docs.pingcap.com/tidb/stable/filter-dml-event/): 介绍如何通过 SQL 表达式过滤 DML 事件
-- [子查询](https://docs.pingcap.com/tidb/stable/dev-guide-use-subqueries/): 介绍 TiDB 子查询功能。
-- [子查询相关的优化](https://docs.pingcap.com/tidb/stable/subquery-optimization/): 了解子查询相关的优化。
-- [字符串函数](https://docs.pingcap.com/tidb/stable/string-functions/): TiDB 支持 MySQL 8.0 中提供的大部分字符串函数以及 Oracle 21 中提供的部分函数。
-- [字符串类型](https://docs.pingcap.com/tidb/stable/data-type-string/): TiDB 支持 MySQL 所有字符串类型，包括 CHAR、VARCHAR、BINARY、VARBINARY、BLOB、TEXT、ENUM 和 SET。CHAR 是定长字符串，长度固定为创建表时声明的长度。VARCHAR 是变长字符串，空间占用大小不得超过 65535 字节。TEXT 是文本串，最大列长为 65535 字节。TINYTEXT 最大列长度为 255。MEDIUMTEXT 最大列长度为 16777215。LONGTEXT 最大列长度为 4294967295。BINARY 存储二进制字符串。VARBINARY 存储二进制字符串。BLOB 是二进制大文件，最大列长度为 65535 字节。TINYBLOB 最大列长度为 255。MEDIUMBLOB 最大列长度为 16777215。LONGBLOB 最大列长度为 4294967295。ENUM 是枚举类型，值必须从固定集合中选取。SET 是集合类型，包含零个或多个值的字符串。
-- [字符集和排序规则](https://docs.pingcap.com/tidb/stable/character-set-and-collation/): TiDB 支持的字符集包括 ascii、binary、gbk、latin1、utf8 和 utf8mb4。排序规则包括 ascii_bin、binary、gbk_bin、gbk_chinese_ci、latin1_bin、utf8_bin、utf8_general_ci、utf8_unicode_ci、utf8mb4_0900_ai_ci、utf8mb4_0900_bin、utf8mb4_bin、utf8mb4_general_ci 和 utf8mb4_unicode_ci。TiDB 强烈建议使用 utf8mb4 字符集，因为它支持更多字符。在 TiDB 中，默认的排序规则受到客户端的连接排序规则设置的影响。如果客户端使用 utf8mb4_0900_ai_ci 作为连接排序规则，TiDB 将遵循客户端的配置。TiDB 还支持新的排序规则框架，用于在语义上支持不同的排序规则。
-- [字面值](https://docs.pingcap.com/tidb/stable/literal-values/): 本文介绍了 TiDB SQL 语句的字面值。
-- [定位消耗系统资源多的查询](https://docs.pingcap.com/tidb/stable/identify-expensive-queries/): TiDB 会将执行时间超过 tidb_expensive_query_time_threshold 限制（默认值为 60s），或使用内存超过 tidb_mem_quota_query 限制（默认值为 1 GB）的语句输出到 tidb-server 日志文件中，用于定位消耗系统资源多的查询语句。expensive query 日志和慢查询日志的区别在于，expensive query 日志可以将正在执行的语句的相关信息打印出来。当一条语句在执行过程中达到资源使用阈值时，TiDB 会即时将这条语句的相关信息写入日志。
-- [对象命名规范](https://docs.pingcap.com/tidb/stable/dev-guide-object-naming-guidelines/): 介绍 TiDB 中的对象命名规范。
-- [将 Grafana 监控数据导出成快照](https://docs.pingcap.com/tidb/stable/exporting-grafana-snapshots/): 了解如何将 Grafana 监控数据导出为快照以及如何将快照文件可视化。
-- [已知的第三方工具兼容问题](https://docs.pingcap.com/tidb/stable/dev-guide-third-party-tools-compatibility/): 介绍在测试中发现的 TiDB 与第三方工具的兼容性问题。
-- [常规统计信息](https://docs.pingcap.com/tidb/stable/statistics/): 介绍 TiDB 中常规统计信息的收集和使用。
-- [平滑升级 TiDB](https://docs.pingcap.com/tidb/stable/smooth-upgrade-tidb/): 本文介绍支持无需手动取消 DDL 的平滑升级集群功能。
-- [序列函数](https://docs.pingcap.com/tidb/stable/sequence-functions/): 了解 TiDB 中的序列函数。
-- [延迟的拆解分析](https://docs.pingcap.com/tidb/stable/latency-breakdown/): 详细介绍 TiDB 运行各阶段中时间消耗带来的延迟，以及如何在真实场景中分析延迟。
-- [开发 Java 应用使用 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/java-app-best-practices/): 本文介绍了开发 Java 应用程序使用 TiDB 的常见问题与解决办法。TiDB 是高度兼容 MySQL 协议的数据库，基于 MySQL 开发的 Java 应用的最佳实践也多适用于 TiDB。
-- [开发者手册概览](https://docs.pingcap.com/tidb/stable/dev-guide-overview/): 整体叙述了开发者手册，罗列了开发者手册的大致脉络。
-- [性能优化概述](https://docs.pingcap.com/tidb/stable/performance-tuning-overview/): 本文介绍性能优化的基本概念，比如用户响应时间、吞吐和数据库时间，以及性能优化的通用流程。
-- [性能调优最佳实践](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql-best-practices/): 介绍使用 TiDB 的性能调优最佳实践。
-- [恢复 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-resume-task/): 了解 TiDB Data Migration 如何恢复数据迁移任务。
-- [悲观模式下分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge-pessimistic/): 介绍 DM 提供的悲观模式（默认模式）下分库分表的合并迁移功能。
-- [慢查询日志](https://docs.pingcap.com/tidb/stable/identify-slow-queries/): TiDB 会将执行时间超过 300 毫秒的语句输出到慢查询日志中，用于帮助用户定位慢查询语句。可以通过修改系统变量来启用或禁用慢查询日志。日志示例包括执行时间、用户信息、执行计划等字段。用户可通过查询 SLOW_QUERY 表来查询慢查询日志中的内容。还可以使用 pt-query-digest 工具分析 TiDB 慢日志。ADMIN SHOW SLOW 命令可以显示最近的慢查询记录或最慢的查询记录。
-- [手动处理 Sharding DDL Lock](https://docs.pingcap.com/tidb/stable/manually-handling-sharding-ddl-locks/): DM 使用 sharding DDL lock 来确保分库分表的 DDL 操作可以正确执行。在异常情况下，需要手动处理异常的 DDL lock。使用 shard-ddl-lock 命令查看 DDL lock 信息，使用 shard-ddl-lock unlock 命令请求 DM-master 解除指定的 DDL lock。支持处理部分 MySQL source 被移除和 unlock 过程中部分 DM-worker 异常停止或网络中断的情况。
-- [执行计划管理 (SPM)](https://docs.pingcap.com/tidb/stable/sql-plan-management/): 介绍 TiDB 的执行计划管理 (SQL Plan Management) 功能。
-- [扩展统计信息](https://docs.pingcap.com/tidb/stable/extended-statistics/): 了解如何使用扩展统计信息指导优化器。
-- [批量建表](https://docs.pingcap.com/tidb/stable/br-batch-create-table/): 了解如何使用批量建表功能。在恢复备份数据时，可以通过批量建表功能加快数据的恢复速度。
-- [控制执行计划](https://docs.pingcap.com/tidb/stable/control-execution-plan/): 本章节介绍了控制执行计划的方法，包括使用提示指导执行计划、执行计划管理、优化规则及表达式下推的黑名单。此外，还介绍了一些系统变量对执行计划的影响，以及引入的特殊变量 `tidb_opt_fix_control`，用于更细粒度地控制优化器的行为。
-- [控制流程函数](https://docs.pingcap.com/tidb/stable/control-flow-functions/): TiDB 支持 MySQL 8.0 中的控制流程函数，包括 CASE、IF()、IFNULL() 和 NULLIF()。这些函数可以用于构建 if/else 语句和处理 NULL 值。
-- [提升 TiDB 建表性能](https://docs.pingcap.com/tidb/stable/accelerated-table-creation/): 介绍 TiDB 加速建表中的概念、原理、实现和影响。
-- [提高 TiDB Dashboard 安全性](https://docs.pingcap.com/tidb/stable/dashboard-ops-security/): TiDB Dashboard 需要提高安全性。建议为 `root` 用户设置强密码或禁用 `root` 账户，并为 TiDB Dashboard 创建最小权限用户。使用防火墙阻止不可信访问，配置反向代理仅代理 TiDB Dashboard，并为反向代理开启 TLS。其他建议的安全措施包括为组件间通信和客户端服务端间通信开启加密传输。
-- [插入数据](https://docs.pingcap.com/tidb/stable/dev-guide-insert-data/): 插入数据、批量导入数据的方法、最佳实践及例子。
-- [搜索 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-search/): 了解搜索 JSON 值的 JSON 函数。
-- [搭建双集群主从复制](https://docs.pingcap.com/tidb/stable/replicate-between-primary-and-secondary-clusters/): 了解如何配置一个 TiDB 集群以及该集群的 TiDB 或 MySQL 从集群，并将增量数据实时从主集群同步到从集群，
-- [搭建私有镜像](https://docs.pingcap.com/tidb/stable/tiup-mirror/): TiUP 提供了构建私有镜像的方案，使用 mirror 指令来实现，可用于离线部署。执行 `tiup mirror clone` 命令，可构建本地地镜像。克隆完成后，可以通过 SCP、NFS、HTTP 或 HTTPS 共享仓库。使用 `TIUP_MIRRORS` 环境变量来使用镜像。重新运行 `tiup mirror clone` 命令会创建新的 manifest，并下载可用的最新版本的组件。可以创建自定义仓库，并使用自己构建的 TiDB 组件。
-- [操作符](https://docs.pingcap.com/tidb/stable/operators/): 操作符是用于在 MySQL 中执行各种操作的关键元素。它们包括逻辑操作符（如 AND、OR、NOT、XOR）、赋值操作符（如 =、:=）、比较操作符（如 =、<、>、LIKE、BETWEEN）、以及其他操作符（如 +、-、*、/）。操作符具有不同的优先级，可以用于执行各种复杂的操作。需要注意的是，MySQL 不支持 ILIKE 操作符。
-- [操作系统性能参数调优](https://docs.pingcap.com/tidb/stable/tune-operating-system/): 了解如何进行 CentOS 7 系统的性能调优。
-- [支持资源](https://docs.pingcap.com/tidb/stable/support/): 在使用 TiDB 时遇到问题，如何获取支持。
-- [数值函数与操作符](https://docs.pingcap.com/tidb/stable/numeric-functions-and-operators/): TiDB 支持 MySQL 8.0 中的所有数值函数和操作符。
-- [数值类型](https://docs.pingcap.com/tidb/stable/data-type-numeric/): TiDB 支持 MySQL 的所有数值类型，包括整数类型、浮点类型和定点类型。整数类型包括 BIT、BOOLEAN、TINYINT、SMALLINT、MEDIUMINT、INTEGER 和 BIGINT，存储空间和取值范围各不相同。浮点类型包括 FLOAT 和 DOUBLE，存储空间分别为 4 和 8 字节。定点类型包括 DECIMAL 和 NUMERIC，可设置小数位数和小数点后位数。建议使用 DECIMAL 类型存储精确值。
-- [数据批量处理](https://docs.pingcap.com/tidb/stable/batch-processing/): 介绍了 TiDB 为数据批量处理场景提供的功能，包括 Pipelined DML、非事务性 DML、IMPORT INTO 语句以及已被废弃的 batch-dml。
-- [数据类型概述](https://docs.pingcap.com/tidb/stable/data-type-overview/): TiDB 支持除了空间类型（SPATIAL）之外的所有 MySQL 数据类型，包括数值型类型、字符串类型、时间和日期类型、JSON 类型。数据类型定义一般为 T(M[, D])，其中 T 表示具体的类型，M 在整数类型中表示最大显示长度，在浮点数或者定点数中表示精度，在字符类型中表示最大长度，D 表示浮点数、定点数的小数位长度，fsp 在时间和日期类型里的 TIME、DATETIME 以及 TIMESTAMP 中表示秒的精度，其取值范围是 0 到 6，值为 0 表示没有小数部分，如果省略，则默认精度为 0。
-- [数据类型的默认值](https://docs.pingcap.com/tidb/stable/data-type-default-values/): 数据类型的默认值描述了列的默认值设置规则。默认值必须是常量，对于时间类型可以使用特定函数。从 v8.0.0 开始，BLOB、TEXT 和 JSON 可以设置表达式默认值。如果列没有设置 DEFAULT，TiDB 会根据规则添加隐式默认值。对于 NOT NULL 列，根据 SQL_MODE 进行不同行为。表达式默认值是实验特性，不建议在生产环境中使用。MySQL 8.0.13 开始支持在 DEFAULT 子句中指定表达式为默认值。TiDB 支持为 BLOB、TEXT 和 JSON 数据类型分配默认值，但仅支持通过表达式来设置。
-- [数据索引一致性错误](https://docs.pingcap.com/tidb/stable/troubleshoot-data-inconsistency-errors/): TiDB 在执行事务或执行 ADMIN CHECK 命令时会检查数据索引的一致性。如果发现不一致，会报错并记录相关错误日志。报错处理可通过改写 SQL 或关闭错误检查来绕过。对于特定错误代码，可通过设置 @@tidb_enable_mutation_checker=0 或 @@tidb_txn_assertion_level=OFF 来跳过检查。需注意关闭开关会关闭所有 SQL 语句的对应检查。
-- [数据迁移工具概览](https://docs.pingcap.com/tidb/stable/migration-tools/): 介绍 TiDB 的数据迁移工具。
-- [数据迁移概述](https://docs.pingcap.com/tidb/stable/migration-overview/): 了解各种数据迁移场景和对应的数据迁移方案。
-- [数据集成概述](https://docs.pingcap.com/tidb/stable/integration-overview/): 了解使用 TiCDC 进行数据集成的具体场景。
-- [断点备份](https://docs.pingcap.com/tidb/stable/br-checkpoint-backup/): 了解断点备份功能，包括它的使用场景、实现原理以及使用方法。
-- [断点恢复](https://docs.pingcap.com/tidb/stable/br-checkpoint-restore/): 了解断点恢复功能，包括它的使用场景、实现原理以及使用方法。
-- [日常巡检](https://docs.pingcap.com/tidb/stable/daily-check/): 介绍 TiDB 集群需要常关注的性能指标。
-- [日志脱敏](https://docs.pingcap.com/tidb/stable/log-redaction/): 了解 TiDB 各组件中的日志脱敏。
-- [日期和时间函数](https://docs.pingcap.com/tidb/stable/date-and-time-functions/): TiDB 支持 MySQL 8.0 中的所有日期和时间函数。
-- [日期和时间类型](https://docs.pingcap.com/tidb/stable/data-type-date-and-time/): TiDB 支持 MySQL 的所有日期和时间类型，包括 DATE、TIME、DATETIME、TIMESTAMP 和 YEAR。每种类型都有有效值范围，值为 0 表示无效值。TIMESTAMP 和 DATETIME 类型能自动生成新的时间值。关于日期和时间值类型，需要注意日期部分必须是“年 - 月 - 日”的格式，如果日期的年份部分是 2 位数，TiDB 会根据具体规则进行转换。不同类型的零值如下表所示：DATE:0000-00-00, TIME:00:00:00, DATETIME:0000-00-00 00:00:00, TIMESTAMP:0000-00-00 00:00:00, YEAR:0000。如果 SQL 模式允许使用无效的 DATE、DATETIME、TIMESTAMP 值，无效值会自动转换为相应的零值。
-- [时区支持](https://docs.pingcap.com/tidb/stable/configure-time-zone/): TiDB 的时区设置由 `time_zone` 系统变量控制，可以在会话级别或全局级别进行设置。`TIMESTAMP` 数据类型的的显示值受时区设置影响，但 `DATETIME`、`DATE` 或 `TIME` 数据类型不受影响。在数据迁移时，需要特别注意主库和从库的时区设置是否一致。
-- [暂停 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-pause-task/): 了解 TiDB Data Migration 如何暂停数据迁移任务。
-- [更新数据](https://docs.pingcap.com/tidb/stable/dev-guide-update-data/): 更新数据、批量更新数据的方法、最佳实践及例子。
-- [最小拓扑架构](https://docs.pingcap.com/tidb/stable/minimal-deployment-topology/): 介绍 TiDB 集群的最小拓扑。
-- [服务器状态变量](https://docs.pingcap.com/tidb/stable/status-variables/): 使用状态变量查看系统和会话状态。
-- [本地快速部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/tiup-playground/): TiDB 集群是分布式系统，由多个组件构成。想要快速体验 TiDB，可以使用 TiUP 中的 playground 组件快速搭建本地测试环境。通过命令行参数可以设置各组件的数量和配置，也可以启动多个组件实例。使用 `tiup client` 可以快速连接到本地启动的 TiDB 集群。还可以查看已启动集群的信息，扩容或缩容集群。
-- [术语表](https://docs.pingcap.com/tidb/stable/glossary/): 了解 TiDB 相关术语。
-- [权限管理](https://docs.pingcap.com/tidb/stable/privilege-management/): TiDB 支持 MySQL 5.7 和 MySQL 8.0 的权限管理系统。权限相关操作包括授予权限、收回权限、查看用户权限和动态权限。权限系统的实现包括授权表和连接验证。权限生效时机是在 TiDB 启动时加载到内存，并且可以手动刷新。
-- [构建 TiFlash 副本](https://docs.pingcap.com/tidb/stable/create-tiflash-replicas/): 了解如何构建 TiFlash 副本。
-- [概览](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql-overview/): 介绍 TiDB 的 SQL 性能调优概览。
-- [概述](https://docs.pingcap.com/tidb/stable/dev-guide-schema-design-overview/): TiDB 数据库模式设计的概述。
-- [注释语法](https://docs.pingcap.com/tidb/stable/comment-syntax/): 本文介绍 TiDB 支持的注释语法。
-- [海量 Region 集群调优最佳实践](https://docs.pingcap.com/tidb/stable/massive-regions-best-practices/): 了解海量 Region 导致性能问题的原因和优化方法。
-- [混合部署拓扑](https://docs.pingcap.com/tidb/stable/hybrid-deployment-topology/): 介绍混合部署 TiDB 集群的拓扑结构。
-- [物理优化](https://docs.pingcap.com/tidb/stable/sql-physical-optimization/): 物理优化是基于代价的优化，为逻辑执行计划制定物理执行计划。优化器根据数据统计信息选择时间复杂度、资源消耗和物理属性最小的物理执行计划。TiDB 执行计划文档介绍了索引选择、统计信息、错误索引解决方案、Distinct 优化和代价模型。
-- [物理导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-physical-import-mode/): 了解 TiDB Lightning 的物理导入模式。
-- [理解 TiKV 中的 Stale Read 和 safe-ts](https://docs.pingcap.com/tidb/stable/troubleshoot-stale-read/): TiKV 中的 Stale Read 依赖于 safe-ts，保证读取历史数据版本的安全性。safe-ts 由每个 Region 中的 peer 维护，resolved-ts 则由 Region leader 维护。诊断 Stale Read 问题可通过 Grafana、tikv-ctl 和日志。常见原因包括事务提交时间过长、事务存在时间过长以及 CheckLeader 信息推送延迟。处理慢事务提交可通过识别锁所属的事务和检查应用程序逻辑。处理长事务可通过识别事务、检查应用程序逻辑和处理慢查询。解决 CheckLeader 问题可通过检查网络和监控面板指标。
-- [生成列](https://docs.pingcap.com/tidb/stable/generated-columns/): 生成列是由列定义中的表达式计算得到的值。它包括存储生成列和虚拟生成列，存储生成列会将计算得到的值存储起来，而虚拟生成列不会存储其值。生成列可以用于从 JSON 数据类型中解出数据，并为该数据建立索引。在 INSERT 和 UPDATE 语句中，会检查生成列计算得到的值是否满足生成列的定义。生成列的局限性包括不能增加存储生成列，不能转换存储生成列为普通列，不能修改存储生成列的生成列表达式，以及不支持所有的 JSON 函数。
-- [生成自签名证书](https://docs.pingcap.com/tidb/stable/generate-self-signed-certificates/): 本文介绍了使用 openssl 生成自签名证书的示例。用户可以根据需要生成符合要求的证书和密钥。首先安装 OpenSSL，然后生成 CA 证书和各个组件的证书，最后为客户端签发证书。证书的作用是为各个组件和客户端验证身份。
-- [用 EXPLAIN 查看 JOIN 查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-joins/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看 MPP 模式查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-mpp/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看分区查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-partitions/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看子查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-subqueries/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看带视图的 SQL 执行计划](https://docs.pingcap.com/tidb/stable/explain-views/): 了解 TiDB 中视图相关语句的执行计划。
-- [用 EXPLAIN 查看索引合并的 SQL 执行计划](https://docs.pingcap.com/tidb/stable/explain-index-merge/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看索引查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-indexes/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用 EXPLAIN 查看聚合查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-aggregation/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
-- [用户自定义变量](https://docs.pingcap.com/tidb/stable/user-defined-variables/): 本文介绍 TiDB 的用户自定义变量。
-- [窗口函数](https://docs.pingcap.com/tidb/stable/window-functions/): TiDB 中的窗口函数与 MySQL 8.0 基本一致。可以将 `tidb_enable_window_function` 设置为 `0` 来解决升级后无法解析语法的问题。TiDB 支持除 `GROUP_CONCAT()` 和 `APPROX_PERCENTILE()` 以外的所有 `GROUP BY` 聚合函数。其他支持的窗口函数包括 `CUME_DIST()`、`DENSE_RANK()`、`FIRST_VALUE()`、`LAG()`、`LAST_VALUE()`、`LEAD()`、`NTH_VALUE()`、`NTILE()`、`PERCENT_RANK()`、`RANK()` 和 `ROW_NUMBER()`。这些函数可以下推到 TiFlash。
-- [管理 Changefeed](https://docs.pingcap.com/tidb/stable/ticdc-manage-changefeed/): 了解 Changefeed 相关的各种管理手段。
-- [管理 TiDB Data Migration 上游数据源](https://docs.pingcap.com/tidb/stable/dm-manage-source/): 了解如何管理上游 MySQL 实例。
-- [管理 TiDB Data Migration 迁移表的表结构](https://docs.pingcap.com/tidb/stable/dm-manage-schema/): 了解如何管理待迁移表在 DM 内部的表结构。
-- [管理资源消耗超出预期的查询 (Runaway Queries)](https://docs.pingcap.com/tidb/stable/tidb-resource-control-runaway-queries/): 介绍如何通过资源管控能力来实现对资源消耗超出预期的语句 (Runaway Queries) 进行控制和降级。
-- [精度数学](https://docs.pingcap.com/tidb/stable/precision-math/): TiDB 中的精确数值运算与 MySQL 基本一致。精确数值运算包括整型和 DECIMAL 类型，以及精确值数字字面量。DECIMAL 数据类型是定点数类型，其运算是精确计算。在表达式计算中，TiDB 会尽可能不做任何修改的使用每个输入的数值。数值修约时，`round()` 函数将使用四舍五入的规则。向 DECIMAL 或整数类型列插入数据时，round 的规则将采用 round half away from zero 的方式。
-- [系统变量](https://docs.pingcap.com/tidb/stable/system-variables/): 使用 TiDB 系统变量来优化性能或修改运行行为。
-- [系统变量索引](https://docs.pingcap.com/tidb/stable/system-variable-reference/): 查看 TiDB 所有的系统变量，以及引用这些变量的文档。
-- [索引推荐 (Index Advisor)](https://docs.pingcap.com/tidb/stable/index-advisor/): 了解如何使用 TiDB 索引推荐 (Index Advisor) 功能优化查询性能。
-- [索引的最佳实践](https://docs.pingcap.com/tidb/stable/dev-guide-index-best-practice/): 介绍 TiDB 中索引的最佳实践。
-- [索引的选择](https://docs.pingcap.com/tidb/stable/choose-index/): 介绍 TiDB 如何选择索引去读入数据，以及相关的一些控制索引选择的方式。
-- [约束](https://docs.pingcap.com/tidb/stable/constraints/): TiDB 支持的约束与 MySQL 基本相同，包括非空约束和 CHECK 约束。非空约束规则与 MySQL 相同，而 CHECK 约束需要在 tidb_enable_check_constraint 设置为 ON 后才能开启。可以通过 CREATE TABLE 或 ALTER TABLE 语句添加 CHECK 约束。唯一约束和主键约束也与 MySQL 相似，但 TiDB 目前仅支持对 NONCLUSTERED 的主键进行添加和删除操作。外键约束从 v6.6.0 开始支持，可以使用 CREATE TABLE 和 ALTER TABLE 命令来添加和删除外键。
-- [结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-jinaai-embedding/): 了解如何结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索，以存储向量嵌入信息并执行语义搜索。
-- [结果集不稳定](https://docs.pingcap.com/tidb/stable/dev-guide-unstable-result-set/): 结果集不稳定错误的处理办法。
-- [缓存表](https://docs.pingcap.com/tidb/stable/cached-tables/): 了解 TiDB 中的缓存表功能，用于很少被修改的热点小表，提升读性能。
-- [聚合 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-aggregate/): 了解聚合 JSON 值的 JSON 函数。
-- [聚簇索引](https://docs.pingcap.com/tidb/stable/clustered-indexes/): 本文档介绍了聚簇索引的概念、使用场景、使用方法、限制和兼容性。
-- [自定义监控组件的配置](https://docs.pingcap.com/tidb/stable/customized-montior-in-tiup-environment/): 了解如何自定义 TiUP 管理的监控组件的配置。
-- [表属性](https://docs.pingcap.com/tidb/stable/table-attributes/): 介绍 TiDB 的 `ATTRIBUTES` 使用方法。
-- [表库过滤](https://docs.pingcap.com/tidb/stable/table-filter/): 在 TiDB 数据迁移工具中使用表库过滤功能。
-- [表达式求值的类型转换](https://docs.pingcap.com/tidb/stable/type-conversion-in-expression-evaluation/): TiDB 中的表达式求值类型转换与 MySQL 基本一致。详情请参见 MySQL 表达式求值类型转换文档。
-- [表达式语法](https://docs.pingcap.com/tidb/stable/expression-syntax/): 本文列出 TiDB 的表达式语法。
-- [视图](https://docs.pingcap.com/tidb/stable/dev-guide-use-views/): 介绍 TiDB 中的视图功能。
-- [视图](https://docs.pingcap.com/tidb/stable/views/): TiDB 支持视图，视图是虚拟表，结构由创建时的 SELECT 语句定义。使用视图可保证数据安全，简化复杂查询。查询视图类似查询表，TiDB 执行查询时会展开视图。可通过 SHOW CREATE TABLE 或 SHOW CREATE VIEW 查看视图创建语句及相关信息。也可查询 INFORMATION_SCHEMA.VIEWS 表或访问 HTTP API 获取视图元信息。视图有局限性，不支持物化视图，且为只读视图，不支持写入操作。已创建的视图仅支持 DROP 操作。
-- [访问 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-access/): TiDB Dashboard 可通过浏览器访问，支持多 PD 实例访问。浏览器兼容性包括 Chrome、Firefox 和 Edge。登录界面可使用 root 用户或自定义 SQL 用户登录。支持简体中文和英文语言切换。可在用户页面登出当前用户。
-- [读写延迟增加](https://docs.pingcap.com/tidb/stable/troubleshoot-cpu-issues/): 介绍读写延时增加、抖动时的排查思路，可能的原因和解决方法。
-- [谓词下推](https://docs.pingcap.com/tidb/stable/predicate-push-down/): TiDB 逻辑优化规则中的谓词下推旨在尽早完成数据过滤，减少数据传输或计算的开销。谓词下推适用于将过滤表达式计算下推到数据源，如示例 1、2、3。但对于存储层不支持的谓词、外连接中的谓词和包含用户变量的谓词则不能下推。
-- [资源管控 (Resource Control) 监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-resource-control-dashboard/): 了解资源管控 (Resource Control) 的 Grafana Dashboard 中所展示的关键指标。
-- [跨数据中心部署拓扑](https://docs.pingcap.com/tidb/stable/geo-distributed-deployment-topology/): 介绍跨数据中心部署 TiDB 集群的拓扑结构。
-- [迁移使用 GH-ost/PT-osc 的源数据库](https://docs.pingcap.com/tidb/stable/feature-online-ddl/): 使用 GH-ost/PT-osc 进行在线 DDL 工具执行 DDL 时，会产生锁表操作，阻塞数据库读写。为降低影响，可选择在线 DDL 工具 gh-ost 和 pt-osc。在 DM 迁移 MySQL 到 TiDB 时，可开启 `online-ddl` 配置，实现 DM 工具与 gh-ost 或 pt-osc 的协同。 DM 与 online DDL 工具协作细节包括 gh-ost 和 pt-osc 的实现过程，以及自定义规则配置。
-- [迁移升级 TiDB 集群](https://docs.pingcap.com/tidb/stable/tidb-upgrade-migration-guide/): 本文介绍如何使用 BR 全量备份恢复与 TiCDC 增量数据同步实现 TiDB 集群的迁移升级。
-- [迁移常见问题](https://docs.pingcap.com/tidb/stable/migration-tidb-faq/): 介绍 TiDB 迁移中的常见问题。
-- [返回 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-return/): 了解返回 JSON 值的 JSON 函数。
-- [连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-connect-to-tidb/): 介绍连接到 TiDB 的方法。
-- [连接池与连接参数](https://docs.pingcap.com/tidb/stable/dev-guide-connection-parameters/): 针对开发者的 TiDB 连接池与连接参数的说明。
-- [选择驱动或 ORM 框架](https://docs.pingcap.com/tidb/stable/dev-guide-choose-driver-or-orm/): 选择驱动或 ORM 框架连接 TiDB。
-- [通过 SQL 表达式过滤 DML](https://docs.pingcap.com/tidb/stable/feature-expression-filter/): 增量数据迁移时可通过 SQL 表达式过滤 binlog event，例如不向下游迁移 `DELETE` 事件。从 v2.0.5 起，DM 支持使用 `binlog value filter` 过滤迁移数据。在 `ROW` 格式的 binlog 中，可以基于列的值配置 SQL 表达式。如果表达式结果为 `TRUE`，DM 就不会向下游迁移该条行变更。具体操作步骤和实现细节，请参考如何通过 SQL 表达式过滤 DML。
-- [通过 TiUP 部署 DM 集群的拓扑文件配置](https://docs.pingcap.com/tidb/stable/tiup-dm-topology-reference/): TiUP 部署 DM 集群的拓扑文件配置包括全局配置、组件配置、master 服务器配置、worker 服务器配置、监控服务器配置、Grafana 服务器配置和 Alertmanager 服务器配置。每个配置包含不同字段，如部署目录、数据目录、日志目录等。部署完成后部分字段不能再修改。
-- [通过 TiUP 部署 TiDB 集群的拓扑文件配置](https://docs.pingcap.com/tidb/stable/tiup-cluster-topology-reference/): 介绍通过 TiUP 部署或扩容 TiDB 集群时提供的拓扑文件配置和示例。
-- [通过反向代理使用 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-ops-reverse-proxy/): TiDB Dashboard 可通过反向代理安全提供给外部网络。首先获取实际地址，然后配置反向代理，最后修改路径前缀。详细步骤可参考官方文档。
-- [通过拓扑 label 进行副本调度](https://docs.pingcap.com/tidb/stable/schedule-replicas-by-topology-labels/): TiDB v5.3.0 引入了通过拓扑 label 进行副本调度的功能。为了提升集群的高可用性和数据容灾能力，推荐让 TiKV 节点在物理层面上尽可能分散。通过设置 TiKV 和 TiFlash 的 labels，可以标识它们的地理位置。同时，需要配置 PD 的 location-labels 和 isolation-level 来使 PD 理解 TiKV 节点拓扑并加强拓扑隔离要求。PD 在副本调度时会保证同一份数据的不同副本尽可能分散，以提高集群容灾能力。
-- [通过系统变量 `tidb_external_ts` 读取历史数据](https://docs.pingcap.com/tidb/stable/tidb-external-ts/): 了解如何通过系统变量 `tidb_external_ts` 读取历史数据。
-- [通过系统变量 `tidb_read_staleness` 读取历史数据](https://docs.pingcap.com/tidb/stable/tidb-read-staleness/): 了解如何通过系统变量 `tidb_read_staleness` 读取历史数据。
-- [通过系统变量 tidb_snapshot 读取历史数据](https://docs.pingcap.com/tidb/stable/read-historical-data/): 本文介绍了通过系统变量 `tidb_snapshot` 读取历史数据的操作流程和历史数据的保留策略。TiDB 实现了通过标准 SQL 接口读取历史数据功能，无需特殊的 client 或者 driver。当数据被更新、删除后，依然可以通过 SQL 接口将更新 / 删除前的数据读取出来。历史数据保留策略使用 MVCC 管理版本，超过一定时间的历史数据会被彻底删除，以减小空间占用以及避免历史版本过多引入的性能开销。
-- [逻辑优化](https://docs.pingcap.com/tidb/stable/sql-logical-optimization/): 本章节介绍了 TiDB 查询计划的关键逻辑改写，包括子查询优化、列裁剪、关联子查询去关联、Max/Min 消除、谓词下推、分区裁剪、TopN 和 Limit 下推以及 Join 重排序。这些改写帮助 TiDB 生成最终的查询计划，提高查询效率。
-- [逻辑导入模式简介](https://docs.pingcap.com/tidb/stable/tidb-lightning-logical-import-mode/): 了解 TiDB Lightning 的逻辑导入模式 (Logical Import Mode)。
-- [遥测](https://docs.pingcap.com/tidb/stable/telemetry/): 介绍遥测的场景，如何禁用功能和查看遥测状态。
-- [避免隐式类型转换](https://docs.pingcap.com/tidb/stable/dev-guide-implicit-type-conversion/): 介绍 TiDB 中隐式类型转换可能会带来的后果和避免方法。
-- [部署 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-ops-deploy/): TiDB Dashboard 是内置于 TiDB 4.0 或更高版本的 PD 组件中的界面，无需额外部署。对于 TiDB v6.5.0 及 TiDB Operator v1.4.0 之后的版本，在 Kubernetes 上支持将 TiDB Dashboard 作为独立的 Pod 部署。部署标准 TiDB 集群的文档可参考快速试用 TiDB 集群、生产环境部署和 Kubernetes 环境部署。当集群中部署了多个 PD 实例时，仅有一个 PD 实例会提供 TiDB Dashboard 服务。可通过 TiUP 查看实际运行 TiDB Dashboard 服务的 PD 实例，并切换其他 PD 实例提供 TiDB Dashboard 服务。也可以禁用和重新启用 TiDB Dashboard。
-- [部署 TiDB Lightning](https://docs.pingcap.com/tidb/stable/deploy-tidb-lightning/): 了解如何部署 TiDB Lightning，包括在线部署和离线部署。
-- [配置 TiDB Dashboard 使用 SSO 登录](https://docs.pingcap.com/tidb/stable/dashboard-session-sso/): 了解如何配置 TiDB Dashboard 启用 SSO 登录。
-- [锁函数](https://docs.pingcap.com/tidb/stable/locking-functions/): 了解 TiDB 中的用户级锁函数。
-- [错误码与故障诊断](https://docs.pingcap.com/tidb/stable/error-codes/): TiDB 错误码包括 MySQL 兼容的错误码和 TiDB 特有的错误码。如果遇到错误码，请参考官方文档或社区获取支持。常见错误码包括内存使用超限、写入冲突、表数据损坏、事务过大、写入冲突等。另外，TiDB 还提供了故障诊断文档供参考。
-- [错误索引的解决方案](https://docs.pingcap.com/tidb/stable/wrong-index-solution/): 了解如何处理错误索引问题。
-- [集合运算](https://docs.pingcap.com/tidb/stable/set-operators/): 了解 TiDB 支持的集合运算。
-- [集群监控部署](https://docs.pingcap.com/tidb/stable/deploy-monitoring-services/): 本文适用于手动部署 TiDB 监控报警系统的用户。假设 TiDB 的拓扑结构如下：Node1 主机 IP 为 192.168.199.113，服务包括 PD1、TiDB、node_export、Prometheus、Grafana；Node2 主机 IP 为 192.168.199.114，服务包括 PD2、node_export；Node3 主机 IP 为 192.168.199.115，服务包括 PD3、node_export；Node4 主机 IP 为 192.168.199.116，服务包括 TiKV1、node_export；Node5 主机 IP 为 192.168.199.117，服务包括 TiKV2、node_export；Node6 主机 IP 为 192.168.199.118，服务包括 TiKV3、node_export。具体部署步骤包括下载二进制包、启动 node_exporter 服务、启动 Prometheus 服务、启动 Grafana 服务、配置 Grafana 数据源和导入 Grafana 面板。可查看 TiDB Server、PD Server 和 TiKV Server 的监控信息。
-- [静态加密](https://docs.pingcap.com/tidb/stable/encryption-at-rest/): 了解如何启用静态加密功能保护敏感数据。
-- [非 Prepare 语句执行计划缓存](https://docs.pingcap.com/tidb/stable/sql-non-prepared-plan-cache/): 介绍 TiDB 中非 Prepare 语句执行计划缓存的原理、使用方法及示例。
-- [非事务 DML 语句](https://docs.pingcap.com/tidb/stable/non-transactional-dml/): 以事务的原子性和隔离性为代价，将 DML 语句拆成多个语句依次执行，用以提升批量数据处理场景的稳定性和易用性。
-- [预处理语句](https://docs.pingcap.com/tidb/stable/dev-guide-prepared-statement/): 介绍 TiDB 的预处理语句功能。
-- [验证 JSON 文档的函数](https://docs.pingcap.com/tidb/stable/json-functions-validate/): 了解验证 JSON 文档的函数。
-- [验证集群运行状态](https://docs.pingcap.com/tidb/stable/post-installation-check/): 介绍如何验证集群运行状态。
-- [高可用常见问题](https://docs.pingcap.com/tidb/stable/high-availability-faq/): 介绍高可用相关的常见问题。
-- [高可靠常见问题](https://docs.pingcap.com/tidb/stable/high-reliability-faq/): 介绍高可靠相关的常见问题。
+- [三节点混合部署最佳实践](https://docs.pingcap.com/tidb/stable/three-nodes-hybrid-deployment.md): 了解三节点混合部署最佳实践。
+- [上游使用 pt-osc/gh-ost 工具的持续同步场景](https://docs.pingcap.com/tidb/stable/migrate-with-pt-ghost.md): 介绍在使用 DM 持续增量数据同步，上游使用 pt-osc/gh-ost 工具进行在线 DDL 变更时 DM 的处理方式和注意事项。
+- [下推到 TiKV 的表达式列表](https://docs.pingcap.com/tidb/stable/expressions-pushed-down.md): TiDB 中下推到 TiKV 的表达式列表及相关设置。
+- [下推计算结果缓存](https://docs.pingcap.com/tidb/stable/coprocessor-cache.md): TiDB 4.0 支持下推计算结果缓存，配置位于 `tikv-client.copr-cache`，缓存仅存储在 TiDB 内存中，不共享缓存，对 Region 写入会导致缓存失效。缓存命中率可通过 `EXPLAIN ANALYZE` 或 Grafana 监控面板查看。
+- [下游存在更多列的迁移场景](https://docs.pingcap.com/tidb/stable/migrate-with-more-columns-downstream.md): 介绍下游存在更多列的迁移场景。
+- [不同库名或表名的数据校验](https://docs.pingcap.com/tidb/stable/route-diff.md): TiDB DM 等同步工具可以使用 route-rules 设置数据同步到下游指定表中。sync-diff-inspector 通过设置 rules 提供了校验不同库名、表名的表的功能。可以通过 rules 设置映射关系来简化配置，校验大量的不同库名或者表名的表。表路由的初始化和示例包括规则中存在 target-schema/target-table 表名为 schema.table 的行为，规则中只存在 target-schema 的行为，以及规则中不存在 target-schema.target-table 的行为。
+- [与 Apache Kafka 和 Apache Flink 进行数据集成](https://docs.pingcap.com/tidb/stable/replicate-data-to-kafka.md): 了解如何使用 TiCDC 从 TiDB 同步数据至 Apache Kafka 和 Apache Flink。
+- [与 Confluent Cloud 和 Snowflake 进行数据集成](https://docs.pingcap.com/tidb/stable/integrate-confluent-using-ticdc.md): 了解如何使用 TiCDC 从 TiDB 同步数据至 Confluent Cloud 以及 Snowflake、ksqlDB、SQL Server。
+- [与 MySQL 兼容性对比](https://docs.pingcap.com/tidb/stable/mysql-compatibility.md): 本文对 TiDB 和 MySQL 二者之间从语法和功能特性上做出详细的对比。
+- [与 MySQL 安全特性差异](https://docs.pingcap.com/tidb/stable/security-compatibility-with-mysql.md): TiDB 支持与 MySQL 5.7 类似的安全特性，同时也支持 MySQL 8.0 的部分安全特性。然而，在实现上存在一些差异，包括不支持列级别权限设置和部分权限属性。此外，TiDB 的密码过期策略和密码复杂度策略与 MySQL 存在一些差异。另外，TiDB 支持多种身份验证方式，包括 TLS 证书和 JWT。
+- [临时表](https://docs.pingcap.com/tidb/stable/dev-guide-use-temporary-tables.md): 介绍 TiDB 临时表创建、删除、限制。
+- [临时表](https://docs.pingcap.com/tidb/stable/temporary-tables.md): 了解 TiDB 中的临时表功能，使用临时表存储业务中间数据，减少表管理开销，并提升性能。
+- [为 DM 的连接开启加密传输](https://docs.pingcap.com/tidb/stable/dm-enable-tls.md): 了解如何为 DM 的连接开启加密传输。
+- [为 TiDB 客户端服务端间通信开启加密传输](https://docs.pingcap.com/tidb/stable/enable-tls-between-clients-and-servers.md): TiDB 服务端与客户端间默认采用非加密连接，容易造成信息泄露。建议使用加密连接确保安全性。要开启 TLS 加密传输，需要在服务端配置开启 TLS 支持，并在客户端应用程序中配置使用 TLS 加密连接。可以通过配置系统变量或在创建 / 修改用户时指定要求加密连接。可通过命令检查当前连接是否是加密连接。TLS 版本为 TLSv1.2 和 TLSv1.3，支持的加密算法包括 AES 和 CHACHA20_POLY1305。
+- [为 TiDB 组件间通信开启加密传输](https://docs.pingcap.com/tidb/stable/enable-tls-between-components.md): 了解如何为 TiDB 集群内各组件间开启加密传输。
+- [为 TiDB 落盘文件开启加密](https://docs.pingcap.com/tidb/stable/enable-disk-spill-encrypt.md): 了解如何为 TiDB 落盘文件开启加密。
+- [主从集群一致性读和数据校验](https://docs.pingcap.com/tidb/stable/ticdc-upstream-downstream-check.md): TiCDC 提供了 Syncpoint 功能，通过利用 TiDB 的 snapshot 特性，在同步过程中维护了一个上下游具有一致性 snapshot 的 `ts-map`。启用 Syncpoint 功能后，可以进行一致性快照读和数据一致性校验。要开启 Syncpoint 功能，只需在创建同步任务时把 TiCDC 的配置项 `enable-sync-point` 设置为 `true`。通过配置 `snapshot` 可以对 TiDB 主从集群的数据进行校验。
+- [乐观事务和悲观事务](https://docs.pingcap.com/tidb/stable/dev-guide-optimistic-and-pessimistic-transaction.md): 介绍 TiDB 中的乐观事务和悲观事务，乐观事务的重试等。
+- [乐观事务模型下写写冲突问题排查](https://docs.pingcap.com/tidb/stable/troubleshoot-write-conflicts.md): 介绍 TiDB 中乐观锁下写写冲突出现的原因以及解决方案。
+- [乐观模式下分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge-optimistic.md): 介绍 DM 提供的乐观模式下分库分表的合并迁移功能。
+- [事务概览](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-overview.md): 简单介绍 TiDB 中的事务。
+- [事务错误处理](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-troubleshoot.md): 介绍 TiDB 中的事务错误处理办法。
+- [事务限制](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-restraints.md): 介绍 TiDB 中的事务限制。
+- [从 Amazon Aurora 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-aurora-to-tidb.md): 介绍如何使用快照从 Amazon Aurora 迁移数据到 TiDB。
+- [从 CSV 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-csv-files-to-tidb.md): 介绍如何从 CSV 等文件迁移数据到 TiDB。
+- [从 MariaDB 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-mariadb.md): 介绍如何将数据从 MariaDB 文件迁移数据到 TiDB。
+- [从 Parquet 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-parquet-files-to-tidb.md): 介绍如何使用 TiDB Lightning 从 Parquet 文件迁移数据到 TiDB。
+- [从 SQL 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-sql-files-to-tidb.md): 介绍如何使用 TiDB Lightning 从 MySQL SQL 文件迁移数据到 TiDB。
+- [从 TiDB 集群迁移数据至兼容 MySQL 的数据库](https://docs.pingcap.com/tidb/stable/migrate-from-tidb-to-mysql.md): 了解如何将数据从 TiDB 集群迁移至与 MySQL 兼容的数据库。
+- [从 TiDB 集群迁移数据至另一 TiDB 集群](https://docs.pingcap.com/tidb/stable/migrate-from-tidb-to-tidb.md): 了解如何将数据从一个 TiDB 集群迁移至另一 TiDB 集群。
+- [从 Vitess 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-vitess.md): 介绍从 Vitess 迁移数据到 TiDB 所使用的工具。
+- [从大数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-large-mysql-to-tidb.md): 介绍如何从大数据量 MySQL 迁移数据到 TiDB。
+- [从大数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-large-mysql-shards-to-tidb.md): 使用 Dumpling 和 TiDB Lightning 合并导入分表数据到 TiDB，以及如何使用 DM 持续增量复制数据。本文介绍的方法适用于导入数据总量大于 1 TiB 的场景。
+- [从小数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-small-mysql-to-tidb.md): 介绍如何从小数据量 MySQL 迁移数据到 TiDB。
+- [从小数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-small-mysql-shards-to-tidb.md): 介绍如何从 TB 级以下分库分表 MySQL 迁移数据到 TiDB。
+- [从窗口函数中推导 TopN 或 Limit](https://docs.pingcap.com/tidb/stable/derive-topn-from-window.md): 介绍从窗口函数中推导 TopN 或 Limit 的优化规则，以及如何开启该规则。
+- [代价模型](https://docs.pingcap.com/tidb/stable/cost-model.md): 介绍 TiDB 进行物理优化时所使用的代价模型的原理。
+- [优化向量搜索性能](https://docs.pingcap.com/tidb/stable/vector-search-improve-performance.md): 了解优化 TiDB 向量搜索性能的最佳实践。
+- [优化规则与表达式下推的黑名单](https://docs.pingcap.com/tidb/stable/blocklist-control-plan.md): 了解优化规则与表达式下推的黑名单。
+- [位函数和操作符](https://docs.pingcap.com/tidb/stable/bit-functions-and-operators.md): TiDB 支持 MySQL 8.0 中的所有位函数和操作符。
+- [使用 AS OF TIMESTAMP 语法读取历史数据](https://docs.pingcap.com/tidb/stable/as-of-timestamp.md): 了解如何使用 AS OF TIMESTAMP 语法读取历史数据。
+- [使用 Django 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-django.md): 了解如何使用 Django 连接到 TiDB。本文提供了使用 Django 与 TiDB 交互的 Python 示例代码片段。
+- [使用 DM binary 部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-binary.md): 本文介绍了如何使用 DM binary 快速部署 DM 集群。首先需要下载 DM 安装包，然后在五台服务器上部署两个 DM-worker 实例和三个 DM-master 实例。对于 DM-master 的部署，可以使用命令行参数或配置文件两种方式。而对于 DM-worker 的部署，也可以使用命令行参数或配置文件两种方式。部署完成后，需要确保各组件间端口可正常连通。
+- [使用 DM 迁移数据](https://docs.pingcap.com/tidb/stable/migrate-data-using-dm.md): 本文介绍如何使用 DM 工具迁移数据。首先部署 DM 集群，然后检查集群信息和创建数据源。配置任务后，启动任务并查询任务状态。最后，停止任务并监控任务与查看日志。
+- [使用 dmctl 运维 TiDB Data Migration 集群](https://docs.pingcap.com/tidb/stable/dmctl-introduction.md): 了解如何使用 dmctl 运维 DM 集群。
+- [使用 Dumpling 和 TiDB Lightning 备份与恢复](https://docs.pingcap.com/tidb/stable/backup-and-restore-using-dumpling-lightning.md): 了解如何使用 Dumpling 和 TiDB Lightning 备份与恢复集群数据。
+- [使用 Dumpling 导出数据](https://docs.pingcap.com/tidb/stable/dumpling-overview.md): 使用 Dumpling 从 TiDB 导出数据。
+- [使用 EXPLAIN 解读执行计划](https://docs.pingcap.com/tidb/stable/explain-walkthrough.md): 通过示例了解如何使用 EXPLAIN 分析执行计划。
+- [使用 FastScan 功能](https://docs.pingcap.com/tidb/stable/use-fastscan.md): 介绍通过使用 FastScan 来加速 OLAP 场景的查询的方法。
+- [使用 Go-MySQL-Driver 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-golang-sql-driver.md): 了解如何使用 Go-MySQL-Driver 连接到 TiDB。本文提供了使用 Go-MySQL-Driver 与 TiDB 交互的 Golang 示例代码片段。
+- [使用 GORM 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-golang-gorm.md): 了解如何使用 GORM 连接到 TiDB。本文提供了使用 GORM 与 TiDB 交互的 Golang 示例代码片段。
+- [使用 Grafana 监控 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/grafana-monitor-best-practices.md): 了解高效利用 Grafana 监控 TiDB 的七个技巧。
+- [使用 Hibernate 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-hibernate.md): 了解如何使用 Hibernate 连接到 TiDB。本文提供了使用 Hibernate 与 TiDB 交互的 Java 示例代码片段。
+- [使用 JDBC 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-jdbc.md): 了解如何使用 JDBC 连接到 TiDB。本文提供了使用 JDBC 与 TiDB 交互的 Java 示例代码片段。
+- [使用 MPP 模式](https://docs.pingcap.com/tidb/stable/use-tiflash-mpp-mode.md): 了解如何使用 MPP 模式。
+- [使用 MyBatis 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-mybatis.md): 了解如何使用 MyBatis 连接到 TiDB。本文提供了使用 MyBatis 与 TiDB 交互的 Java 示例代码片段。
+- [使用 MySQL Connector/Python 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-mysql-connector.md): 了解如何使用 MySQL Connector/Python 连接到 TiDB。本文提供了使用 MySQL Connector/Python 与 TiDB 交互的 Python 示例代码片段。
+- [使用 MySQL Workbench 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-gui-mysql-workbench.md): 了解如何使用 MySQL Workbench 连接到 TiDB。
+- [使用 mysql.js 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-mysqljs.md): 本文描述了 TiDB 和 mysql.js 的连接步骤，并给出了简单示例代码片段。
+- [使用 mysql2 连接 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-ruby-mysql2.md): 本文描述了 TiDB 和 mysql2 的连接步骤，并给出了使用 mysql2 gem 连接 TiDB 的简单示例代码片段。
+- [使用 mysqlclient 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-mysqlclient.md): 了解如何使用 mysqlclient 连接到 TiDB。本文提供了使用 mysqlclient 与 TiDB 交互的 Python 示例代码片段。
+- [使用 Navicat 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-gui-navicat.md): 了解如何使用 Navicat 连接到 TiDB。
+- [使用 node-mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-mysql2.md): 本文描述了 TiDB 和 node-mysql2 的连接步骤，并给出了简单示例代码片段。
+- [使用 OpenAPI 运维 TiDB Data Migration 集群](https://docs.pingcap.com/tidb/stable/dm-open-api.md): 了解如何使用 OpenAPI 接口来管理 DM 集群状态和数据同步。
+- [使用 peewee 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-peewee.md): 了解如何使用 peewee 连接到 TiDB。本文提供了使用 peewee 与 TiDB 交互的 Python 示例代码片段。
+- [使用 PingCAP Clinic Diag 采集 SQL 查询计划信息](https://docs.pingcap.com/tidb/stable/clinic-collect-sql-query-plan.md): 了解如何使用 PingCAP Clinic Diag 采集 TiUP 部署集群的 SQL 查询计划信息。
+- [使用 PingCAP Clinic 生成诊断报告](https://docs.pingcap.com/tidb/stable/clinic-report.md): 介绍 PingCAP Clinic 诊断报告的使用场景、方法以及如何解读报告。
+- [使用 PingCAP Clinic 诊断集群](https://docs.pingcap.com/tidb/stable/clinic-user-guide-for-tiup.md): 详细介绍在使用 TiUP 部署的 TiDB 集群或 DM 集群上如何通过 PingCAP Clinic 诊断服务远程定位集群问题和本地快速检查集群状态。
+- [使用 PLAN REPLAYER 保存和恢复集群现场信息](https://docs.pingcap.com/tidb/stable/sql-plan-replayer.md): 了解如何使用 PLAN REPLAY 命令保存和恢复集群现场信息。
+- [使用 Prisma 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-prisma.md): 本文描述了 TiDB 和 Prisma 的连接步骤，并给出了简单示例代码片段。
+- [使用 PyMySQL 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-pymysql.md): 了解如何使用 PyMySQL 连接到 TiDB。本文提供了使用 PyMySQL 与 TiDB 交互的 Python 示例代码片段。
+- [使用 Python 开始向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-get-started-using-python.md): 了解如何使用 Python 和 TiDB 向量搜索快速开发可执行语义搜索的人工智能应用程序。
+- [使用 Rails 框架和 ActiveRecord ORM 连接 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-ruby-rails.md): 本文描述了 TiDB 和 Rails 框架的连接步骤，并给出了使用 Rails 框架和 ActiveRecord ORM 连接 TiDB 的简单示例代码片段。
+- [使用 Sequelize 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-sequelize.md): 本文描述了 TiDB 和 Sequelize 的连接步骤，并给出了简单示例代码片段。
+- [使用 Spring Boot 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-spring-boot.md): 了解如何使用 Spring Boot 连接到 TiDB。本文提供了使用 Spring Boot 与 TiDB 交互的 Java 示例代码片段。
+- [使用 SQL 开始向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-get-started-using-sql.md): 了解如何在 TiDB 中使用 SQL 语句快速开始向量搜索，从而为你的生成式 AI 应用提供支持。
+- [使用 SQLAlchemy 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-sqlalchemy.md): 了解如何使用 SQLAlchemy 连接到 TiDB。本文提供了使用 SQLAlchemy 与 TiDB 交互的 Python 示例代码片段。
+- [使用 TiDB Cloud Serverless 构建 TiDB 集群](https://docs.pingcap.com/tidb/stable/dev-guide-build-cluster-in-cloud.md): 使用 TiDB Cloud Serverless 构建 TiDB 集群，并连接 TiDB Cloud Serverless 集群。
+- [使用 TiDB Dashboard 诊断报告定位问题](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-usage.md): 本文介绍了使用 TiDB Dashboard 诊断报告定位问题的方法。通过对比两个时间段的监控项差异来帮助 DBA 定位问题。示例中展示了大查询/写入导致 QPS 抖动或延迟上升的诊断方法，以及如何用对比报告定位问题。对比报告可以帮助 DBA 更快速地定位问题，例如通过查看监控项的差异大小排序来发现异常。通过对比报告定位问题，可以更准确地诊断可能的慢查询和影响查询执行的负载。
+- [使用 TiDB Data Migration 处理出错的 DDL 语句](https://docs.pingcap.com/tidb/stable/handle-failed-ddl-statements.md): 了解在使用 TiDB Data Migration 迁移数据时，如何处理出错的 DDL 语句。
+- [使用 TiDB 的增删改查 SQL](https://docs.pingcap.com/tidb/stable/dev-guide-tidb-crud-sql.md): 简单介绍 TiDB 的增删改查 SQL。
+- [使用 TiDB 读取 TiFlash](https://docs.pingcap.com/tidb/stable/use-tidb-to-read-tiflash.md): 了解如何使用 TiDB 读取 TiFlash 副本。
+- [使用 TiSpark 读取 TiFlash](https://docs.pingcap.com/tidb/stable/use-tispark-to-read-tiflash.md): 了解如何使用 TiSpark 读取 TiFlash。
+- [使用 TiUP bench 组件压测 TiDB](https://docs.pingcap.com/tidb/stable/tiup-bench.md): TiUP bench 组件集成了多种压测 workloads，包括 TPC-C、TPC-H、CH-benCHmark、YCSB 和自定义 SQL 文件。每种压测都有对应的命令和参数，可以通过 TiUP 运行。TPC-C 测试包括准备数据、运行测试、检查一致性和清理数据等步骤。TPC-H 测试也有类似的步骤，包括准备数据、运行测试和清理数据。YCSB 测试可以分别针对 TiDB 和 TiKV 节点进行，包括准备数据和运行测试。此外，还可以通过 RawSQL 文件进行测试，包括准备数据和执行查询。
+- [使用 TiUP no-sudo 模式部署运维 TiDB 线上集群](https://docs.pingcap.com/tidb/stable/tiup-cluster-no-sudo-mode.md): 了解如何使用 TiUP no-sudo 模式部署运维 TiDB 线上集群。
+- [使用 TiUP 升级 TiDB](https://docs.pingcap.com/tidb/stable/upgrade-tidb-using-tiup.md): TiUP 可用于 TiDB 升级。升级过程中需注意不支持 TiFlash 组件从 5.3 之前的老版本在线升级至 5.3 及之后的版本，只能采用停机升级。在升级过程中，不要执行 DDL 语句，避免出现行为未定义的问题。升级前需查看集群中是否有正在进行的 DDL Job，并等待其完成或取消后再进行升级。升级完成后，可使用 TiUP 安装对应版本的 `ctl` 组件来更新相关工具版本。
+- [使用 TiUP 命令管理组件](https://docs.pingcap.com/tidb/stable/tiup-component-management.md): TiUP 是一个用于管理组件的命令行工具。它提供了一系列命令来查询组件列表、安装、升级、运行、查看状态、清理实例和卸载组件。此外，还可以使用实验性的 `link` 和 `unlink` 命令来将组件的二进制符号链接到可执行文件目录。
+- [使用 TiUP 扩容缩容 PD 微服务节点](https://docs.pingcap.com/tidb/stable/scale-microservices-using-tiup.md): 介绍如何使用 TiUP 扩容缩容集群中的 PD 微服务节点，以及如何切换 PD 工作模式。
+- [使用 TiUP 扩容缩容 TiDB 集群](https://docs.pingcap.com/tidb/stable/scale-tidb-using-tiup.md): TiUP 可以在不中断线上服务的情况下扩容和缩容 TiDB 集群。使用 `tiup cluster list` 查看当前集群名称列表。扩容 TiDB/PD/TiKV 节点需要编写扩容拓扑配置，并执行扩容命令。扩容后，使用 `tiup cluster display <cluster-name>` 检查集群状态。缩容 TiDB/PD/TiKV 节点需要查看节点 ID 信息，执行缩容操作，然后检查集群状态。缩容 TiFlash/TiCDC 节点也需要执行相似的操作。
+- [使用 TiUP 离线镜像部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-tiup-offline.md): 学习如何使用 TiUP DM 组件来离线部署 TiDB Data Migration 工具。
+- [使用 TiUP 运维 DM 集群](https://docs.pingcap.com/tidb/stable/maintain-dm-using-tiup.md): 学习如何使用 TiUP 运维 DM 集群。
+- [使用 TiUP 部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-tiup.md): 学习如何使用 TiUP DM 组件来部署 TiDB Data Migration 工具。
+- [使用 TiUP 部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/production-deployment-using-tiup.md): 了解如何使用 TiUP 部署 TiDB 集群。
+- [使用 TiUP 部署运维 TiDB 线上集群](https://docs.pingcap.com/tidb/stable/tiup-cluster.md): 使用 TiUP 的 cluster 组件可以快速部署生产集群，并提供强大的生产集群管理功能，包括升级、缩容、扩容、操作、审计等。部署集群的命令为 tiup cluster deploy，部署完成后可以通过 tiup cluster list 查看集群列表。启动集群的命令为 tiup cluster start，查看集群状态的命令为 tiup cluster display。可以使用 tiup cluster scale-in 进行集群缩容，tiup cluster scale-out 进行集群扩容。另外，还可以使用 tiup cluster upgrade 进行滚动升级，使用 tiup cluster edit-config 进行配置更新。最后，可以使用 tiup cluster exec 在集群节点机器上执行命令。
+- [使用 TTL (Time to Live) 定期删除过期数据](https://docs.pingcap.com/tidb/stable/time-to-live.md): Time to Live (TTL) 提供了行级别的生命周期控制策略。本篇文档介绍如何通过 TTL (Time to Live) 来管理表数据的生命周期。
+- [使用 TypeORM 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-typeorm.md): 本文描述了 TiDB 和 TypeORM 的连接步骤，并给出了简单示例代码片段。
+- [使用 WebUI 管理 DM 迁移任务](https://docs.pingcap.com/tidb/stable/dm-webui-guide.md): 学习如何使用 WebUI 来方便的管理数据迁移任务。
+- [使用物理导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-physical-import-mode-usage.md): 了解如何使用 TiDB Lightning 的物理导入模式。
+- [使用资源管控 (Resource Control) 实现资源组限制和流控](https://docs.pingcap.com/tidb/stable/tidb-resource-control-ru-groups.md): 介绍如何通过资源管控能力来实现对应用资源消耗的控制和有效调度。
+- [使用资源管控 (Resource Control) 管理后台任务](https://docs.pingcap.com/tidb/stable/tidb-resource-control-background-tasks.md): 介绍如何通过资源管控 (Resource Control) 控制后台任务。
+- [使用逻辑导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-logical-import-mode-usage.md): 了解在 TiDB Lightning 的逻辑导入模式下，如何编写数据导入任务的配置文件，如何进行性能调优等。
+- [信息函数](https://docs.pingcap.com/tidb/stable/information-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分信息函数。
+- [修改 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-modify.md): 了解修改 JSON 值的 JSON 函数。
+- [停止 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-stop-task.md): 了解 TiDB Data Migration 如何停止数据迁移任务。
+- [元数据锁](https://docs.pingcap.com/tidb/stable/metadata-lock.md): 介绍 TiDB 中元数据锁的概念、原理、实现和影响。
+- [公共表表达式 (CTE)](https://docs.pingcap.com/tidb/stable/dev-guide-use-common-table-expression.md): 介绍 TiDB 公共表表达式能力，用以简化 SQL。
+- [关联子查询去关联](https://docs.pingcap.com/tidb/stable/correlated-subquery-optimization.md): 了解如何给关联子查询解除关联。
+- [关键字](https://docs.pingcap.com/tidb/stable/keywords.md): 本文介绍 TiDB 的关键字。
+- [其他函数](https://docs.pingcap.com/tidb/stable/miscellaneous-functions.md): TiDB 支持使用 MySQL 8.0 中提供的大部分其他函数。
+- [函数和操作符概述](https://docs.pingcap.com/tidb/stable/functions-and-operators-overview.md): TiDB 中的函数和操作符使用方法与 MySQL 基本一致。在 SQL 语句中，表达式可用于诸如 SELECT 语句的 ORDER BY 或 HAVING 子句，SELECT/DELETE/UPDATE 语句的 WHERE 子句，或 SET 语句之类的地方。可使用字面值，列名，NULL，内置函数，操作符等来书写表达式。其中有些表达式下推到 TiKV 上执行，详见下推到 TiKV 的表达式列表。
+- [分享 TiDB Dashboard 会话](https://docs.pingcap.com/tidb/stable/dashboard-session-share.md): 了解如何将当前的 TiDB Dashboard 会话分享给其他用户访问。
+- [分区表](https://docs.pingcap.com/tidb/stable/partitioned-table.md): 了解如何使用 TiDB 的分区表。
+- [分区裁剪](https://docs.pingcap.com/tidb/stable/partition-pruning.md): 了解 TiDB 分区裁剪的使用场景。
+- [分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge.md): DM 提供了分库分表的合并迁移功能，可将上游 MySQL/MariaDB 实例中的表迁移到下游 TiDB 的同一个表中。支持悲观协调和乐观协调两种模式。悲观模式保证数据不出错，但可能会阻塞迁移；乐观模式处理 DDL 时不会阻塞数据迁移，但可能导致数据不一致。
+- [分库分表场景下的数据校验](https://docs.pingcap.com/tidb/stable/shard-diff.md): sync-diff-inspector 支持对分库分表场景进行数据校验。使用 Datasource config 进行配置，设置对应 rules，配置上游表与下游表的映射关系。当上游分表较多且符合一定规则时，可以使用 table-rules 进行配置。注意事项：如果上游数据库有 test.table-0 也会被下游数据库匹配到。
+- [分析慢查询](https://docs.pingcap.com/tidb/stable/analyze-slow-queries.md): 学习如何定位和分析慢查询。
+- [分表合并数据迁移最佳实践](https://docs.pingcap.com/tidb/stable/shard-merge-best-practices.md): 使用 DM 对分库分表进行合并迁移时的最佳实践。
+- [分页查询](https://docs.pingcap.com/tidb/stable/dev-guide-paginate-results.md): 介绍 TiDB 的分页查询功能。
+- [切换 DM-worker 与上游 MySQL 实例的连接](https://docs.pingcap.com/tidb/stable/usage-scenario-master-slave-switch.md): 了解如何切换 DM-worker 与上游 MySQL 实例的连接。
+- [列裁剪](https://docs.pingcap.com/tidb/stable/column-pruning.md): 列裁剪是优化器在优化过程中删除不需要的列的基本思想。这样可以减少 I/O 资源占用并为后续优化带来便利。TiDB 会在逻辑优化阶段进行列裁剪，减少资源浪费。该扫描过程称作“列裁剪”，对应逻辑优化规则中的 columnPruner。如果要关闭这个规则，可以参照优化规则及表达式下推的黑名单中的关闭方法。
+- [创建 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-create.md): 了解创建 JSON 值的 JSON 函数。
+- [创建 TiDB Data Migration 数据源](https://docs.pingcap.com/tidb/stable/quick-start-create-source.md): 了解如何为 DM 创建数据源。
+- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-create-task.md): 了解 TiDB Data Migration 如何创建数据迁移任务。
+- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/quick-start-create-task.md): 了解在部署 DM 集群后，如何快速创建数据迁移任务。
+- [创建二级索引](https://docs.pingcap.com/tidb/stable/dev-guide-create-secondary-indexes.md): 创建二级索引的方法、规范及例子。
+- [创建数据库](https://docs.pingcap.com/tidb/stable/dev-guide-create-database.md): 创建数据库的方法、规范及例子。
+- [创建表](https://docs.pingcap.com/tidb/stable/dev-guide-create-table.md): 创建表的方法、规范及例子。
+- [删除数据](https://docs.pingcap.com/tidb/stable/dev-guide-delete-data.md): 删除数据、批量删除数据的方法、最佳实践及例子。
+- [加密和压缩函数](https://docs.pingcap.com/tidb/stable/encryption-and-compression-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分加密和压缩函数。
+- [升级与升级后常见问题](https://docs.pingcap.com/tidb/stable/upgrade-faq.md): TiDB 升级与升级后的常见问题与解决办法。
+- [升级集群监控组件](https://docs.pingcap.com/tidb/stable/upgrade-monitoring-services.md): 介绍如何升级 TiDB 集群监控组件 Prometheus、Grafana 和 Alertmanager。
+- [单区域双 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/two-data-centers-in-one-city-deployment.md): 了解单个区域两个可用区自适应同步模式部署方式。
+- [单区域多 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/multi-data-centers-in-one-city-deployment.md): 本文档介绍单个区域多个可用区部署 TiDB 的方案。
+- [单表查询](https://docs.pingcap.com/tidb/stable/dev-guide-get-data-from-single-table.md): 介绍 TiDB 中的单表查询功能。
+- [双区域多 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/three-data-centers-in-two-cities-deployment.md): 介绍在两个区域多个可用区部署 TiDB 的方式。
+- [只读存储节点最佳实践](https://docs.pingcap.com/tidb/stable/readonly-nodes.md): 介绍如何通过使用只读存储节点，达到物理隔离部分流量的目的。
+- [同步数据到 Kafka](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-kafka.md): 了解如何使用 TiCDC 将数据同步到 Kafka。
+- [同步数据到 MySQL 兼容数据库](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-mysql.md): 了解如何使用 TiCDC 将数据同步到 TiDB 或 MySQL
+- [同步数据到 Pulsar](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-pulsar.md): 了解如何使用 TiCDC 将数据同步到 Pulsar。
+- [同步数据到存储服务](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-cloud-storage.md): 了解如何使用 TiCDC 将数据同步到存储服务，以及数据变更记录的存储路径。
+- [向量函数和操作符](https://docs.pingcap.com/tidb/stable/vector-search-functions-and-operators.md): 本文介绍 TiDB 的向量相关函数和操作。
+- [向量搜索概述](https://docs.pingcap.com/tidb/stable/vector-search-overview.md): 介绍 TiDB 向量搜索功能。TiDB 向量搜索可以对文档、图像、音频和视频等多种数据类型进行语义搜索。
+- [向量搜索索引](https://docs.pingcap.com/tidb/stable/vector-search-index.md): 了解如何在 TiDB 中构建并使用向量搜索索引加速 K 近邻 (K-Nearest Neighbors, KNN) 查询。
+- [向量搜索限制](https://docs.pingcap.com/tidb/stable/vector-search-limitations.md): 了解 TiDB 向量搜索功能的限制。
+- [向量搜索集成概览](https://docs.pingcap.com/tidb/stable/vector-search-integration-overview.md): 介绍 TiDB 向量搜索支持的 AI 框架、嵌入模型和 ORM 库。
+- [向量数据类型](https://docs.pingcap.com/tidb/stable/vector-search-data-types.md): 本文介绍 TiDB 的向量数据类型。
+- [唯一序列号生成方案](https://docs.pingcap.com/tidb/stable/dev-guide-unique-serial-number-generation.md): 唯一序列号生成方案，为自行生成唯一 ID 的开发者提供帮助。
+- [在 AWS Lambda 函数中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-aws-lambda.md): 本文介绍如何在 AWS Lambda 函数中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
+- [在 Django ORM 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-django-orm.md): 了解如何在 Django ORM 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
+- [在 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/tidb-in-kubernetes.md): 你可以使用 TiDB Operator 在 Kubernetes 上部署 TiDB。TiDB Operator 是 Kubernetes 上的 TiDB 集群自动运维系统，提供部署、升级、扩缩容、备份恢复、配置变更的 TiDB 全生命周期管理。借助 TiDB Operator，TiDB 可以无缝运行在公有云或自托管的 Kubernetes 集群上。TiDB Operator 的文档目前独立于 TiDB 文档。要查看如何在 Kubernetes 上部署 TiDB 的详细步骤，请参阅对应版本的 TiDB Operator 文档。
+- [在 LangChain 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-langchain.md): 展示如何在 LangChain 中使用 TiDB 向量搜索
+- [在 LlamaIndex 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-llamaindex.md): 了解如何在 LlamaIndex 中使用 TiDB 向量搜索。
+- [在 Next.js 中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nextjs.md): 本文介绍了如何在 Next.js 中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
+- [在 peewee 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-peewee.md): 了解如何在 peewee 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
+- [在 SQLAlchemy 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-sqlalchemy.md): 了解如何在 SQLAlchemy 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
+- [在三数据中心下就近读取数据](https://docs.pingcap.com/tidb/stable/three-dc-local-read.md): 了解通过 Stale Read 功能在三数据中心下就近读取数据，减少跨数据中心请求。
+- [在公有云上部署 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/best-practices-on-public-cloud.md): 了解在公有云上部署 TiDB 的最佳实践。
+- [在线修改集群配置](https://docs.pingcap.com/tidb/stable/dynamic-config.md): 介绍在线修改集群配置的功能。
+- [在线应用 Hotfix 到 DM 集群](https://docs.pingcap.com/tidb/stable/tiup-component-dm-patch.md): 了解如何应用 hotfix 补丁包到 DM 集群。
+- [基于 Avro 的 TiCDC 行数据 Checksum 校验](https://docs.pingcap.com/tidb/stable/ticdc-avro-checksum-verification.md): 介绍 TiCDC 行数据 Checksum 校验的具体实现。
+- [基于 DM 同步场景下的数据校验](https://docs.pingcap.com/tidb/stable/dm-diff.md): 了解如何使用 TiDB DM 拉取指定配置进行数据校验。
+- [基于主备集群的容灾方案](https://docs.pingcap.com/tidb/stable/dr-secondary-cluster.md): 了解如何使用 TiCDC 构建主备集群进行容灾。
+- [基于备份与恢复的容灾方案](https://docs.pingcap.com/tidb/stable/dr-backup-restore.md): 了解如何基于 TiDB 的备份与恢复功能实现容灾。
+- [基于多副本的单集群容灾方案](https://docs.pingcap.com/tidb/stable/dr-multi-replica.md): 了解 TiDB 提供的基于多副本的单集群容灾方案。
+- [基于角色的访问控制](https://docs.pingcap.com/tidb/stable/role-based-access-control.md): TiDB 的基于角色的访问控制 (RBAC) 系统类似于 MySQL 8.0 的 RBAC 系统。用户可以创建、删除和授予角色权限，也可以将角色授予其他用户。角色需要在用户启用后才能生效。用户可以通过 `SHOW GRANTS` 查看角色权限，也可以设置默认启用角色。角色授权具有原子性，失败会回滚。除了角色授权外，还有用户管理和权限管理相关操作。
+- [备份与恢复 RawKV 数据](https://docs.pingcap.com/tidb/stable/rawkv-backup-and-restore.md): 了解如何使用 tikv-br 命令行工具备份和恢复 RawKV 数据。
+- [备份与恢复常见问题](https://docs.pingcap.com/tidb/stable/backup-and-restore-faq.md): 了解备份恢复相关的常见问题以及解决方法。
+- [备份存储](https://docs.pingcap.com/tidb/stable/backup-and-restore-storages.md): 了解 BR 支持的备份存储服务的 URI 格式、鉴权方案和使用方式。
+- [备份恢复监控告警](https://docs.pingcap.com/tidb/stable/br-monitoring-and-alert.md): 了解备份恢复的监控告警。
+- [备份自动调节](https://docs.pingcap.com/tidb/stable/br-auto-tune.md): 了解 TiDB 的自动调节备份功能，在集群资源占用率较高的情况下，BR 会自动限制备份使用的资源以求减少对集群的影响。
+- [外部存储服务的 URI 格式](https://docs.pingcap.com/tidb/stable/external-storage-uri.md): 介绍了外部存储服务 Amazon S3、GCS、和 Azure Blob Storage 的 URI 格式。
+- [外键约束](https://docs.pingcap.com/tidb/stable/foreign-key.md): TiDB 数据库中外键约束的使用概况。
+- [多表连接查询](https://docs.pingcap.com/tidb/stable/dev-guide-join-tables.md): 介绍 TiDB 中的多表连接查询功能。
+- [如何对 TiDB 进行 CH-benCHmark 测试](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-ch.md): 本文介绍如何对 TiDB 进行 CH-benCHmark 测试。
+- [如何对 TiDB 进行 TPC-C 测试](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-tpcc.md): 本文介绍了如何对 TiDB 进行 TPC-C 测试。TPC-C 是一个对 OLTP 系统进行测试的规范，使用商品销售模型对系统进行测试，包含五类事务：NewOrder、Payment、OrderStatus、Delivery、StockLevel。测试使用 tpmC 值衡量系统最大有效吞吐量，以 NewOrder Transaction 为准。使用 go-tpc 进行测试实现，通过 TiUP 命令下载测试程序。测试包括数据导入、运行测试和清理测试数据。
+- [如何用 Sysbench 测试 TiDB](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-sysbench.md): 使用 Sysbench 1.0 或更新版本测试 TiDB 性能。调整 TiDB 和 TiKV 的日志级别以提高性能。配置 RocksDB 的 block cache 以充分利用内存。调整 Sysbench 配置文件并导入数据。进行数据预热和统计信息收集。执行 Point select、Update index 和 Read-only 测试命令。解决可能出现的性能问题。
+- [如何过滤 binlog 事件](https://docs.pingcap.com/tidb/stable/filter-binlog-event.md): 介绍如何过滤 binlog 事件。
+- [如何通过 SQL 表达式过滤 DML](https://docs.pingcap.com/tidb/stable/filter-dml-event.md): 介绍如何通过 SQL 表达式过滤 DML 事件
+- [子查询](https://docs.pingcap.com/tidb/stable/dev-guide-use-subqueries.md): 介绍 TiDB 子查询功能。
+- [子查询相关的优化](https://docs.pingcap.com/tidb/stable/subquery-optimization.md): 了解子查询相关的优化。
+- [字符串函数](https://docs.pingcap.com/tidb/stable/string-functions.md): TiDB 支持 MySQL 8.0 中提供的大部分字符串函数以及 Oracle 21 中提供的部分函数。
+- [字符串类型](https://docs.pingcap.com/tidb/stable/data-type-string.md): TiDB 支持 MySQL 所有字符串类型，包括 CHAR、VARCHAR、BINARY、VARBINARY、BLOB、TEXT、ENUM 和 SET。CHAR 是定长字符串，长度固定为创建表时声明的长度。VARCHAR 是变长字符串，空间占用大小不得超过 65535 字节。TEXT 是文本串，最大列长为 65535 字节。TINYTEXT 最大列长度为 255。MEDIUMTEXT 最大列长度为 16777215。LONGTEXT 最大列长度为 4294967295。BINARY 存储二进制字符串。VARBINARY 存储二进制字符串。BLOB 是二进制大文件，最大列长度为 65535 字节。TINYBLOB 最大列长度为 255。MEDIUMBLOB 最大列长度为 16777215。LONGBLOB 最大列长度为 4294967295。ENUM 是枚举类型，值必须从固定集合中选取。SET 是集合类型，包含零个或多个值的字符串。
+- [字符集和排序规则](https://docs.pingcap.com/tidb/stable/character-set-and-collation.md): TiDB 支持的字符集包括 ascii、binary、gbk、latin1、utf8 和 utf8mb4。排序规则包括 ascii_bin、binary、gbk_bin、gbk_chinese_ci、latin1_bin、utf8_bin、utf8_general_ci、utf8_unicode_ci、utf8mb4_0900_ai_ci、utf8mb4_0900_bin、utf8mb4_bin、utf8mb4_general_ci 和 utf8mb4_unicode_ci。TiDB 强烈建议使用 utf8mb4 字符集，因为它支持更多字符。在 TiDB 中，默认的排序规则受到客户端的连接排序规则设置的影响。如果客户端使用 utf8mb4_0900_ai_ci 作为连接排序规则，TiDB 将遵循客户端的配置。TiDB 还支持新的排序规则框架，用于在语义上支持不同的排序规则。
+- [字面值](https://docs.pingcap.com/tidb/stable/literal-values.md): 本文介绍了 TiDB SQL 语句的字面值。
+- [定位消耗系统资源多的查询](https://docs.pingcap.com/tidb/stable/identify-expensive-queries.md): TiDB 会将执行时间超过 tidb_expensive_query_time_threshold 限制（默认值为 60s），或使用内存超过 tidb_mem_quota_query 限制（默认值为 1 GB）的语句输出到 tidb-server 日志文件中，用于定位消耗系统资源多的查询语句。expensive query 日志和慢查询日志的区别在于，expensive query 日志可以将正在执行的语句的相关信息打印出来。当一条语句在执行过程中达到资源使用阈值时，TiDB 会即时将这条语句的相关信息写入日志。
+- [对象命名规范](https://docs.pingcap.com/tidb/stable/dev-guide-object-naming-guidelines.md): 介绍 TiDB 中的对象命名规范。
+- [将 Grafana 监控数据导出成快照](https://docs.pingcap.com/tidb/stable/exporting-grafana-snapshots.md): 了解如何将 Grafana 监控数据导出为快照以及如何将快照文件可视化。
+- [已知的第三方工具兼容问题](https://docs.pingcap.com/tidb/stable/dev-guide-third-party-tools-compatibility.md): 介绍在测试中发现的 TiDB 与第三方工具的兼容性问题。
+- [常规统计信息](https://docs.pingcap.com/tidb/stable/statistics.md): 介绍 TiDB 中常规统计信息的收集和使用。
+- [平滑升级 TiDB](https://docs.pingcap.com/tidb/stable/smooth-upgrade-tidb.md): 本文介绍支持无需手动取消 DDL 的平滑升级集群功能。
+- [序列函数](https://docs.pingcap.com/tidb/stable/sequence-functions.md): 了解 TiDB 中的序列函数。
+- [延迟的拆解分析](https://docs.pingcap.com/tidb/stable/latency-breakdown.md): 详细介绍 TiDB 运行各阶段中时间消耗带来的延迟，以及如何在真实场景中分析延迟。
+- [开发 Java 应用使用 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/java-app-best-practices.md): 本文介绍了开发 Java 应用程序使用 TiDB 的常见问题与解决办法。TiDB 是高度兼容 MySQL 协议的数据库，基于 MySQL 开发的 Java 应用的最佳实践也多适用于 TiDB。
+- [开发者手册概览](https://docs.pingcap.com/tidb/stable/dev-guide-overview.md): 整体叙述了开发者手册，罗列了开发者手册的大致脉络。
+- [性能优化概述](https://docs.pingcap.com/tidb/stable/performance-tuning-overview.md): 本文介绍性能优化的基本概念，比如用户响应时间、吞吐和数据库时间，以及性能优化的通用流程。
+- [性能调优最佳实践](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql-best-practices.md): 介绍使用 TiDB 的性能调优最佳实践。
+- [恢复 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-resume-task.md): 了解 TiDB Data Migration 如何恢复数据迁移任务。
+- [悲观模式下分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge-pessimistic.md): 介绍 DM 提供的悲观模式（默认模式）下分库分表的合并迁移功能。
+- [慢查询日志](https://docs.pingcap.com/tidb/stable/identify-slow-queries.md): TiDB 会将执行时间超过 300 毫秒的语句输出到慢查询日志中，用于帮助用户定位慢查询语句。可以通过修改系统变量来启用或禁用慢查询日志。日志示例包括执行时间、用户信息、执行计划等字段。用户可通过查询 SLOW_QUERY 表来查询慢查询日志中的内容。还可以使用 pt-query-digest 工具分析 TiDB 慢日志。ADMIN SHOW SLOW 命令可以显示最近的慢查询记录或最慢的查询记录。
+- [手动处理 Sharding DDL Lock](https://docs.pingcap.com/tidb/stable/manually-handling-sharding-ddl-locks.md): DM 使用 sharding DDL lock 来确保分库分表的 DDL 操作可以正确执行。在异常情况下，需要手动处理异常的 DDL lock。使用 shard-ddl-lock 命令查看 DDL lock 信息，使用 shard-ddl-lock unlock 命令请求 DM-master 解除指定的 DDL lock。支持处理部分 MySQL source 被移除和 unlock 过程中部分 DM-worker 异常停止或网络中断的情况。
+- [执行计划管理 (SPM)](https://docs.pingcap.com/tidb/stable/sql-plan-management.md): 介绍 TiDB 的执行计划管理 (SQL Plan Management) 功能。
+- [扩展统计信息](https://docs.pingcap.com/tidb/stable/extended-statistics.md): 了解如何使用扩展统计信息指导优化器。
+- [批量建表](https://docs.pingcap.com/tidb/stable/br-batch-create-table.md): 了解如何使用批量建表功能。在恢复备份数据时，可以通过批量建表功能加快数据的恢复速度。
+- [控制执行计划](https://docs.pingcap.com/tidb/stable/control-execution-plan.md): 本章节介绍了控制执行计划的方法，包括使用提示指导执行计划、执行计划管理、优化规则及表达式下推的黑名单。此外，还介绍了一些系统变量对执行计划的影响，以及引入的特殊变量 `tidb_opt_fix_control`，用于更细粒度地控制优化器的行为。
+- [控制流程函数](https://docs.pingcap.com/tidb/stable/control-flow-functions.md): TiDB 支持 MySQL 8.0 中的控制流程函数，包括 CASE、IF()、IFNULL() 和 NULLIF()。这些函数可以用于构建 if/else 语句和处理 NULL 值。
+- [提升 TiDB 建表性能](https://docs.pingcap.com/tidb/stable/accelerated-table-creation.md): 介绍 TiDB 加速建表中的概念、原理、实现和影响。
+- [提高 TiDB Dashboard 安全性](https://docs.pingcap.com/tidb/stable/dashboard-ops-security.md): TiDB Dashboard 需要提高安全性。建议为 `root` 用户设置强密码或禁用 `root` 账户，并为 TiDB Dashboard 创建最小权限用户。使用防火墙阻止不可信访问，配置反向代理仅代理 TiDB Dashboard，并为反向代理开启 TLS。其他建议的安全措施包括为组件间通信和客户端服务端间通信开启加密传输。
+- [插入数据](https://docs.pingcap.com/tidb/stable/dev-guide-insert-data.md): 插入数据、批量导入数据的方法、最佳实践及例子。
+- [搜索 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-search.md): 了解搜索 JSON 值的 JSON 函数。
+- [搭建双集群主从复制](https://docs.pingcap.com/tidb/stable/replicate-between-primary-and-secondary-clusters.md): 了解如何配置一个 TiDB 集群以及该集群的 TiDB 或 MySQL 从集群，并将增量数据实时从主集群同步到从集群，
+- [搭建私有镜像](https://docs.pingcap.com/tidb/stable/tiup-mirror.md): TiUP 提供了构建私有镜像的方案，使用 mirror 指令来实现，可用于离线部署。执行 `tiup mirror clone` 命令，可构建本地地镜像。克隆完成后，可以通过 SCP、NFS、HTTP 或 HTTPS 共享仓库。使用 `TIUP_MIRRORS` 环境变量来使用镜像。重新运行 `tiup mirror clone` 命令会创建新的 manifest，并下载可用的最新版本的组件。可以创建自定义仓库，并使用自己构建的 TiDB 组件。
+- [操作符](https://docs.pingcap.com/tidb/stable/operators.md): 操作符是用于在 MySQL 中执行各种操作的关键元素。它们包括逻辑操作符（如 AND、OR、NOT、XOR）、赋值操作符（如 =、:=）、比较操作符（如 =、<、>、LIKE、BETWEEN）、以及其他操作符（如 +、-、*、/）。操作符具有不同的优先级，可以用于执行各种复杂的操作。需要注意的是，MySQL 不支持 ILIKE 操作符。
+- [操作系统性能参数调优](https://docs.pingcap.com/tidb/stable/tune-operating-system.md): 了解如何进行 CentOS 7 系统的性能调优。
+- [支持资源](https://docs.pingcap.com/tidb/stable/support.md): 在使用 TiDB 时遇到问题，如何获取支持。
+- [数值函数与操作符](https://docs.pingcap.com/tidb/stable/numeric-functions-and-operators.md): TiDB 支持 MySQL 8.0 中的所有数值函数和操作符。
+- [数值类型](https://docs.pingcap.com/tidb/stable/data-type-numeric.md): TiDB 支持 MySQL 的所有数值类型，包括整数类型、浮点类型和定点类型。整数类型包括 BIT、BOOLEAN、TINYINT、SMALLINT、MEDIUMINT、INTEGER 和 BIGINT，存储空间和取值范围各不相同。浮点类型包括 FLOAT 和 DOUBLE，存储空间分别为 4 和 8 字节。定点类型包括 DECIMAL 和 NUMERIC，可设置小数位数和小数点后位数。建议使用 DECIMAL 类型存储精确值。
+- [数据批量处理](https://docs.pingcap.com/tidb/stable/batch-processing.md): 介绍了 TiDB 为数据批量处理场景提供的功能，包括 Pipelined DML、非事务性 DML、IMPORT INTO 语句以及已被废弃的 batch-dml。
+- [数据类型概述](https://docs.pingcap.com/tidb/stable/data-type-overview.md): TiDB 支持除了空间类型（SPATIAL）之外的所有 MySQL 数据类型，包括数值型类型、字符串类型、时间和日期类型、JSON 类型。数据类型定义一般为 T(M[, D])，其中 T 表示具体的类型，M 在整数类型中表示最大显示长度，在浮点数或者定点数中表示精度，在字符类型中表示最大长度，D 表示浮点数、定点数的小数位长度，fsp 在时间和日期类型里的 TIME、DATETIME 以及 TIMESTAMP 中表示秒的精度，其取值范围是 0 到 6，值为 0 表示没有小数部分，如果省略，则默认精度为 0。
+- [数据类型的默认值](https://docs.pingcap.com/tidb/stable/data-type-default-values.md): 数据类型的默认值描述了列的默认值设置规则。默认值必须是常量，对于时间类型可以使用特定函数。从 v8.0.0 开始，BLOB、TEXT 和 JSON 可以设置表达式默认值。如果列没有设置 DEFAULT，TiDB 会根据规则添加隐式默认值。对于 NOT NULL 列，根据 SQL_MODE 进行不同行为。表达式默认值是实验特性，不建议在生产环境中使用。MySQL 8.0.13 开始支持在 DEFAULT 子句中指定表达式为默认值。TiDB 支持为 BLOB、TEXT 和 JSON 数据类型分配默认值，但仅支持通过表达式来设置。
+- [数据索引一致性错误](https://docs.pingcap.com/tidb/stable/troubleshoot-data-inconsistency-errors.md): TiDB 在执行事务或执行 ADMIN CHECK 命令时会检查数据索引的一致性。如果发现不一致，会报错并记录相关错误日志。报错处理可通过改写 SQL 或关闭错误检查来绕过。对于特定错误代码，可通过设置 @@tidb_enable_mutation_checker=0 或 @@tidb_txn_assertion_level=OFF 来跳过检查。需注意关闭开关会关闭所有 SQL 语句的对应检查。
+- [数据迁移工具概览](https://docs.pingcap.com/tidb/stable/migration-tools.md): 介绍 TiDB 的数据迁移工具。
+- [数据迁移概述](https://docs.pingcap.com/tidb/stable/migration-overview.md): 了解各种数据迁移场景和对应的数据迁移方案。
+- [数据集成概述](https://docs.pingcap.com/tidb/stable/integration-overview.md): 了解使用 TiCDC 进行数据集成的具体场景。
+- [断点备份](https://docs.pingcap.com/tidb/stable/br-checkpoint-backup.md): 了解断点备份功能，包括它的使用场景、实现原理以及使用方法。
+- [断点恢复](https://docs.pingcap.com/tidb/stable/br-checkpoint-restore.md): 了解断点恢复功能，包括它的使用场景、实现原理以及使用方法。
+- [日常巡检](https://docs.pingcap.com/tidb/stable/daily-check.md): 介绍 TiDB 集群需要常关注的性能指标。
+- [日志脱敏](https://docs.pingcap.com/tidb/stable/log-redaction.md): 了解 TiDB 各组件中的日志脱敏。
+- [日期和时间函数](https://docs.pingcap.com/tidb/stable/date-and-time-functions.md): TiDB 支持 MySQL 8.0 中的所有日期和时间函数。
+- [日期和时间类型](https://docs.pingcap.com/tidb/stable/data-type-date-and-time.md): TiDB 支持 MySQL 的所有日期和时间类型，包括 DATE、TIME、DATETIME、TIMESTAMP 和 YEAR。每种类型都有有效值范围，值为 0 表示无效值。TIMESTAMP 和 DATETIME 类型能自动生成新的时间值。关于日期和时间值类型，需要注意日期部分必须是“年 - 月 - 日”的格式，如果日期的年份部分是 2 位数，TiDB 会根据具体规则进行转换。不同类型的零值如下表所示：DATE:0000-00-00, TIME:00:00:00, DATETIME:0000-00-00 00:00:00, TIMESTAMP:0000-00-00 00:00:00, YEAR:0000。如果 SQL 模式允许使用无效的 DATE、DATETIME、TIMESTAMP 值，无效值会自动转换为相应的零值。
+- [时区支持](https://docs.pingcap.com/tidb/stable/configure-time-zone.md): TiDB 的时区设置由 `time_zone` 系统变量控制，可以在会话级别或全局级别进行设置。`TIMESTAMP` 数据类型的的显示值受时区设置影响，但 `DATETIME`、`DATE` 或 `TIME` 数据类型不受影响。在数据迁移时，需要特别注意主库和从库的时区设置是否一致。
+- [暂停 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-pause-task.md): 了解 TiDB Data Migration 如何暂停数据迁移任务。
+- [更新数据](https://docs.pingcap.com/tidb/stable/dev-guide-update-data.md): 更新数据、批量更新数据的方法、最佳实践及例子。
+- [最小拓扑架构](https://docs.pingcap.com/tidb/stable/minimal-deployment-topology.md): 介绍 TiDB 集群的最小拓扑。
+- [服务器状态变量](https://docs.pingcap.com/tidb/stable/status-variables.md): 使用状态变量查看系统和会话状态。
+- [本地快速部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/tiup-playground.md): TiDB 集群是分布式系统，由多个组件构成。想要快速体验 TiDB，可以使用 TiUP 中的 playground 组件快速搭建本地测试环境。通过命令行参数可以设置各组件的数量和配置，也可以启动多个组件实例。使用 `tiup client` 可以快速连接到本地启动的 TiDB 集群。还可以查看已启动集群的信息，扩容或缩容集群。
+- [术语表](https://docs.pingcap.com/tidb/stable/glossary.md): 了解 TiDB 相关术语。
+- [权限管理](https://docs.pingcap.com/tidb/stable/privilege-management.md): TiDB 支持 MySQL 5.7 和 MySQL 8.0 的权限管理系统。权限相关操作包括授予权限、收回权限、查看用户权限和动态权限。权限系统的实现包括授权表和连接验证。权限生效时机是在 TiDB 启动时加载到内存，并且可以手动刷新。
+- [构建 TiFlash 副本](https://docs.pingcap.com/tidb/stable/create-tiflash-replicas.md): 了解如何构建 TiFlash 副本。
+- [概览](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql-overview.md): 介绍 TiDB 的 SQL 性能调优概览。
+- [概述](https://docs.pingcap.com/tidb/stable/dev-guide-schema-design-overview.md): TiDB 数据库模式设计的概述。
+- [注释语法](https://docs.pingcap.com/tidb/stable/comment-syntax.md): 本文介绍 TiDB 支持的注释语法。
+- [海量 Region 集群调优最佳实践](https://docs.pingcap.com/tidb/stable/massive-regions-best-practices.md): 了解海量 Region 导致性能问题的原因和优化方法。
+- [混合部署拓扑](https://docs.pingcap.com/tidb/stable/hybrid-deployment-topology.md): 介绍混合部署 TiDB 集群的拓扑结构。
+- [物理优化](https://docs.pingcap.com/tidb/stable/sql-physical-optimization.md): 物理优化是基于代价的优化，为逻辑执行计划制定物理执行计划。优化器根据数据统计信息选择时间复杂度、资源消耗和物理属性最小的物理执行计划。TiDB 执行计划文档介绍了索引选择、统计信息、错误索引解决方案、Distinct 优化和代价模型。
+- [物理导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-physical-import-mode.md): 了解 TiDB Lightning 的物理导入模式。
+- [理解 TiKV 中的 Stale Read 和 safe-ts](https://docs.pingcap.com/tidb/stable/troubleshoot-stale-read.md): TiKV 中的 Stale Read 依赖于 safe-ts，保证读取历史数据版本的安全性。safe-ts 由每个 Region 中的 peer 维护，resolved-ts 则由 Region leader 维护。诊断 Stale Read 问题可通过 Grafana、tikv-ctl 和日志。常见原因包括事务提交时间过长、事务存在时间过长以及 CheckLeader 信息推送延迟。处理慢事务提交可通过识别锁所属的事务和检查应用程序逻辑。处理长事务可通过识别事务、检查应用程序逻辑和处理慢查询。解决 CheckLeader 问题可通过检查网络和监控面板指标。
+- [生成列](https://docs.pingcap.com/tidb/stable/generated-columns.md): 生成列是由列定义中的表达式计算得到的值。它包括存储生成列和虚拟生成列，存储生成列会将计算得到的值存储起来，而虚拟生成列不会存储其值。生成列可以用于从 JSON 数据类型中解出数据，并为该数据建立索引。在 INSERT 和 UPDATE 语句中，会检查生成列计算得到的值是否满足生成列的定义。生成列的局限性包括不能增加存储生成列，不能转换存储生成列为普通列，不能修改存储生成列的生成列表达式，以及不支持所有的 JSON 函数。
+- [生成自签名证书](https://docs.pingcap.com/tidb/stable/generate-self-signed-certificates.md): 本文介绍了使用 openssl 生成自签名证书的示例。用户可以根据需要生成符合要求的证书和密钥。首先安装 OpenSSL，然后生成 CA 证书和各个组件的证书，最后为客户端签发证书。证书的作用是为各个组件和客户端验证身份。
+- [用 EXPLAIN 查看 JOIN 查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-joins.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看 MPP 模式查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-mpp.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看分区查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-partitions.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看子查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-subqueries.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看带视图的 SQL 执行计划](https://docs.pingcap.com/tidb/stable/explain-views.md): 了解 TiDB 中视图相关语句的执行计划。
+- [用 EXPLAIN 查看索引合并的 SQL 执行计划](https://docs.pingcap.com/tidb/stable/explain-index-merge.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看索引查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-indexes.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看聚合查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-aggregation.md): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用户自定义变量](https://docs.pingcap.com/tidb/stable/user-defined-variables.md): 本文介绍 TiDB 的用户自定义变量。
+- [窗口函数](https://docs.pingcap.com/tidb/stable/window-functions.md): TiDB 中的窗口函数与 MySQL 8.0 基本一致。可以将 `tidb_enable_window_function` 设置为 `0` 来解决升级后无法解析语法的问题。TiDB 支持除 `GROUP_CONCAT()` 和 `APPROX_PERCENTILE()` 以外的所有 `GROUP BY` 聚合函数。其他支持的窗口函数包括 `CUME_DIST()`、`DENSE_RANK()`、`FIRST_VALUE()`、`LAG()`、`LAST_VALUE()`、`LEAD()`、`NTH_VALUE()`、`NTILE()`、`PERCENT_RANK()`、`RANK()` 和 `ROW_NUMBER()`。这些函数可以下推到 TiFlash。
+- [管理 Changefeed](https://docs.pingcap.com/tidb/stable/ticdc-manage-changefeed.md): 了解 Changefeed 相关的各种管理手段。
+- [管理 TiDB Data Migration 上游数据源](https://docs.pingcap.com/tidb/stable/dm-manage-source.md): 了解如何管理上游 MySQL 实例。
+- [管理 TiDB Data Migration 迁移表的表结构](https://docs.pingcap.com/tidb/stable/dm-manage-schema.md): 了解如何管理待迁移表在 DM 内部的表结构。
+- [管理资源消耗超出预期的查询 (Runaway Queries)](https://docs.pingcap.com/tidb/stable/tidb-resource-control-runaway-queries.md): 介绍如何通过资源管控能力来实现对资源消耗超出预期的语句 (Runaway Queries) 进行控制和降级。
+- [精度数学](https://docs.pingcap.com/tidb/stable/precision-math.md): TiDB 中的精确数值运算与 MySQL 基本一致。精确数值运算包括整型和 DECIMAL 类型，以及精确值数字字面量。DECIMAL 数据类型是定点数类型，其运算是精确计算。在表达式计算中，TiDB 会尽可能不做任何修改的使用每个输入的数值。数值修约时，`round()` 函数将使用四舍五入的规则。向 DECIMAL 或整数类型列插入数据时，round 的规则将采用 round half away from zero 的方式。
+- [系统变量](https://docs.pingcap.com/tidb/stable/system-variables.md): 使用 TiDB 系统变量来优化性能或修改运行行为。
+- [系统变量索引](https://docs.pingcap.com/tidb/stable/system-variable-reference.md): 查看 TiDB 所有的系统变量，以及引用这些变量的文档。
+- [索引推荐 (Index Advisor)](https://docs.pingcap.com/tidb/stable/index-advisor.md): 了解如何使用 TiDB 索引推荐 (Index Advisor) 功能优化查询性能。
+- [索引的最佳实践](https://docs.pingcap.com/tidb/stable/dev-guide-index-best-practice.md): 介绍 TiDB 中索引的最佳实践。
+- [索引的选择](https://docs.pingcap.com/tidb/stable/choose-index.md): 介绍 TiDB 如何选择索引去读入数据，以及相关的一些控制索引选择的方式。
+- [约束](https://docs.pingcap.com/tidb/stable/constraints.md): TiDB 支持的约束与 MySQL 基本相同，包括非空约束和 CHECK 约束。非空约束规则与 MySQL 相同，而 CHECK 约束需要在 tidb_enable_check_constraint 设置为 ON 后才能开启。可以通过 CREATE TABLE 或 ALTER TABLE 语句添加 CHECK 约束。唯一约束和主键约束也与 MySQL 相似，但 TiDB 目前仅支持对 NONCLUSTERED 的主键进行添加和删除操作。外键约束从 v6.6.0 开始支持，可以使用 CREATE TABLE 和 ALTER TABLE 命令来添加和删除外键。
+- [结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-jinaai-embedding.md): 了解如何结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索，以存储向量嵌入信息并执行语义搜索。
+- [结果集不稳定](https://docs.pingcap.com/tidb/stable/dev-guide-unstable-result-set.md): 结果集不稳定错误的处理办法。
+- [缓存表](https://docs.pingcap.com/tidb/stable/cached-tables.md): 了解 TiDB 中的缓存表功能，用于很少被修改的热点小表，提升读性能。
+- [聚合 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-aggregate.md): 了解聚合 JSON 值的 JSON 函数。
+- [聚簇索引](https://docs.pingcap.com/tidb/stable/clustered-indexes.md): 本文档介绍了聚簇索引的概念、使用场景、使用方法、限制和兼容性。
+- [自定义监控组件的配置](https://docs.pingcap.com/tidb/stable/customized-montior-in-tiup-environment.md): 了解如何自定义 TiUP 管理的监控组件的配置。
+- [表属性](https://docs.pingcap.com/tidb/stable/table-attributes.md): 介绍 TiDB 的 `ATTRIBUTES` 使用方法。
+- [表库过滤](https://docs.pingcap.com/tidb/stable/table-filter.md): 在 TiDB 数据迁移工具中使用表库过滤功能。
+- [表达式求值的类型转换](https://docs.pingcap.com/tidb/stable/type-conversion-in-expression-evaluation.md): TiDB 中的表达式求值类型转换与 MySQL 基本一致。详情请参见 MySQL 表达式求值类型转换文档。
+- [表达式语法](https://docs.pingcap.com/tidb/stable/expression-syntax.md): 本文列出 TiDB 的表达式语法。
+- [视图](https://docs.pingcap.com/tidb/stable/dev-guide-use-views.md): 介绍 TiDB 中的视图功能。
+- [视图](https://docs.pingcap.com/tidb/stable/views.md): TiDB 支持视图，视图是虚拟表，结构由创建时的 SELECT 语句定义。使用视图可保证数据安全，简化复杂查询。查询视图类似查询表，TiDB 执行查询时会展开视图。可通过 SHOW CREATE TABLE 或 SHOW CREATE VIEW 查看视图创建语句及相关信息。也可查询 INFORMATION_SCHEMA.VIEWS 表或访问 HTTP API 获取视图元信息。视图有局限性，不支持物化视图，且为只读视图，不支持写入操作。已创建的视图仅支持 DROP 操作。
+- [访问 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-access.md): TiDB Dashboard 可通过浏览器访问，支持多 PD 实例访问。浏览器兼容性包括 Chrome、Firefox 和 Edge。登录界面可使用 root 用户或自定义 SQL 用户登录。支持简体中文和英文语言切换。可在用户页面登出当前用户。
+- [读写延迟增加](https://docs.pingcap.com/tidb/stable/troubleshoot-cpu-issues.md): 介绍读写延时增加、抖动时的排查思路，可能的原因和解决方法。
+- [谓词下推](https://docs.pingcap.com/tidb/stable/predicate-push-down.md): TiDB 逻辑优化规则中的谓词下推旨在尽早完成数据过滤，减少数据传输或计算的开销。谓词下推适用于将过滤表达式计算下推到数据源，如示例 1、2、3。但对于存储层不支持的谓词、外连接中的谓词和包含用户变量的谓词则不能下推。
+- [资源管控 (Resource Control) 监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-resource-control-dashboard.md): 了解资源管控 (Resource Control) 的 Grafana Dashboard 中所展示的关键指标。
+- [跨数据中心部署拓扑](https://docs.pingcap.com/tidb/stable/geo-distributed-deployment-topology.md): 介绍跨数据中心部署 TiDB 集群的拓扑结构。
+- [迁移使用 GH-ost/PT-osc 的源数据库](https://docs.pingcap.com/tidb/stable/feature-online-ddl.md): 使用 GH-ost/PT-osc 进行在线 DDL 工具执行 DDL 时，会产生锁表操作，阻塞数据库读写。为降低影响，可选择在线 DDL 工具 gh-ost 和 pt-osc。在 DM 迁移 MySQL 到 TiDB 时，可开启 `online-ddl` 配置，实现 DM 工具与 gh-ost 或 pt-osc 的协同。 DM 与 online DDL 工具协作细节包括 gh-ost 和 pt-osc 的实现过程，以及自定义规则配置。
+- [迁移升级 TiDB 集群](https://docs.pingcap.com/tidb/stable/tidb-upgrade-migration-guide.md): 本文介绍如何使用 BR 全量备份恢复与 TiCDC 增量数据同步实现 TiDB 集群的迁移升级。
+- [迁移常见问题](https://docs.pingcap.com/tidb/stable/migration-tidb-faq.md): 介绍 TiDB 迁移中的常见问题。
+- [返回 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-return.md): 了解返回 JSON 值的 JSON 函数。
+- [连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-connect-to-tidb.md): 介绍连接到 TiDB 的方法。
+- [连接池与连接参数](https://docs.pingcap.com/tidb/stable/dev-guide-connection-parameters.md): 针对开发者的 TiDB 连接池与连接参数的说明。
+- [选择驱动或 ORM 框架](https://docs.pingcap.com/tidb/stable/dev-guide-choose-driver-or-orm.md): 选择驱动或 ORM 框架连接 TiDB。
+- [通过 SQL 表达式过滤 DML](https://docs.pingcap.com/tidb/stable/feature-expression-filter.md): 增量数据迁移时可通过 SQL 表达式过滤 binlog event，例如不向下游迁移 `DELETE` 事件。从 v2.0.5 起，DM 支持使用 `binlog value filter` 过滤迁移数据。在 `ROW` 格式的 binlog 中，可以基于列的值配置 SQL 表达式。如果表达式结果为 `TRUE`，DM 就不会向下游迁移该条行变更。具体操作步骤和实现细节，请参考如何通过 SQL 表达式过滤 DML。
+- [通过 TiUP 部署 DM 集群的拓扑文件配置](https://docs.pingcap.com/tidb/stable/tiup-dm-topology-reference.md): TiUP 部署 DM 集群的拓扑文件配置包括全局配置、组件配置、master 服务器配置、worker 服务器配置、监控服务器配置、Grafana 服务器配置和 Alertmanager 服务器配置。每个配置包含不同字段，如部署目录、数据目录、日志目录等。部署完成后部分字段不能再修改。
+- [通过 TiUP 部署 TiDB 集群的拓扑文件配置](https://docs.pingcap.com/tidb/stable/tiup-cluster-topology-reference.md): 介绍通过 TiUP 部署或扩容 TiDB 集群时提供的拓扑文件配置和示例。
+- [通过反向代理使用 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-ops-reverse-proxy.md): TiDB Dashboard 可通过反向代理安全提供给外部网络。首先获取实际地址，然后配置反向代理，最后修改路径前缀。详细步骤可参考官方文档。
+- [通过拓扑 label 进行副本调度](https://docs.pingcap.com/tidb/stable/schedule-replicas-by-topology-labels.md): TiDB v5.3.0 引入了通过拓扑 label 进行副本调度的功能。为了提升集群的高可用性和数据容灾能力，推荐让 TiKV 节点在物理层面上尽可能分散。通过设置 TiKV 和 TiFlash 的 labels，可以标识它们的地理位置。同时，需要配置 PD 的 location-labels 和 isolation-level 来使 PD 理解 TiKV 节点拓扑并加强拓扑隔离要求。PD 在副本调度时会保证同一份数据的不同副本尽可能分散，以提高集群容灾能力。
+- [通过系统变量 `tidb_external_ts` 读取历史数据](https://docs.pingcap.com/tidb/stable/tidb-external-ts.md): 了解如何通过系统变量 `tidb_external_ts` 读取历史数据。
+- [通过系统变量 `tidb_read_staleness` 读取历史数据](https://docs.pingcap.com/tidb/stable/tidb-read-staleness.md): 了解如何通过系统变量 `tidb_read_staleness` 读取历史数据。
+- [通过系统变量 tidb_snapshot 读取历史数据](https://docs.pingcap.com/tidb/stable/read-historical-data.md): 本文介绍了通过系统变量 `tidb_snapshot` 读取历史数据的操作流程和历史数据的保留策略。TiDB 实现了通过标准 SQL 接口读取历史数据功能，无需特殊的 client 或者 driver。当数据被更新、删除后，依然可以通过 SQL 接口将更新 / 删除前的数据读取出来。历史数据保留策略使用 MVCC 管理版本，超过一定时间的历史数据会被彻底删除，以减小空间占用以及避免历史版本过多引入的性能开销。
+- [逻辑优化](https://docs.pingcap.com/tidb/stable/sql-logical-optimization.md): 本章节介绍了 TiDB 查询计划的关键逻辑改写，包括子查询优化、列裁剪、关联子查询去关联、Max/Min 消除、谓词下推、分区裁剪、TopN 和 Limit 下推以及 Join 重排序。这些改写帮助 TiDB 生成最终的查询计划，提高查询效率。
+- [逻辑导入模式简介](https://docs.pingcap.com/tidb/stable/tidb-lightning-logical-import-mode.md): 了解 TiDB Lightning 的逻辑导入模式 (Logical Import Mode)。
+- [遥测](https://docs.pingcap.com/tidb/stable/telemetry.md): 介绍遥测的场景，如何禁用功能和查看遥测状态。
+- [避免隐式类型转换](https://docs.pingcap.com/tidb/stable/dev-guide-implicit-type-conversion.md): 介绍 TiDB 中隐式类型转换可能会带来的后果和避免方法。
+- [部署 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-ops-deploy.md): TiDB Dashboard 是内置于 TiDB 4.0 或更高版本的 PD 组件中的界面，无需额外部署。对于 TiDB v6.5.0 及 TiDB Operator v1.4.0 之后的版本，在 Kubernetes 上支持将 TiDB Dashboard 作为独立的 Pod 部署。部署标准 TiDB 集群的文档可参考快速试用 TiDB 集群、生产环境部署和 Kubernetes 环境部署。当集群中部署了多个 PD 实例时，仅有一个 PD 实例会提供 TiDB Dashboard 服务。可通过 TiUP 查看实际运行 TiDB Dashboard 服务的 PD 实例，并切换其他 PD 实例提供 TiDB Dashboard 服务。也可以禁用和重新启用 TiDB Dashboard。
+- [部署 TiDB Lightning](https://docs.pingcap.com/tidb/stable/deploy-tidb-lightning.md): 了解如何部署 TiDB Lightning，包括在线部署和离线部署。
+- [配置 TiDB Dashboard 使用 SSO 登录](https://docs.pingcap.com/tidb/stable/dashboard-session-sso.md): 了解如何配置 TiDB Dashboard 启用 SSO 登录。
+- [锁函数](https://docs.pingcap.com/tidb/stable/locking-functions.md): 了解 TiDB 中的用户级锁函数。
+- [错误码与故障诊断](https://docs.pingcap.com/tidb/stable/error-codes.md): TiDB 错误码包括 MySQL 兼容的错误码和 TiDB 特有的错误码。如果遇到错误码，请参考官方文档或社区获取支持。常见错误码包括内存使用超限、写入冲突、表数据损坏、事务过大、写入冲突等。另外，TiDB 还提供了故障诊断文档供参考。
+- [错误索引的解决方案](https://docs.pingcap.com/tidb/stable/wrong-index-solution.md): 了解如何处理错误索引问题。
+- [集合运算](https://docs.pingcap.com/tidb/stable/set-operators.md): 了解 TiDB 支持的集合运算。
+- [集群监控部署](https://docs.pingcap.com/tidb/stable/deploy-monitoring-services.md): 本文适用于手动部署 TiDB 监控报警系统的用户。假设 TiDB 的拓扑结构如下：Node1 主机 IP 为 192.168.199.113，服务包括 PD1、TiDB、node_export、Prometheus、Grafana；Node2 主机 IP 为 192.168.199.114，服务包括 PD2、node_export；Node3 主机 IP 为 192.168.199.115，服务包括 PD3、node_export；Node4 主机 IP 为 192.168.199.116，服务包括 TiKV1、node_export；Node5 主机 IP 为 192.168.199.117，服务包括 TiKV2、node_export；Node6 主机 IP 为 192.168.199.118，服务包括 TiKV3、node_export。具体部署步骤包括下载二进制包、启动 node_exporter 服务、启动 Prometheus 服务、启动 Grafana 服务、配置 Grafana 数据源和导入 Grafana 面板。可查看 TiDB Server、PD Server 和 TiKV Server 的监控信息。
+- [静态加密](https://docs.pingcap.com/tidb/stable/encryption-at-rest.md): 了解如何启用静态加密功能保护敏感数据。
+- [非 Prepare 语句执行计划缓存](https://docs.pingcap.com/tidb/stable/sql-non-prepared-plan-cache.md): 介绍 TiDB 中非 Prepare 语句执行计划缓存的原理、使用方法及示例。
+- [非事务 DML 语句](https://docs.pingcap.com/tidb/stable/non-transactional-dml.md): 以事务的原子性和隔离性为代价，将 DML 语句拆成多个语句依次执行，用以提升批量数据处理场景的稳定性和易用性。
+- [预处理语句](https://docs.pingcap.com/tidb/stable/dev-guide-prepared-statement.md): 介绍 TiDB 的预处理语句功能。
+- [验证 JSON 文档的函数](https://docs.pingcap.com/tidb/stable/json-functions-validate.md): 了解验证 JSON 文档的函数。
+- [验证集群运行状态](https://docs.pingcap.com/tidb/stable/post-installation-check.md): 介绍如何验证集群运行状态。
+- [高可用常见问题](https://docs.pingcap.com/tidb/stable/high-availability-faq.md): 介绍高可用相关的常见问题。
+- [高可靠常见问题](https://docs.pingcap.com/tidb/stable/high-reliability-faq.md): 介绍高可靠相关的常见问题。
 
 ## TiDB on Kubernetes 文档（使用 TiDB Operator 部署）
 
-- [TiDB on Kubernetes 文档](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/): 使用 PingCAP 提供的 TiDB Operator，你可以在公有云或自托管的 Kubernetes 集群上自动运维 TiDB 集群，实现 TiDB 在 Kubernetes 上的无缝运行。
+- [TiDB on Kubernetes 文档](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable.md): 使用 PingCAP 提供的 TiDB Operator，你可以在公有云或自托管的 Kubernetes 集群上自动运维 TiDB 集群，实现 TiDB 在 Kubernetes 上的无缝运行。
 - [API 文档](https://github.com/pingcap/tidb-operator/blob/v1.6.1/docs/api-references/docs.md)
-- [Kubernetes 上的 TiDB Binlog Drainer 配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-tidb-binlog-drainer/): 了解 Kubernetes 上的 TiDB Binlog Drainer 配置参数。
-- [Kubernetes 上的 TiDB 工具指南](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-toolkit/): 详细介绍 Kubernetes 上的 TiDB 相关的工具及其使用方法。
-- [Kubernetes 上的 TiDB 常见部署错误](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-failures/): 介绍 Kubernetes 上 TiDB 部署的常见错误以及处理办法。
-- [Kubernetes 上的 TiDB 集群常见异常](https://docs.pingcap.com/tidb-in-kubernetes/stable/exceptions/): 介绍 TiDB 集群运行过程中常见异常以及处理办法。
-- [Kubernetes 上的 TiDB 集群常见网络问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/network-issues/): 介绍 Kubernetes 上 TiDB 集群的常见网络问题以及诊断解决方案。
-- [Kubernetes 上的 TiDB 集群常见问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/faq/): 介绍 Kubernetes 上的 TiDB 集群常见问题以及解决方案。
-- [Kubernetes 上的 TiDB 集群故障自动转移](https://docs.pingcap.com/tidb-in-kubernetes/stable/use-auto-failover/): 介绍 Kubernetes 上的 TiDB 集群故障自动转移的功能。
-- [Kubernetes 上的 TiDB 集群环境需求](https://docs.pingcap.com/tidb-in-kubernetes/stable/prerequisites/): 介绍在 Kubernetes 上部署 TiDB 集群的软硬件环境需求。
-- [Kubernetes 上的 TiDB 集群管理常用使用技巧](https://docs.pingcap.com/tidb-in-kubernetes/stable/tips/): 介绍 Kubernetes 上 TiDB 集群管理常用使用技巧。
-- [Kubernetes 上的持久化存储类型配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-storage-class/): 介绍 Kubernetes 上的数据持久化存储类型配置。
-- [Kubernetes 上的集群初始化配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/initialize-a-cluster/): 介绍如何初始化配置 Kubernetes 上的 TiDB 集群。
-- [Kubernetes 的监控与告警](https://docs.pingcap.com/tidb-in-kubernetes/stable/monitor-kubernetes/): 介绍如何监控 Kubernetes。
-- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/tidb-in-kubernetes/stable/clinic-data-collection/): 详细说明 PingCAP Clinic 诊断服务在使用 Operator 部署的 TiDB 集群中能够采集的诊断数据类型、输出文件及采集参数。
-- [TiDB on Kubernetes Sysbench 性能测试](https://docs.pingcap.com/tidb-in-kubernetes/stable/benchmark-sysbench/): TiDB Operator GA 发布后，我们在 GKE 平台进行了全面的性能测试。测试结果显示，在 Host 网络模式下，TiDB 性能略优于 Pod 网络模式（约 7%）。此外，使用 Ubuntu 系统的 Host 网络模式下，TiDB 性能也略优于 COS 系统（约 9%）。在集群外访问时，使用 Load Balancer 会略损失性能（约 5%）。多可用区下节点之间的延迟增加，会对 TiDB 性能产生一定影响（30% ~ 6%）。计算型机型相对普通型机器带来了很大 QPS 提升（50% ~ 60%）。
-- [TiDB Operator 0.1.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.1.0/): TiDB Operator 0.1.0 was released on August 22, 2018. Notable changes include the ability to bootstrap multiple TiDB clusters, support for monitoring deployment and Helm charts, basic Network PV/Local PV support, safe scaling of the TiDB cluster, orderly cluster upgrades, and stopping the TiDB process without terminating the Pod. Additionally, cluster meta info can be synchronized to POD/PV/PVC labels, and basic unit tests & E2E tests are available. Tutorials for GKE and local DinD are also provided.
-- [TiDB Operator 0.2.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.2.0/): TiDB Operator 0.2.0 was released on September 11, 2018. Notable changes include experimental support for auto-failover, unification of Tiller and TiDB Operator managed resources labels, managing TiDB service via Tiller, adding toleration for TiDB cluster components, and refactoring upgrade functions as interface. Additionally, a script for easy setup of DinD environment was added, and code was linted and formatted in CI.
-- [TiDB Operator 0.2.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.2.1/): TiDB Operator 0.2.1 was released on September 20, 2018. This version includes bug fixes for retry on conflict logic, TiDB timezone configuration, failover, and repeated updating of pod and pd/tidb StatefulSet.
-- [TiDB Operator 0.3.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.3.0/): TiDB Operator 0.3.0 was released on October 12, 2018. Notable changes include the addition of full backup support, TiDB Binlog support, graceful upgrade feature, and the ability to persist monitor data.
-- [TiDB Operator 0.3.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.3.1/): TiDB Operator 0.3.1 was released on October 31, 2018. The release includes minor changes such as parameterizing the serviceAccount, bumping TiDB to v2.0.7, and allowing user-specified config files. Bug fixes include addressing issues with parallel upgrades, wrong parameters, and recovery after a failed upgrade.
-- [TiDB Operator 0.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.4.0/): TiDB Operator 0.4.0 was released on November 9, 2018. Notable changes include extending Kubernetes scheduler for TiDB data awareness, restoring backup data from GCS bucket, and setting password for TiDB when first deployed. Minor changes and bug fixes include updating roadmap, adding unit tests, E2E tests, adding TiDB failover limit, synchronizing PV reclaim policy early, using helm release name as instance label, and fixing local PV setup script.
-- [TiDB Operator 1.0 Beta.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.0/): TiDB Operator 1.0 Beta.0 was released on November 26, 2018. Notable changes include the introduction of basic chaos testing, improved unit test coverage, default log-level values for PD/TiKV/TiDB, and various bug fixes and enhancements. The release also includes a user guide and migration to Go 1.11 module.
-- [TiDB Operator 1.0 Beta.1 P1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p1/): TiDB Operator 1.0 Beta.1 P1 was released on January 7, 2019. The bug fixes include resolving scheduler policy issues for Kubernetes v1.10, v1.11, and v1.12. The documentation updates include a proposal to add multiple statefulsets support to TiDB Operator and an updated roadmap.
-- [TiDB Operator 1.0 Beta.1 P2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p2/): TiDB Operator 1.0 Beta.1 P2 was released on February 21, 2019. Notable changes include a new algorithm for scheduler HA predicate, addition of TiDB discovery service, serial scheduling, change in tolerations type to an array, direct start when there is a join file, addition of code coverage icon, omission of just the empty leaves in `values.yml`, backup to ceph object storage in charts, and addition of `ClusterIDLabelKey` label to TidbCluster.
-- [TiDB Operator 1.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1/): TiDB Operator 1.0 Beta.1 was released on December 27, 2018. The release includes bug fixes such as pd_control bug, orphan pod cleaner, scheduler configuration fix, Grafana configuration fix, and more. Minor improvements include adding Kubernetes 1.12 local DinD scripts, bumping default TiDB to v2.1.0, releasing tidb-operator/tidb-cluster charts, and adding connection timeout for TiDB password setter job. Other improvements involve separating ad-hoc backup and restore to another chart, adding compiler version info to tidb-operator binary, allowing specifying TiDB service LoadBalancer IP, and exposing TiKV cpu/memory related configuration to values.yaml.
-- [TiDB Operator 1.0 Beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.2/): TiDB Operator 1.0 Beta.2 has been released on May 10, 2019. The new version includes enhanced stability, improved ease of use, bug fixes, and other improvements. Some of the key changes include refactored e2e test, one-command deployment for AWS and Aliyun, and support for slow log of TiDB. Numerous bug fixes and detailed changes have also been made to improve the overall performance and user experience.
-- [TiDB Operator 1.0 Beta.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.3/): TiDB Operator 1.0 Beta.3 was released on June 6, 2019. The new version includes the removal of `nodeSelectorRequired` from values.yaml and the addition of stability cases, new features, documentation improvements, and bug fixes. Some notable new features include ConfigMap rollout management, stable scheduling for pods, and support for adding additional pod annotations. The default TiDB version has been upgraded to v3.0.0-rc.1, and various bug fixes and changes have been implemented.
-- [TiDB Operator 1.0 GA Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0-ga/): TiDB Operator 1.0.0 has been released on July 30, 2019. The new version requires action to be taken for configuration changes in `values.yaml`. Stability test cases have been added, along with improvements such as GKE SSD setup simplification and AWS Terraform script modularization. Bug fixes include sysbench installation and TiKV metrics monitoring. Detailed bug fixes and changes include upgrading TiDB monitor, specifying TiKV status address, and enabling nlb cross zone load balancing by default. Multiple TiDB clusters management is now supported in Alibaba Cloud. The default TiDB version has been upgraded to v3.0.1. The release also includes various other bug fixes and improvements.
-- [TiDB Operator 1.0 RC.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-rc.1/): TiDB Operator 1.0 RC.1 was released on July 12, 2019. The new version includes stability test cases, improvements such as increasing TiKV GC life time, and bug fixes like fixing unbound variables in the backup script and scheduled backup bugs. It also supports force upgrade when PD cluster is unavailable and adds Amazon S3 support for backup/restore features. Multiple clusters management in EKS and local SSD provision for COS on GKE are also included. The release notes contain detailed bug fixes and changes, including various pull requests for bug fixes and improvements.
-- [TiDB Operator 1.0.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.1/): TiDB Operator version 1.0.1 was released on September 17, 2019. The release includes important bug fixes and improvements. Users of version 1.0.0 or prior must upgrade to avoid potential service outage. The backup tool image has been updated to fix a serious bug. Other improvements include modularizing GCP Terraform, adding support for various configurations, and reducing e2e run time. Bug fixes address issues such as TiKV scale-in failure, orphan pods cleaner bugs, and incorrect condition judgment. The release also includes detailed bug fixes and changes.
-- [TiDB Operator 1.0.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.2/): TiDB Operator version 1.0.2 was released on November 1, 2019. The new version includes improvements such as suspending the ReplaceUnhealthy process for AWS TiKV auto-scaling-group, adding a new VM manager 'qm' in stability test, and setting default externalTrafficPolicy to 'Local' for TiDB service in AWS/GCP/Aliyun. Bug fixes include issues with tkctl version, create_tidb_cluster_release variable in AWS Terraform script, and compatibility issues with Kubernetes 1.16 and above versions. Other fixes and changes are also included in this release.
-- [TiDB Operator 1.0.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.3/): TiDB Operator version 1.0.3 was released on November 13, 2019. The new version requires an upgrade to TiDB v3.0.5 and adds timezone support for all charts. Existing TiDB clusters with customized timezones will trigger a rolling update. Improvements include timezone support and configuring resource requests and limits for all containers of the TiDB cluster. Bug fixes include upgrading default TiDB version to v3.0.5 and adding timezone support for all containers of the TiDB cluster.
-- [TiDB Operator 1.0.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.4/): TiDB Operator version 1.0.4 was released on November 23, 2019. The new version introduces HostNetwork support for better performance, podSecurityContext support, and new Helm charts for TiDB Lightning and TiDB Binlog. It also includes bug fixes and changes. Users of the v1.1.0.alpha branch are advised to upgrade to v1.0.4, as it includes all fixes from the alpha branch and introduces additional improvements.
-- [TiDB Operator 1.0.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.5/): TiDB Operator version 1.0.5 was released on December 11, 2019. The new features include fixing backup failure issue, recommending deployment of TiDB and Pump on the same node, fixing RBAC permission, and resolving e2e nil point dereference. No action is required for upgrading from v1.0.4.
-- [TiDB Operator 1.0.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.6/): TiDB Operator 1.0.6 was released on December 27, 2019. Users need to migrate configs from the old `values.yaml` to the new one to avoid monitor pod failures. The new release includes improvements in monitor, TiDB Scheduler, compatibility, TiKV Importer, E2E, and CI. Notable changes include enabling alert rule persistence, adding node & pod info in TiDB Grafana, refining scheduler error messages, fixing compatibility issues in Kubernetes v1.17, and adjusting the release CI script.
-- [TiDB Operator 1.0.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.7/): TiDB Operator 1.0.7 was released on June 16, 2020. Notable changes include fixing alert rules lost after rolling upgrade, upgrading local volume provisioner to 2.3.4, fixing operator failover config invalid, removing unnecessary duplicated docs, updating doc links and image in readme, emitting events when PD failover, fixing some broken urls, and removing some not very useful update events.
-- [TiDB Operator 1.1 Beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-beta.1/): 支持配置时区，备份到 S3，基础默认设置，增强型 StatefulSet 扩缩容，自定义资源初始化 TiDB 集群，优化配置结构，支持临时存储，发布 Terraform Aliyun ACK 版本，优化报错信息，支持 TLS 加密连接，支持动态扩展云存储 PV，支持自动生成证书，支持暂停备份计划，升级 TiDB 版本。
-- [TiDB Operator 1.1 Beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-beta.2/): 默认存储类和备份存储类已废弃，现在使用 Kubernetes 默认存储类。用户可设置备份和恢复的亲和性和容忍度。解决了 AdvancedStatefulSet 和 Admission Webhook 一起使用的问题。支持基于 CPU 平均负载的集群自动扩容。支持用户自定义证书。修复了一些问题并优化了日志。
-- [TiDB Operator 1.1 GA Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1-ga/): TiDB Operator 1.1 GA 发布日期 2020 年 5 月 28 日。将 TiDB Pod 的 readiness 探针从 HTTPGet 更改为 TCPSocket 4000 端口。这将触发 tidb-server 组件滚动升级。你可以在升级 TiDB Operator 之前将 spec.paused 设置为 true 以避免滚动升级，并在准备升级 tidb-server 时将其重新设置为 false。
-- [TiDB Operator 1.1 RC.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.1/): 此版本包括对 tidb-server 的配置选项的更新，备份和恢复规范的修改，以及对 TiDB 组件的一些修复和改进。还支持通过 Terraform 在 AWS 和 ACK 上部署 TiDB 集群，并添加了一些新的功能和文档。
-- [TiDB Operator 1.1 RC.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.2/): TiDB Operator 1.1 RC.2 was released on April 15, 2020. Action required includes changing TiDB pod readiness probe and setting spec.paused to true before upgrading. Notable changes include adding status field for TidbAutoScaler CR, emitting more events for TidbCluster and TidbClusterAutoScaler, and adding TLS support for TiKV metrics API. Other changes involve adding a switch to skip PD Dashboard TLS configuration, supporting TiFlash in TidbCluster CR, and fixing errors related to alertmanager in TidbMonitor.
-- [TiDB Operator 1.1 RC.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.3/): TiDB Operator 1.1 RC.3 was released on April 30, 2020. Notable changes include support for TiFlash metrics in TidbMonitor, fixing bugs related to failover pods and statefulsets, and adding new features like configuring Ingress in TidbMonitor and supporting failover for TiFlash. Other changes include updates to terraform scripts and adding new fields in TiKVConfig.
-- [TiDB Operator 1.1 RC.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.4/): TiDB Operator 1.1 RC.4 发布于 2020 年 5 月 15 日。每个组件可以使用单独的 TiDB 客户端证书。用户应该将 `Backup` 和 `Restore` CR 中的旧的 TLS 配置迁移到新的配置。
-- [TiDB Operator 1.1.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.1/): TiDB Operator 1.1.1 版本发布，重大变化包括添加 `additionalContainers` 和 `additionalVolumes` 字段，修复了多个问题，并更新了配置版本到 v4.0.1。
-- [TiDB Operator 1.1.10 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.10/): TiDB Operator 1.1.10 版本发布，包含兼容性改动、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性改动包括 `apiVersion` 更改，滚动升级改动导致 TidbMonitor Pod 删除重建。新功能包括灰度升级、TidbMonitor 支持 `remotewrite`、配置 init containers 等。优化提升包括自定义存储、增加 label 支持多集群监控等。Bug 修复包括备份或者恢复失败、Pod 在升级过程中不会进行迁移 leader 等问题。
-- [TiDB Operator 1.1.11 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.11/): TiDB Operator 1.1.11 版本发布，新增优化 LeaderElection 和自定义 Store 标签功能。优化 TiFlash 滚动更新机制，改进获取 region leader 数量方式。支持打印 RocksDB 和 Raft 日志到 stdout。
-- [TiDB Operator 1.1.12 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.12/): TiDB Operator 1.1.12 版本发布日期为 2021 年 4 月 15 日。新功能包括支持为备份和恢复 Job 设置自定义环境变量，支持备份恢复 CR 设置 affinity 和 tolerations，以及支持 tidb-operator chart 使用新的 service account。优化提升包括 TiDBInitializer 中增加重试机制，增加多 PVC 支持，以及优化 `PodsAreChanged` 函数。Bug 修复包括修复挂载多 PVC 时容量设置错误的问题，修复创建 `.spec.tidb` 为空并开启 TLS 的 TidbCluster 导致 tidb-controller-manager panic 的问题，以及修复 `UnjoinedMembers` 中 PVC 状态异常的问题。
-- [TiDB Operator 1.1.13 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.13/): TiDB Operator 1.1.13 版本发布，优化了 TiCDC 配置 TLS 证书、BR 工具镜像 tag、扩缩容 TiDB 过程中协调 PVC、备份日志中隐藏数据库密码。修复了部署异构集群时可能 panic 的问题和 TiDB 实例缩容后在 TiDB Dashboard 中仍然存在的问题。
-- [TiDB Operator 1.1.14 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.14/): TiDB Operator 1.1.14 版本发布日期为 2021 年 10 月 21 日。此版本修复了 `tidb-backup-manager` 和 `tidb-operator` 镜像中的安全漏洞。
-- [TiDB Operator 1.1.15 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.15/): TiDB Operator 1.1.15 发布日期为 2022 年 2 月 17 日。此版本修复了 TiDB Operator 计算 TiKV Region leader 数量时可能会造成 goroutine 泄露的问题。
-- [TiDB Operator 1.1.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.2/): TiDB Operator 1.1.2 版本修复了与 PD 4.0.2 不兼容的问题。需要将 TiDB Operator 升级到 v1.1.2 后再部署 TiDB 4.0.2 及更高版本。其他变更包括抓取监控指标和更新配置为 v4.0.2，修复缩容后 PD 成员可能仍然存在的错误，同步信息到 `TidbCluster` `Status` 字段，以及支持在 TiDB 参数中配置容器生命周期 hook 和 `terminationGracePeriodSeconds`。
-- [TiDB Operator 1.1.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.3/): TiDB Operator 1.1.3 版本发布，需要采取的行动包括在 `BackupSpec` 中添加 `cleanPolicy` 字段，将 `mydumper` 替换为 `dumpling` 进行备份。其他变更包括更新 backup manager 工具、为 TiCDC 添加 TLS 支持、在 Drainer 和下游数据库服务器之间添加 TLS 支持等。
-- [TiDB Operator 1.1.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.4/): TiDB Operator 1.1.4 版本发布，重大变化包括添加 TableFilter 到 BackupSpec 和 RestoreSpec，更新 TiDB 和配套工具版本为 v4.0.4，支持自定义环境变量，增加存储请求，为备份恢复添加 TLS 支持，支持 TiFlash 中的 cert-allowed-cn 配置项，修复了启用 TLS 时的内存泄漏问题，为 TiFlash 添加 TLS 支持，配置 TZ 环境。
-- [TiDB Operator 1.1.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.5/): TiDB Operator 1.1.5 版本发布日期为 2020 年 9 月 18 日。此版本兼容性变化需要注意 TiFlash 版本低于 `v4.0.5` 的设置。新功能包括支持为 TiDB/Pump/PD 配置 `serviceAccount`，以及配置 `spec.tikv.config.log-format` 和 `spec.tikv.config.server.max-grpc-send-msg-len`。优化提升方面支持 TiDB/PD/TiKV 的 v4.0.6 配置，挂载集群客户端证书到 PD Pod，以及对于 TiFlash/PD/TiDB 的伸缩实例优先于升级。同时修复了 TidbMonitor CR 中的 Grafana container 忽略 `Env` 配置的问题。
-- [TiDB Operator 1.1.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.6/): TiDB Operator 1.1.6 版本发布日期为 2020 年 10 月 16 日。此版本包含兼容性变化、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性变化包括 `spec.pd.config` 参数的自动转换和需要手动编辑 TidbCluster CR 的配置。滚动升级改动包括 TiDB 或 TiKV 集群的滚动升级以及 TiFlash 集群的滚动升级。新功能包括支持 Backup 和 Restore CR 自定义 BR 命令行参数、配置 TiKV evict leader 超时时间等。优化提升包括透传 TiFlash/TiKV/PD/Pump 的 TOML 格式配置、定时备份到 GCS 时目录名称添加备份时间等。Bug 修复包括修复 Discovery 可能导致启动多个 PD 集群的错误。
-- [TiDB Operator 1.1.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.7/): TiDB Operator 1.1.7 版本发布日期为 2020 年 11 月 13 日。此版本中兼容性变化包括配置项 `prometheus.spec.config.commandOptions` 的行为变化。新增功能包括对 `Backup` 和 `Restore` CR 的配置项 `spec.toolImage` 的新增，以及对 `spec.pd.storageVolumes`、`spec.tidb.storageVolumes` 和 `spec.tikv.storageVolumes` 的支持。优化提升方面包括禁止缩容 TiKV 实例和新增 `BackupStatus` 和 `RestoreStatus` 中的 `phase` 状态。此外还修复了当前 `TidbCluster` 之外存在 PD member 时无法把 PD scale 到 0 的 bug。
-- [TiDB Operator 1.1.8 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.8/): TiDB Operator 1.1.8 版本新增了对备份和恢复任务的支持，用户可以利用该功能实现基于 NFS 或者任意 Kubernetes 支持的 Volume 类型的任务。此外，还优化了 TiDB 组件和客户端开启 TLS 的功能，支持为 TiDB service 指定额外的端口，以及在连接 TiDB server 时不使用 TLS。修复了一系列 Bug，包括部署 TiDB 集群问题、编码错误问题、Pods 误认为问题等。
-- [TiDB Operator 1.1.9 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.9/): TiDB Operator 1.1.9 版本发布日期为 2020 年 12 月 28 日。此版本优化了支持使用 `spec.toolImage` 来为 `Backup` 和 `Restore` 指定 Dumpling/TiDB Lightning 的二进制可执行文件。同时修复了 Prometheus 不能拉取 TiKV Importer 的 metrics 以及用 BR 和 GCS 进行备份与恢复时的兼容性问题。
-- [TiDB Operator 1.2.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0/): TiDB Operator 1.2.0 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级改动包括升级 TiDB Operator 会导致 TidbMonitor Pod 删除重建。新功能包括支持为 `TiDBMonitor` 的 `Prometheus` 设置更细粒度的 `retentionTime` 和通过 `priorityClassName` 设置备份 Job 优先级。优化提升包括调整升级过程中驱逐 TiKV 的 Region Leader 超时的默认值。Bug 修复包括修复解析 `TiDBMonitor` 定义中 `Prometheus.RemoteWrite` 的 URL 可能失败的问题。
-- [TiDB Operator 1.2.0-alpha.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-alpha.1/): TiDB Operator 1.2.0-alpha.1 版本发布。滚动升级改动包括 TidbMonitor Pod 重建。新增功能包括跨多个 Kubernetes 集群部署 TiDB 集群、管理 DM 2.0、PD API 弹性伸缩、灰度升级 TiDB Operator。优化提升包括 TiDB Lightning chart 支持 local backend、TLS、持久化 checkpoint，TidbMonitor 支持配置 Thanos sidecar，管理资源从 Deployment 变为 StatefulSet。其他改进包括优化队列 rate limiter 间隔，修改 TidbMonitor 自定义告警规则存储目录。
-- [TiDB Operator 1.2.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-beta.1/): TiDB Operator 1.2.0-beta.1 发布日期为 2021 年 4 月 7 日。此版本包含兼容性改动和滚动升级改动。新增功能包括为备份和恢复 Job 设置自定义环境变量，支持配置额外的 volume 和 volumeMount，以及支持设置自定义 Store 标签。优化提升方面包括增加重试机制解决 DNS 查询异常处理问题，优化 Thanos 的 example yaml，以及在 PD 的扩缩容和容灾过程中增加多 PVC 支持。Bug 修复方面包括修复挂载多 PVC 时容量设置错误的问题，修复 TidbMonitor 外部标签包含无法识别的环境变量的问题，以及修复备份或恢复 Pod 状态没有正常更新为 Failed 的问题。
-- [TiDB Operator 1.2.0-beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-beta.2/): TiDB Operator 1.2.0-beta.2 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。新功能包括 TidbMonitor 支持监控多个启用了 TLS 的 TidbCluster，以及为所有 TiDB 组件设置安全上下文和拓扑约束。优化提升包括为 TidbMonitor Pod 增加 readiness 探测器和支持不生成 Prometheus 的告警规则。 Bug 修复包括修复 TiDB 实例缩容后仍在 TiDB Dashboard 中展示的问题和解决 TidbCluster CR 同步问题。
-- [TiDB Operator 1.2.0-rc.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-rc.1/): TiDB Operator 1.2.0-rc.1 发布，滚动升级改动会导致 Pump Pod 删除重建。新增支持为 TidbCluster 中的 Pod 与 service 设置自定义的 label，以及对 Pump 的完整生命周期管理。优化提升包括隐藏数据库密码的展示、支持为 Grafana 配置额外的 volumeMount、为 TidbMonitor 增加额外的信息展示列，以及 TidbMonitor 支持将配置信息直接写入到 PD 的 etcd 中。Bug 修复包括对启用了 TLS 的 DmCluster 进行监控的问题、PD 在扩容过程中 member 数量统计不正确的问题、DM-master 可能无法成功重启的问题、`configUpdateStrategy` 从 `InPlace` 修改为 `RollingUpdate` 后可能造成的 TidbCluster 组件滚动更新的问题，以及使用 Dumpling 备份数据时可能失败的问题。
-- [TiDB Operator 1.2.0-rc.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-rc.2/): TiDB Operator 1.2.0-rc.2 发布，新增支持透传 TiCDC 的 TOML 格式配置、为 TiCDC 设置存储卷和挂载、自定义 Discovery、TidbMonitor 和 TidbInitializer 的标签和注释、修改 Grafana 仪表盘。优化支持未指定 BR toolImage tag 时将 TiKV 版本作为 tag、扩缩容 TiDB 过程中协调 PVC、增加 liveness 与 readiness 探测器。修复部署异构集群时可能 panic 的问题、TidbCluster spec 未更改时 TiDB service 与 TidbCluster 状态持续更新的问题。
-- [TiDB Operator 1.2.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.1/): TiDB Operator 1.2.1 版本发布日期为 2021 年 8 月 18 日。滚动升级改动，如果部署 TiCDC 时配置了 hostNetwork 为 true，升级 TiDB Operator 后会导致 TiCDC Pod 删除重建。优化提升包括支持为 TidbCluster 的所有组件配置 hostNetwork，使所有组件都可以使用宿主机网络。
-- [TiDB Operator 1.2.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.2/): TiDB Operator 1.2.2 版本发布日期为 2021 年 9 月 3 日。滚动升级改动包括升级 TiDB Operator 会导致 TiDBMonitor Pod 和 TiFlash Pod 删除重建。新功能包括 TiDBMonitor 支持动态重新加载配置。Bug 修复包括修复 TiCDC 无法从低版本升级到 v5.2.0 的问题。
-- [TiDB Operator 1.2.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.3/): TiDB Operator 1.2.3 版本发布日期为 2021 年 9 月 7 日。此版本修复了升级到 TiDB Operator v1.2.2 时导致 TiFlash Pod 滚动重启的问题。
-- [TiDB Operator 1.2.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.4/): TiDB Operator 1.2.4 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级会导致 TidbMonitor Pod 删除重建。新增 TidbMonitor 支持用户自定义 Prometheus 告警规则和动态重新加载告警规则，以及支持批量删除备份数据。优化了 TiFlash 滚动升级流程，修复了镜像中的安全漏洞和备份数据残留的问题。
-- [TiDB Operator 1.2.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.5/): TiDB Operator 1.2.5 版本发布，优化了 DM 配置、TiFlash init container 资源配置和 TiDB TLS 客户端认证参数配置。修复了组件启动脚本更新后的滚动更新问题、启用 TLS 后 TidbCluster spec 自动更新问题、TiKV Region leader 数量计算可能导致 goroutine 泄露的问题和一些高级别的安全问题。
-- [TiDB Operator 1.2.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.6/): TiDB Operator 1.2.6 发布日期 2022 年 1 月 4 日。优化更新 Restore 和 Backup 状态时的重试逻辑。
-- [TiDB Operator 1.2.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.7/): TiDB Operator 1.2.7 发布，新增 `spec.pd.startUpScriptVersion` 字段，支持在 PD 启动脚本中使用 `dig` 命令解析域名。优化部署或更新组件的 StatefulSet，预先检查配置的 VolumeMount 是否存在，防止集群进行失败的滚动更新。
-- [TiDB Operator 1.3.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.0/): TiDB Operator 1.3.0 版本发布，包括兼容性改动、新功能、优化提升和 Bug 修复。兼容性改动包括跨集群部署 TiDB 集群升级操作，TiFlash 升级操作需注意。新增功能包括支持内部组件访问 TiDB 时跳过服务端证书验证、设置所有组件 Pod 的 DNS 配置等。优化提升包括部署或更新组件的 StatefulSet 预先检查配置的 VolumeMount 是否存在，跨集群部署 TiDB 集群功能增强。Bug 修复包括修复 Kubernetes v1.23 及之后版本无法部署 tidb scheduler 的问题。
-- [TiDB Operator 1.3.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.0-beta.1/): TiDB Operator 1.3.0-beta.1 发布日期为 2022 年 1 月 12 日。此版本的兼容性改动包括删除 Pod `ValidatingWebhook` 和 `MutatingWebhook`，升级后不会影响 TiDB 集群管理。升级到 1.3.0-beta.1 版本后，需要按照操作来升级 TiDB Operator。此版本还支持新功能和优化提升，包括支持 TiFlash 的 init container 配置资源使用量，支持持续性能分析，以及优化 TidbMonitor 部署示例等。
-- [TiDB Operator 1.3.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.1/): TiDB Operator 1.3.1 版本发布日期为 2022 年 2 月 24 日。此版本修复了 TiFlash 丢失元数据的问题，并添加了新的 `spec.dnsPolicy` 字段以支持配置 Pod 的 DNSPolicy。另外，`tidb-lightning` Helm chart 默认后端改为使用 `local`。还修复了 TiFlash 配置中缺少 `tmp_path` 字段时无法使用 TiFlash v5.4.0 及以后版本的问题，以及 Discovery 服务错误导致 TiDB 集群 PD 组件启动失败的问题。
-- [TiDB Operator 1.3.10 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.10/): TiDB Operator 1.3.10 发布，优化提升包括升级 Golang 版本到 1.19 以修复安全漏洞。
-- [TiDB Operator 1.3.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.2/): TiDB Operator 1.3.2 版本发布，优化支持在启用 Istio 的 Kubernetes 集群上部署与运行 TiDB，支持多架构 Docker 镜像包括 ARM 系统。
-- [TiDB Operator 1.3.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.3/): TiDB Operator 1.3.3 发布，新增了 `spec.tidb.service.port` 字段，修复了集群升级过程中可能泄漏的问题，更新了 `tidb-backup-manager` 镜像的基础镜像，修复了不兼容 ARM 架构的问题，修复了当 tidb Service 没有 Endpoint 时可能会 panic 的问题，修复了 Kubernetes 集群访问失败并重试后组件 Pod 的 Labels 和 Annotations 可能丢失的问题。
-- [TiDB Operator 1.3.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.4/): TiDB Operator 1.3.4 发布，优化提升包括在各个组件的状态信息中添加了 `volumes` 字段，以展示存储卷状态。
-- [TiDB Operator 1.3.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.5/): TiDB Operator 1.3.5 发布，新增功能支持使用 Azure Blob Storage 备份与恢复 TiDB 集群数据。
-- [TiDB Operator 1.3.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.6/): TiDB Operator 1.3.6 版本发布日期为 2022 年 7 月 5 日。此版本优化了扩容 PVC 对集群性能的影响，现在扩容 PVC 时按照 Pod 一个个扩容，并且在扩容 TiKV 的 PVC 前会先驱逐该 TiKV 上的 leader。
-- [TiDB Operator 1.3.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.7/): TiDB Operator 1.3.7 版本发布，新增了暂停组件功能，优化了扩容完成后重建 StatefulSet 的流程，修复了本地存储升级 TiKV 和清理备份文件后残留的问题。
-- [TiDB Operator 1.3.8 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.8/): TiDB Operator 1.3.8 版本发布，新增了为 `TidbCluster` 添加特殊 Annotation 的功能，支持配置 TiDB、TiKV 和 TiFlash 的 Pod 的最小等待时间。此外，还优化了支持优雅升级版本大于或等于 6.3.0 的 TiCDC pod。
-- [TiDB Operator 1.3.9 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.9/): TiDB Operator 1.3.9 发布，修复了在已设置 `acrossK8s` 字段但未设置 `clusterDomain` 的情况下，PD 升级流程会卡住的问题。
-- [TiDB Operator 1.4. Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.7/): TiDB Operator 1.4.7 发布，修复了 BackupSchedule CR 字段中的 `logBackupTemplate` 字段变成可选值的问题。
-- [TiDB Operator 1.4.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0/): TiDB Operator 1.4.0 版本发布，新增支持独立管理 TiDB Dashboard，配置 TiKV 和 PD 的 Readiness Probe，以及基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复。优化支持 IPv6 网络环境，修复了基于 EBS 快照备份无法恢复到不同 namespace 的问题和日志备份停止占用 Complete 状态的 bug。
-- [TiDB Operator 1.4.0-alpha.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-alpha.1/): TiDB Operator 1.4.0-alpha.1 发布，包含兼容性改动、滚动升级改动、新功能、优化提升和错误修复。新增自动设置 TiDB 的 location labels、新字段 `spec.tikv.scalePolicy` 与 `spec.tiflash.scalePolicy`、`startScriptVersion` 字段、BR 恢复集群到备份时间点、feature gate `VolumeModifying`、修改存储参数、配置 BR 的 `--check-requirements` 参数、使用字段 `additionalContainers` 自定义 Pod 容器配置。优化了 `TidbMonitor` 使用的 Prometheus 的 remoteWrite 配置和 TiFlash `Service` 添加 metric 端口。修复了集群扩缩容时的问题和 PD spec 为空导致 TiDB Operator 崩溃的问题。
-- [TiDB Operator 1.4.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.1/): TiDB Operator 1.4.0-beta.1 发布，新增支持基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复（实验特性），修复了日志备份的 checkpoint ts 无法更新的问题。
-- [TiDB Operator 1.4.0-beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.2/): TiDB Operator 1.4.0-beta.2 发布日期为 2022 年 11 月 11 日。此版本修复了使用 Azure Blob Storage 时未设置前缀的问题，并升级了 AWS SDK 到 v1.44.72 以支持使用 AWS 的 Asia Pacific (Jakarta) 区域 (`ap-southeast-3`)。
-- [TiDB Operator 1.4.0-beta.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.3/): TiDB Operator 1.4.0-beta.3 发布，新增 TiProxy 实验性支持和基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复 GA。修复了拼写错误和清理卷快照备份失败的问题，以及大规模 TiKV 节点下备份 TiDB 集群失败的问题。
-- [TiDB Operator 1.4.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.1/): TiDB Operator 1.4.1 版本发布，新增故障自动转移功能，优化了 TiDB Controller Manager 中 Kubernetes 客户端的配置，修复了未配置 PV 权限时 TiDB Controller Manager panic 的问题。
-- [TiDB Operator 1.4.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.2/): TiDB Operator 1.4.2 发布，修复了开启 `preferIPv6` 时 TiFlash 没有监听 IPv6 地址的问题。
-- [TiDB Operator 1.4.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.3/): TiDB Operator 1.4.3 发布，修复了开启 `preferIPv6` 时 TiFlash 的 metric server 未监听正确 IPv6 地址的问题，以及在 AWS 环境中打开了 feature gate `VolumeModifying` 且 `StorageClass` 缺少 EBS 相关参数时 TiDB Operator 会一直尝试修改 EBS 参数的问题。
-- [TiDB Operator 1.4.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.4/): TiDB Operator 1.4.4 发布，新增支持在已部署 TiFlash 的集群上使用卷快照备份和恢复，准确显示备份大小，支持重试快照备份，集成管理日志备份和快照备份。修复了使用非语义版本格式的 TiDB 镜像同步失败的问题，使用卷快照备份一个已缩容的集群后无法恢复数据的问题，卷快照备份可能崩溃的问题，卷快照恢复可能在最后阶段失败的问题。
-- [TiDB Operator 1.4.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.5/): TiDB Operator 1.4.5 版本发布，优化了 TidbCluster 的错误处理相关 metrics 和 worker 队列相关 metrics，增加了 DM master 组件的 `startUpScriptVersion` 字段，以及跨 Kubernetes 集群滚动重启或缩容 TiCDC 集群的能力。同时修复了定时备份中取消 GC、Backup CR 字段可选值、TiDB Operator 未配置权限时的 panic 问题，以及 TidbCluster 中设置 `AdditionalVolumeMounts` 时可能的 panic 问题。
-- [TiDB Operator 1.4.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.6/): TiDB Operator 1.4.6 发布，优化默认启用 volume resize 支持，修复备份恢复时报错问题，修复 TiCDC image tag 不符合语义化版本时无法 Graceful Drain TiCDC 的问题。
-- [TiDB Operator 1.5.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.0/): 了解 TiDB Operator 1.5.0 版本的新功能、优化提升，以及 Bug 修复。
-- [TiDB Operator 1.5.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.0-beta.1/): TiDB Operator 1.5.0-beta.1 发布，新增支持优雅重启 PD 和 TiDB Pod，使用 Advanced StatefulSet 管理 TiCDC 和 TiProxy，新增 TiDB Spec 字段，允许用户定义策略重启失败备份任务，升级 Kubernetes 依赖库至 v1.20 版本，添加与 reconciler 和 worker queue 相关的 Metric，优化滚动升级 TiKV 节点性能，允许用户自定义 Prometheus Scraping 相关配置，TiProxy 支持共享部分 TiDB 证书，配置 `spec.preferIPv6` 为 `true` 时，Service 的 `ipFamilyPolicy` 将配置为 `PreferDualStack`，添加统计协调流程失败计数的 Metric，修复了因为 metric 接口冲突而导致 pprof 接口无法访问的问题。
-- [TiDB Operator 1.5.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.1/): TiDB Operator 1.5.1 发布，新增支持替换 PD、TiKV 和 TiDB 所使用的 volume。修复了多个 Bug，包括手动触发 TiKV eviction 时 PVC Modifier 报错的问题，替换 TiKV volume 过程中再触发 TiKV eviction 时可能造成 TiDB Operator reconcile 死锁的问题，TidbCluster 在 Upgrade 过程中可能无法回滚的问题，以及 MaxReservedTime 选项没有被 backup schedule gc 使用的问题。
-- [TiDB Operator 1.5.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.2/): TiDB Operator 1.5.2 版本新增了对 AWS EBS 快照的备份能力的跨多个 K8S 集群的支持。优化了重启 PD、TiKV 时的启动流程，修复了替换 volume 时可能出现的问题。
-- [TiDB Operator 1.5.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.3/): 了解 TiDB Operator 1.5.3 版本的新功能和 Bug 修复。
-- [TiDB Operator 1.5.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.4/): 了解 TiDB Operator 1.5.4 版本的优化提升和 Bug 修复。
-- [TiDB Operator 1.5.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.5/): 了解 TiDB Operator 1.5.5 版本的新功能和优化提升。
-- [TiDB Operator 1.6.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.0/): 了解 TiDB Operator 1.6.0 版本的新功能、优化提升，以及 Bug 修复。
-- [TiDB Operator 1.6.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.0-beta.1/): 了解 TiDB Operator 1.6.0-beta.1 版本的新功能、优化提升，以及 Bug 修复。
-- [TiDB Operator 1.6.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.1/): 了解 TiDB Operator 1.6.1 版本的新功能、优化提升，以及 Bug 修复。
-- [TiDB Operator RBAC 规则](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-operator-rbac/): 介绍 TiDB Operator 需要的 RBAC 规则。
-- [TiDB Operator v1.6 新特性](https://docs.pingcap.com/tidb-in-kubernetes/stable/whats-new-in-v1.6/): 了解 TiDB Operator 1.6.0 版本引入的新特性。
-- [TiDB Operator 架构](https://docs.pingcap.com/tidb-in-kubernetes/stable/architecture/): 了解 TiDB Operator 架构及其工作原理。
-- [TiDB Operator 简介](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-operator-overview/): 介绍 TiDB Operator 的整体架构及使用方式。
-- [TiDB Scheduler 扩展调度器](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-scheduler/): 了解 TiDB Scheduler 扩展调度器及其工作原理。
-- [TiDB 集群的监控与告警](https://docs.pingcap.com/tidb-in-kubernetes/stable/monitor-a-tidb-cluster/): 介绍如何监控 TiDB 集群。
-- [TidbMonitor 分片功能](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-monitor-shards/): 如何使用 TidbMonitor 分片功能
-- [TidbMonitor 开启动态配置功能](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-monitor-dynamic-configuration/): 动态更新 TidbMonitor 配置
-- [为 DM 开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-dm/): 在 Kubernetes 上如何为 DM 开启 TLS。
-- [为 MySQL 客户端开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-mysql-client/): 在 Kubernetes 上如何为 TiDB 集群的 MySQL 客户端开启 TLS。
-- [为 TiDB 组件间开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-between-components/): 在 Kubernetes 上如何为 TiDB 集群组件间开启 TLS。
-- [为使用云存储的 TiDB 集群更换节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/replace-nodes-for-cloud-disk/): 介绍如何为使用云存储的 TiDB 集群更换节点。
-- [为使用本地存储的 TiDB 集群更换节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/replace-nodes-for-local-disk/): 介绍如何为使用本地存储的 TiDB 集群更换节点。
-- [为已有 TiDB 集群部署 HTAP 存储引擎 TiFlash](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tiflash/): 了解如何在 Kubernetes 上为已有 TiDB 集群部署 TiDB HTAP 存储引擎 TiFlash。
-- [为已有 TiDB 集群部署异构集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-heterogeneous-tidb-cluster/): 本文档介绍如何为已有的 TiDB 集群部署一个异构集群。
-- [为已有 TiDB 集群部署负载均衡 TiProxy](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tiproxy/): 了解如何在 Kubernetes 上为已有 TiDB 集群部署负载均衡 TiProxy。
-- [从 Helm 2 迁移到 Helm 3](https://docs.pingcap.com/tidb-in-kubernetes/stable/migrate-to-helm3/): 介绍如何将由 Helm 2 管理的组件迁移到由 Helm 3 管理。
-- [以非 root 用户运行容器](https://docs.pingcap.com/tidb-in-kubernetes/stable/containers-run-as-non-root-user/): 了解如何以非 root 用户运行容器。
-- [使用 BR 备份 TiDB 集群到 GCS](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs-using-br/): 介绍如何使用 BR 备份 TiDB 集群到 Google Cloud Storage (GCS)。
-- [使用 BR 备份 TiDB 集群数据到 Azure Blob Storage](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-azblob-using-br/): 介绍如何使用 BR 备份 TiDB 集群数据到 Azure Blob Storage 上。
-- [使用 BR 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-aws-s3-using-br/): 介绍如何使用 BR 备份 TiDB 集群数据到兼容 Amazon S3 的存储。
-- [使用 BR 恢复 Azure Blob Storage 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-azblob-using-br/): 介绍如何使用 BR 恢复 Azure Blob Storage 上的备份数据。
-- [使用 BR 恢复 GCS 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-gcs-using-br/): 介绍如何使用 BR 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
-- [使用 BR 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-aws-s3-using-br/): 介绍如何使用 BR 恢复 Amazon S3 兼容存储上的备份数据。
-- [使用 Dumpling 备份 TiDB 集群数据到 GCS](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs/): 介绍如何使用 Dumpling 将 TiDB 集群数据备份到 Google Cloud Storage (GCS)。
-- [使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-s3/): 介绍如何使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储。
-- [使用 PD Recover 恢复 PD 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/pd-recover/): 了解如何使用 PD Recover 恢复 PD 集群。
-- [使用 PingCAP Clinic 诊断 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/clinic-user-guide/): 详细介绍在使用 TiDB Operator 部署的集群上如何安装、使用 PingCAP Clinic 诊断服务进行数据采集和快速检查。
-- [使用 TiDB Lightning 恢复 GCS 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-gcs/): 介绍如何使用 TiDB Lightning 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
-- [使用 TiDB Lightning 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-s3/): 了解如何使用 TiDB Lightning 将兼容 S3 存储上的备份数据恢复到 TiDB 集群。
-- [使用多套 TiDB Operator 单独管理不同的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-multiple-tidb-operator/): 介绍如何部署多套 TiDB Operator 分别管理不同的 TiDB 集群。
-- [修改 TiDB 集群配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/modify-tidb-configuration/): 了解如何修改部署在 Kubernetes 上的 TiDB 的集群配置。
-- [升级 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster/): 介绍如何升级 Kubernetes 上的 TiDB 集群。
-- [升级 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/upgrade-tidb-operator/): 介绍如何升级 TiDB Operator。
-- [同步数据到开启 TLS 的下游服务](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-ticdc-sink/): 了解在 Kubernetes 上如何同步数据到开启 TLS 的下游服务。
-- [在 ARM64 机器上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-cluster-on-arm64/): 本文档介绍如何在 ARM64 机器上部署 TiDB 集群
-- [在 AWS EKS 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-aws-eks/): 介绍如何在 AWS EKS (Elastic Kubernetes Service) 上部署 TiDB 集群。
-- [在 Azure AKS 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-azure-aks/): 介绍如何在 Azure AKS (Azure Kubernetes Service) 上部署 TiDB 集群。
-- [在 Google Cloud GKE 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-gcp-gke/): 了解如何在 Google Cloud GKE 上部署 TiDB 集群。
-- [在 Kubernetes 上使用 DM](https://docs.pingcap.com/tidb-in-kubernetes/stable/use-tidb-dm/): 了解如何在 Kubernetes 上使用 TiDB DM 迁移数据。
-- [在 Kubernetes 上快速上手 TiDB](https://docs.pingcap.com/tidb-in-kubernetes/stable/get-started/): 介绍如何快速地在 Kubernetes 上使用 TiDB Operator 部署 TiDB 集群
-- [在 Kubernetes 上部署 DM](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-dm/): 了解如何在 Kubernetes 上部署 TiDB DM 集群。
-- [在 Kubernetes 上部署 TiCDC](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-ticdc/): 了解如何在 Kubernetes 上部署 TiCDC。
-- [在 Kubernetes 上部署 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-operator/): 了解如何在 Kubernetes 上部署 TiDB Operator。
-- [在标准 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-general-kubernetes/): 介绍如何在标准 Kubernetes 集群上通过 TiDB Operator 部署 TiDB 集群。
-- [基于 AWS EBS 卷快照的备份](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-aws-s3-by-snapshot/): 介绍如何基于 EBS 卷快照使用 TiDB Operator 备份 TiDB 集群数据到 S3。
-- [基于 AWS EBS 卷快照的恢复](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-aws-s3-by-snapshot/): 介绍如何将存储在 S3 上的备份元数据以及 EBS 卷快照恢复到 TiDB 集群。
-- [基于 EBS 卷快照备份恢复的性能介绍](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-snapshot-perf/): 了解 EBS 卷快照备份恢复的性能基线。
-- [基于 EBS 卷快照的备份恢复功能架构](https://docs.pingcap.com/tidb-in-kubernetes/stable/volume-snapshot-backup-restore/): 了解 TiDB EBS 卷快照的备份恢复架构设计。
-- [基于 EBS 快照备份恢复的常见问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-faq/): 介绍卷快照备份恢复中的常见问题以及解决方案。
-- [增强型 StatefulSet 控制器](https://docs.pingcap.com/tidb-in-kubernetes/stable/advanced-statefulset/): 介绍如何开启、使用增强型 StatefulSet 控制器
-- [备份 TiDB 集群到持久卷](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-pv-using-br/): 介绍如何使用 BR 备份 TiDB 集群数据到持久卷。
-- [备份与恢复 CR 介绍](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-cr/): 介绍用于备份与恢复的 Custom Resource (CR) 资源的各字段。
-- [备份与恢复简介](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-overview/): 介绍如何使用 BR、Dumpling、TiDB Lightning 工具对 Kubernetes 上的 TiDB 集群进行数据备份和数据恢复。
-- [导入集群数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-data-using-tidb-lightning/): 使用 TiDB Lightning 导入集群数据。
-- [将 TiDB 迁移至 Kubernetes](https://docs.pingcap.com/tidb-in-kubernetes/stable/migrate-tidb-to-kubernetes/): 介绍如何将部署在物理机或虚拟机中的 TiDB 迁移至 Kubernetes 集群中
-- [开启 TiDB Operator 准入控制器](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-admission-webhook/): 介绍如何开启 TiDB Operator 准入控制器以及它的作用。
-- [恢复持久卷上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-pv-using-br/): 介绍如何将存储在持久卷上的备份数据恢复到 TiDB 集群。
-- [恢复误删的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/recover-deleted-cluster/): 介绍如何恢复误删的 TiDB 集群。
-- [手动扩缩容 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/scale-a-tidb-cluster/): 了解如何在 Kubernetes 上对 TiDB 集群手动扩缩容。
-- [挂起 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/suspend-tidb-cluster/): 了解如何通过配置挂起 Kubernetes 上的 TiDB 集群。
-- [日志收集](https://docs.pingcap.com/tidb-in-kubernetes/stable/logs-collection/): 介绍收集 TiDB 及相关组件日志的方法。
-- [暂停同步 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/pause-sync-of-tidb-cluster/): 介绍如何暂停同步 Kubernetes 上的 TiDB 集群
-- [更新和替换 TLS 证书](https://docs.pingcap.com/tidb-in-kubernetes/stable/renew-tls-certificate/): 介绍如何更新和替换 TiDB 组件间的 TLS 证书。
-- [构建多个网络互通的 AWS EKS 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/build-multi-aws-eks/): 介绍如何构建多个 AWS EKS 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
-- [构建多个网络互通的 Google Cloud GKE 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/build-multi-gcp-gke/): 介绍如何构建多个 Google Cloud GKE 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
-- [查看日志](https://docs.pingcap.com/tidb-in-kubernetes/stable/view-logs/): 介绍如何查看 TiDB 集群各组件日志以及 TiDB 慢查询日志。
-- [灰度升级 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/canary-upgrade-tidb-operator/): 介绍如何灰度升级 TiDB Operator，避免 TiDB Operator 升级对整个 Kubernetes 集群中的所有 TiDB 集群产生不可预知的影响。
-- [管理 TiDB 集群的 Command Cheat Sheet](https://docs.pingcap.com/tidb-in-kubernetes/stable/cheat-sheet/): 介绍管理 TiDB 集群的 Command Cheat Sheet。
-- [维护 TiDB 集群所在的 Kubernetes 节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/maintain-a-kubernetes-node/): 介绍如何维护 TiDB 集群所在的 Kubernetes 节点。
-- [聚合多个 TiDB 集群的监控数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/aggregate-multiple-cluster-monitor-data/): 通过 Thanos 框架聚合多个 TiDB 集群的监控数据
-- [访问 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/access-tidb/): 介绍如何访问 Kubernetes 上的 TiDB 集群。
-- [访问 TiDB Dashboard](https://docs.pingcap.com/tidb-in-kubernetes/stable/access-dashboard/): 介绍如何在 Kubernetes 环境下访问 TiDB Dashboard
-- [跨多个 Kubernetes 集群监控 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-monitor-across-multiple-kubernetes/): 介绍如何对跨多个 Kubernetes 集群的 TiDB 集群进行监控，并集成到常见 Prometheus 多集群监控体系中
-- [跨多个 Kubernetes 集群部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-cluster-across-multiple-kubernetes/): 本文档介绍如何实现跨多个 Kubernetes 集群部署 TiDB 集群
-- [远程存储访问授权](https://docs.pingcap.com/tidb-in-kubernetes/stable/grant-permissions-to-remote-storage/): 介绍如何授权访问远程存储。
-- [部署 TiDB Binlog](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-binlog/): 了解如何在 Kubernetes 上部署 TiDB 集群的 TiDB Binlog。
-- [配置 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-a-tidb-cluster/): 了解如何在 Kubernetes 中配置 TiDB 集群。
-- [重启 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/restart-a-tidb-cluster/): 了解如何重启 Kubernetes 集群上的 TiDB 集群。
-- [销毁 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/destroy-a-tidb-cluster/): 介绍如何销毁 Kubernetes 集群上的 TiDB 集群。
+- [Kubernetes 上的 TiDB Binlog Drainer 配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-tidb-binlog-drainer.md): 了解 Kubernetes 上的 TiDB Binlog Drainer 配置参数。
+- [Kubernetes 上的 TiDB 工具指南](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-toolkit.md): 详细介绍 Kubernetes 上的 TiDB 相关的工具及其使用方法。
+- [Kubernetes 上的 TiDB 常见部署错误](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-failures.md): 介绍 Kubernetes 上 TiDB 部署的常见错误以及处理办法。
+- [Kubernetes 上的 TiDB 集群常见异常](https://docs.pingcap.com/tidb-in-kubernetes/stable/exceptions.md): 介绍 TiDB 集群运行过程中常见异常以及处理办法。
+- [Kubernetes 上的 TiDB 集群常见网络问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/network-issues.md): 介绍 Kubernetes 上 TiDB 集群的常见网络问题以及诊断解决方案。
+- [Kubernetes 上的 TiDB 集群常见问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/faq.md): 介绍 Kubernetes 上的 TiDB 集群常见问题以及解决方案。
+- [Kubernetes 上的 TiDB 集群故障自动转移](https://docs.pingcap.com/tidb-in-kubernetes/stable/use-auto-failover.md): 介绍 Kubernetes 上的 TiDB 集群故障自动转移的功能。
+- [Kubernetes 上的 TiDB 集群环境需求](https://docs.pingcap.com/tidb-in-kubernetes/stable/prerequisites.md): 介绍在 Kubernetes 上部署 TiDB 集群的软硬件环境需求。
+- [Kubernetes 上的 TiDB 集群管理常用使用技巧](https://docs.pingcap.com/tidb-in-kubernetes/stable/tips.md): 介绍 Kubernetes 上 TiDB 集群管理常用使用技巧。
+- [Kubernetes 上的持久化存储类型配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-storage-class.md): 介绍 Kubernetes 上的数据持久化存储类型配置。
+- [Kubernetes 上的集群初始化配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/initialize-a-cluster.md): 介绍如何初始化配置 Kubernetes 上的 TiDB 集群。
+- [Kubernetes 的监控与告警](https://docs.pingcap.com/tidb-in-kubernetes/stable/monitor-kubernetes.md): 介绍如何监控 Kubernetes。
+- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/tidb-in-kubernetes/stable/clinic-data-collection.md): 详细说明 PingCAP Clinic 诊断服务在使用 Operator 部署的 TiDB 集群中能够采集的诊断数据类型、输出文件及采集参数。
+- [TiDB on Kubernetes Sysbench 性能测试](https://docs.pingcap.com/tidb-in-kubernetes/stable/benchmark-sysbench.md): TiDB Operator GA 发布后，我们在 GKE 平台进行了全面的性能测试。测试结果显示，在 Host 网络模式下，TiDB 性能略优于 Pod 网络模式（约 7%）。此外，使用 Ubuntu 系统的 Host 网络模式下，TiDB 性能也略优于 COS 系统（约 9%）。在集群外访问时，使用 Load Balancer 会略损失性能（约 5%）。多可用区下节点之间的延迟增加，会对 TiDB 性能产生一定影响（30% ~ 6%）。计算型机型相对普通型机器带来了很大 QPS 提升（50% ~ 60%）。
+- [TiDB Operator 0.1.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.1.0.md): TiDB Operator 0.1.0 was released on August 22, 2018. Notable changes include the ability to bootstrap multiple TiDB clusters, support for monitoring deployment and Helm charts, basic Network PV/Local PV support, safe scaling of the TiDB cluster, orderly cluster upgrades, and stopping the TiDB process without terminating the Pod. Additionally, cluster meta info can be synchronized to POD/PV/PVC labels, and basic unit tests & E2E tests are available. Tutorials for GKE and local DinD are also provided.
+- [TiDB Operator 0.2.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.2.0.md): TiDB Operator 0.2.0 was released on September 11, 2018. Notable changes include experimental support for auto-failover, unification of Tiller and TiDB Operator managed resources labels, managing TiDB service via Tiller, adding toleration for TiDB cluster components, and refactoring upgrade functions as interface. Additionally, a script for easy setup of DinD environment was added, and code was linted and formatted in CI.
+- [TiDB Operator 0.2.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.2.1.md): TiDB Operator 0.2.1 was released on September 20, 2018. This version includes bug fixes for retry on conflict logic, TiDB timezone configuration, failover, and repeated updating of pod and pd/tidb StatefulSet.
+- [TiDB Operator 0.3.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.3.0.md): TiDB Operator 0.3.0 was released on October 12, 2018. Notable changes include the addition of full backup support, TiDB Binlog support, graceful upgrade feature, and the ability to persist monitor data.
+- [TiDB Operator 0.3.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.3.1.md): TiDB Operator 0.3.1 was released on October 31, 2018. The release includes minor changes such as parameterizing the serviceAccount, bumping TiDB to v2.0.7, and allowing user-specified config files. Bug fixes include addressing issues with parallel upgrades, wrong parameters, and recovery after a failed upgrade.
+- [TiDB Operator 0.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.4.0.md): TiDB Operator 0.4.0 was released on November 9, 2018. Notable changes include extending Kubernetes scheduler for TiDB data awareness, restoring backup data from GCS bucket, and setting password for TiDB when first deployed. Minor changes and bug fixes include updating roadmap, adding unit tests, E2E tests, adding TiDB failover limit, synchronizing PV reclaim policy early, using helm release name as instance label, and fixing local PV setup script.
+- [TiDB Operator 1.0 Beta.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.0.md): TiDB Operator 1.0 Beta.0 was released on November 26, 2018. Notable changes include the introduction of basic chaos testing, improved unit test coverage, default log-level values for PD/TiKV/TiDB, and various bug fixes and enhancements. The release also includes a user guide and migration to Go 1.11 module.
+- [TiDB Operator 1.0 Beta.1 P1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p1.md): TiDB Operator 1.0 Beta.1 P1 was released on January 7, 2019. The bug fixes include resolving scheduler policy issues for Kubernetes v1.10, v1.11, and v1.12. The documentation updates include a proposal to add multiple statefulsets support to TiDB Operator and an updated roadmap.
+- [TiDB Operator 1.0 Beta.1 P2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p2.md): TiDB Operator 1.0 Beta.1 P2 was released on February 21, 2019. Notable changes include a new algorithm for scheduler HA predicate, addition of TiDB discovery service, serial scheduling, change in tolerations type to an array, direct start when there is a join file, addition of code coverage icon, omission of just the empty leaves in `values.yml`, backup to ceph object storage in charts, and addition of `ClusterIDLabelKey` label to TidbCluster.
+- [TiDB Operator 1.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1.md): TiDB Operator 1.0 Beta.1 was released on December 27, 2018. The release includes bug fixes such as pd_control bug, orphan pod cleaner, scheduler configuration fix, Grafana configuration fix, and more. Minor improvements include adding Kubernetes 1.12 local DinD scripts, bumping default TiDB to v2.1.0, releasing tidb-operator/tidb-cluster charts, and adding connection timeout for TiDB password setter job. Other improvements involve separating ad-hoc backup and restore to another chart, adding compiler version info to tidb-operator binary, allowing specifying TiDB service LoadBalancer IP, and exposing TiKV cpu/memory related configuration to values.yaml.
+- [TiDB Operator 1.0 Beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.2.md): TiDB Operator 1.0 Beta.2 has been released on May 10, 2019. The new version includes enhanced stability, improved ease of use, bug fixes, and other improvements. Some of the key changes include refactored e2e test, one-command deployment for AWS and Aliyun, and support for slow log of TiDB. Numerous bug fixes and detailed changes have also been made to improve the overall performance and user experience.
+- [TiDB Operator 1.0 Beta.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.3.md): TiDB Operator 1.0 Beta.3 was released on June 6, 2019. The new version includes the removal of `nodeSelectorRequired` from values.yaml and the addition of stability cases, new features, documentation improvements, and bug fixes. Some notable new features include ConfigMap rollout management, stable scheduling for pods, and support for adding additional pod annotations. The default TiDB version has been upgraded to v3.0.0-rc.1, and various bug fixes and changes have been implemented.
+- [TiDB Operator 1.0 GA Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0-ga.md): TiDB Operator 1.0.0 has been released on July 30, 2019. The new version requires action to be taken for configuration changes in `values.yaml`. Stability test cases have been added, along with improvements such as GKE SSD setup simplification and AWS Terraform script modularization. Bug fixes include sysbench installation and TiKV metrics monitoring. Detailed bug fixes and changes include upgrading TiDB monitor, specifying TiKV status address, and enabling nlb cross zone load balancing by default. Multiple TiDB clusters management is now supported in Alibaba Cloud. The default TiDB version has been upgraded to v3.0.1. The release also includes various other bug fixes and improvements.
+- [TiDB Operator 1.0 RC.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-rc.1.md): TiDB Operator 1.0 RC.1 was released on July 12, 2019. The new version includes stability test cases, improvements such as increasing TiKV GC life time, and bug fixes like fixing unbound variables in the backup script and scheduled backup bugs. It also supports force upgrade when PD cluster is unavailable and adds Amazon S3 support for backup/restore features. Multiple clusters management in EKS and local SSD provision for COS on GKE are also included. The release notes contain detailed bug fixes and changes, including various pull requests for bug fixes and improvements.
+- [TiDB Operator 1.0.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.1.md): TiDB Operator version 1.0.1 was released on September 17, 2019. The release includes important bug fixes and improvements. Users of version 1.0.0 or prior must upgrade to avoid potential service outage. The backup tool image has been updated to fix a serious bug. Other improvements include modularizing GCP Terraform, adding support for various configurations, and reducing e2e run time. Bug fixes address issues such as TiKV scale-in failure, orphan pods cleaner bugs, and incorrect condition judgment. The release also includes detailed bug fixes and changes.
+- [TiDB Operator 1.0.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.2.md): TiDB Operator version 1.0.2 was released on November 1, 2019. The new version includes improvements such as suspending the ReplaceUnhealthy process for AWS TiKV auto-scaling-group, adding a new VM manager 'qm' in stability test, and setting default externalTrafficPolicy to 'Local' for TiDB service in AWS/GCP/Aliyun. Bug fixes include issues with tkctl version, create_tidb_cluster_release variable in AWS Terraform script, and compatibility issues with Kubernetes 1.16 and above versions. Other fixes and changes are also included in this release.
+- [TiDB Operator 1.0.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.3.md): TiDB Operator version 1.0.3 was released on November 13, 2019. The new version requires an upgrade to TiDB v3.0.5 and adds timezone support for all charts. Existing TiDB clusters with customized timezones will trigger a rolling update. Improvements include timezone support and configuring resource requests and limits for all containers of the TiDB cluster. Bug fixes include upgrading default TiDB version to v3.0.5 and adding timezone support for all containers of the TiDB cluster.
+- [TiDB Operator 1.0.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.4.md): TiDB Operator version 1.0.4 was released on November 23, 2019. The new version introduces HostNetwork support for better performance, podSecurityContext support, and new Helm charts for TiDB Lightning and TiDB Binlog. It also includes bug fixes and changes. Users of the v1.1.0.alpha branch are advised to upgrade to v1.0.4, as it includes all fixes from the alpha branch and introduces additional improvements.
+- [TiDB Operator 1.0.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.5.md): TiDB Operator version 1.0.5 was released on December 11, 2019. The new features include fixing backup failure issue, recommending deployment of TiDB and Pump on the same node, fixing RBAC permission, and resolving e2e nil point dereference. No action is required for upgrading from v1.0.4.
+- [TiDB Operator 1.0.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.6.md): TiDB Operator 1.0.6 was released on December 27, 2019. Users need to migrate configs from the old `values.yaml` to the new one to avoid monitor pod failures. The new release includes improvements in monitor, TiDB Scheduler, compatibility, TiKV Importer, E2E, and CI. Notable changes include enabling alert rule persistence, adding node & pod info in TiDB Grafana, refining scheduler error messages, fixing compatibility issues in Kubernetes v1.17, and adjusting the release CI script.
+- [TiDB Operator 1.0.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.7.md): TiDB Operator 1.0.7 was released on June 16, 2020. Notable changes include fixing alert rules lost after rolling upgrade, upgrading local volume provisioner to 2.3.4, fixing operator failover config invalid, removing unnecessary duplicated docs, updating doc links and image in readme, emitting events when PD failover, fixing some broken urls, and removing some not very useful update events.
+- [TiDB Operator 1.1 Beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-beta.1.md): 支持配置时区，备份到 S3，基础默认设置，增强型 StatefulSet 扩缩容，自定义资源初始化 TiDB 集群，优化配置结构，支持临时存储，发布 Terraform Aliyun ACK 版本，优化报错信息，支持 TLS 加密连接，支持动态扩展云存储 PV，支持自动生成证书，支持暂停备份计划，升级 TiDB 版本。
+- [TiDB Operator 1.1 Beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-beta.2.md): 默认存储类和备份存储类已废弃，现在使用 Kubernetes 默认存储类。用户可设置备份和恢复的亲和性和容忍度。解决了 AdvancedStatefulSet 和 Admission Webhook 一起使用的问题。支持基于 CPU 平均负载的集群自动扩容。支持用户自定义证书。修复了一些问题并优化了日志。
+- [TiDB Operator 1.1 GA Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1-ga.md): TiDB Operator 1.1 GA 发布日期 2020 年 5 月 28 日。将 TiDB Pod 的 readiness 探针从 HTTPGet 更改为 TCPSocket 4000 端口。这将触发 tidb-server 组件滚动升级。你可以在升级 TiDB Operator 之前将 spec.paused 设置为 true 以避免滚动升级，并在准备升级 tidb-server 时将其重新设置为 false。
+- [TiDB Operator 1.1 RC.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.1.md): 此版本包括对 tidb-server 的配置选项的更新，备份和恢复规范的修改，以及对 TiDB 组件的一些修复和改进。还支持通过 Terraform 在 AWS 和 ACK 上部署 TiDB 集群，并添加了一些新的功能和文档。
+- [TiDB Operator 1.1 RC.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.2.md): TiDB Operator 1.1 RC.2 was released on April 15, 2020. Action required includes changing TiDB pod readiness probe and setting spec.paused to true before upgrading. Notable changes include adding status field for TidbAutoScaler CR, emitting more events for TidbCluster and TidbClusterAutoScaler, and adding TLS support for TiKV metrics API. Other changes involve adding a switch to skip PD Dashboard TLS configuration, supporting TiFlash in TidbCluster CR, and fixing errors related to alertmanager in TidbMonitor.
+- [TiDB Operator 1.1 RC.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.3.md): TiDB Operator 1.1 RC.3 was released on April 30, 2020. Notable changes include support for TiFlash metrics in TidbMonitor, fixing bugs related to failover pods and statefulsets, and adding new features like configuring Ingress in TidbMonitor and supporting failover for TiFlash. Other changes include updates to terraform scripts and adding new fields in TiKVConfig.
+- [TiDB Operator 1.1 RC.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.4.md): TiDB Operator 1.1 RC.4 发布于 2020 年 5 月 15 日。每个组件可以使用单独的 TiDB 客户端证书。用户应该将 `Backup` 和 `Restore` CR 中的旧的 TLS 配置迁移到新的配置。
+- [TiDB Operator 1.1.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.1.md): TiDB Operator 1.1.1 版本发布，重大变化包括添加 `additionalContainers` 和 `additionalVolumes` 字段，修复了多个问题，并更新了配置版本到 v4.0.1。
+- [TiDB Operator 1.1.10 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.10.md): TiDB Operator 1.1.10 版本发布，包含兼容性改动、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性改动包括 `apiVersion` 更改，滚动升级改动导致 TidbMonitor Pod 删除重建。新功能包括灰度升级、TidbMonitor 支持 `remotewrite`、配置 init containers 等。优化提升包括自定义存储、增加 label 支持多集群监控等。Bug 修复包括备份或者恢复失败、Pod 在升级过程中不会进行迁移 leader 等问题。
+- [TiDB Operator 1.1.11 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.11.md): TiDB Operator 1.1.11 版本发布，新增优化 LeaderElection 和自定义 Store 标签功能。优化 TiFlash 滚动更新机制，改进获取 region leader 数量方式。支持打印 RocksDB 和 Raft 日志到 stdout。
+- [TiDB Operator 1.1.12 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.12.md): TiDB Operator 1.1.12 版本发布日期为 2021 年 4 月 15 日。新功能包括支持为备份和恢复 Job 设置自定义环境变量，支持备份恢复 CR 设置 affinity 和 tolerations，以及支持 tidb-operator chart 使用新的 service account。优化提升包括 TiDBInitializer 中增加重试机制，增加多 PVC 支持，以及优化 `PodsAreChanged` 函数。Bug 修复包括修复挂载多 PVC 时容量设置错误的问题，修复创建 `.spec.tidb` 为空并开启 TLS 的 TidbCluster 导致 tidb-controller-manager panic 的问题，以及修复 `UnjoinedMembers` 中 PVC 状态异常的问题。
+- [TiDB Operator 1.1.13 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.13.md): TiDB Operator 1.1.13 版本发布，优化了 TiCDC 配置 TLS 证书、BR 工具镜像 tag、扩缩容 TiDB 过程中协调 PVC、备份日志中隐藏数据库密码。修复了部署异构集群时可能 panic 的问题和 TiDB 实例缩容后在 TiDB Dashboard 中仍然存在的问题。
+- [TiDB Operator 1.1.14 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.14.md): TiDB Operator 1.1.14 版本发布日期为 2021 年 10 月 21 日。此版本修复了 `tidb-backup-manager` 和 `tidb-operator` 镜像中的安全漏洞。
+- [TiDB Operator 1.1.15 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.15.md): TiDB Operator 1.1.15 发布日期为 2022 年 2 月 17 日。此版本修复了 TiDB Operator 计算 TiKV Region leader 数量时可能会造成 goroutine 泄露的问题。
+- [TiDB Operator 1.1.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.2.md): TiDB Operator 1.1.2 版本修复了与 PD 4.0.2 不兼容的问题。需要将 TiDB Operator 升级到 v1.1.2 后再部署 TiDB 4.0.2 及更高版本。其他变更包括抓取监控指标和更新配置为 v4.0.2，修复缩容后 PD 成员可能仍然存在的错误，同步信息到 `TidbCluster` `Status` 字段，以及支持在 TiDB 参数中配置容器生命周期 hook 和 `terminationGracePeriodSeconds`。
+- [TiDB Operator 1.1.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.3.md): TiDB Operator 1.1.3 版本发布，需要采取的行动包括在 `BackupSpec` 中添加 `cleanPolicy` 字段，将 `mydumper` 替换为 `dumpling` 进行备份。其他变更包括更新 backup manager 工具、为 TiCDC 添加 TLS 支持、在 Drainer 和下游数据库服务器之间添加 TLS 支持等。
+- [TiDB Operator 1.1.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.4.md): TiDB Operator 1.1.4 版本发布，重大变化包括添加 TableFilter 到 BackupSpec 和 RestoreSpec，更新 TiDB 和配套工具版本为 v4.0.4，支持自定义环境变量，增加存储请求，为备份恢复添加 TLS 支持，支持 TiFlash 中的 cert-allowed-cn 配置项，修复了启用 TLS 时的内存泄漏问题，为 TiFlash 添加 TLS 支持，配置 TZ 环境。
+- [TiDB Operator 1.1.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.5.md): TiDB Operator 1.1.5 版本发布日期为 2020 年 9 月 18 日。此版本兼容性变化需要注意 TiFlash 版本低于 `v4.0.5` 的设置。新功能包括支持为 TiDB/Pump/PD 配置 `serviceAccount`，以及配置 `spec.tikv.config.log-format` 和 `spec.tikv.config.server.max-grpc-send-msg-len`。优化提升方面支持 TiDB/PD/TiKV 的 v4.0.6 配置，挂载集群客户端证书到 PD Pod，以及对于 TiFlash/PD/TiDB 的伸缩实例优先于升级。同时修复了 TidbMonitor CR 中的 Grafana container 忽略 `Env` 配置的问题。
+- [TiDB Operator 1.1.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.6.md): TiDB Operator 1.1.6 版本发布日期为 2020 年 10 月 16 日。此版本包含兼容性变化、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性变化包括 `spec.pd.config` 参数的自动转换和需要手动编辑 TidbCluster CR 的配置。滚动升级改动包括 TiDB 或 TiKV 集群的滚动升级以及 TiFlash 集群的滚动升级。新功能包括支持 Backup 和 Restore CR 自定义 BR 命令行参数、配置 TiKV evict leader 超时时间等。优化提升包括透传 TiFlash/TiKV/PD/Pump 的 TOML 格式配置、定时备份到 GCS 时目录名称添加备份时间等。Bug 修复包括修复 Discovery 可能导致启动多个 PD 集群的错误。
+- [TiDB Operator 1.1.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.7.md): TiDB Operator 1.1.7 版本发布日期为 2020 年 11 月 13 日。此版本中兼容性变化包括配置项 `prometheus.spec.config.commandOptions` 的行为变化。新增功能包括对 `Backup` 和 `Restore` CR 的配置项 `spec.toolImage` 的新增，以及对 `spec.pd.storageVolumes`、`spec.tidb.storageVolumes` 和 `spec.tikv.storageVolumes` 的支持。优化提升方面包括禁止缩容 TiKV 实例和新增 `BackupStatus` 和 `RestoreStatus` 中的 `phase` 状态。此外还修复了当前 `TidbCluster` 之外存在 PD member 时无法把 PD scale 到 0 的 bug。
+- [TiDB Operator 1.1.8 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.8.md): TiDB Operator 1.1.8 版本新增了对备份和恢复任务的支持，用户可以利用该功能实现基于 NFS 或者任意 Kubernetes 支持的 Volume 类型的任务。此外，还优化了 TiDB 组件和客户端开启 TLS 的功能，支持为 TiDB service 指定额外的端口，以及在连接 TiDB server 时不使用 TLS。修复了一系列 Bug，包括部署 TiDB 集群问题、编码错误问题、Pods 误认为问题等。
+- [TiDB Operator 1.1.9 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.9.md): TiDB Operator 1.1.9 版本发布日期为 2020 年 12 月 28 日。此版本优化了支持使用 `spec.toolImage` 来为 `Backup` 和 `Restore` 指定 Dumpling/TiDB Lightning 的二进制可执行文件。同时修复了 Prometheus 不能拉取 TiKV Importer 的 metrics 以及用 BR 和 GCS 进行备份与恢复时的兼容性问题。
+- [TiDB Operator 1.2.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0.md): TiDB Operator 1.2.0 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级改动包括升级 TiDB Operator 会导致 TidbMonitor Pod 删除重建。新功能包括支持为 `TiDBMonitor` 的 `Prometheus` 设置更细粒度的 `retentionTime` 和通过 `priorityClassName` 设置备份 Job 优先级。优化提升包括调整升级过程中驱逐 TiKV 的 Region Leader 超时的默认值。Bug 修复包括修复解析 `TiDBMonitor` 定义中 `Prometheus.RemoteWrite` 的 URL 可能失败的问题。
+- [TiDB Operator 1.2.0-alpha.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-alpha.1.md): TiDB Operator 1.2.0-alpha.1 版本发布。滚动升级改动包括 TidbMonitor Pod 重建。新增功能包括跨多个 Kubernetes 集群部署 TiDB 集群、管理 DM 2.0、PD API 弹性伸缩、灰度升级 TiDB Operator。优化提升包括 TiDB Lightning chart 支持 local backend、TLS、持久化 checkpoint，TidbMonitor 支持配置 Thanos sidecar，管理资源从 Deployment 变为 StatefulSet。其他改进包括优化队列 rate limiter 间隔，修改 TidbMonitor 自定义告警规则存储目录。
+- [TiDB Operator 1.2.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-beta.1.md): TiDB Operator 1.2.0-beta.1 发布日期为 2021 年 4 月 7 日。此版本包含兼容性改动和滚动升级改动。新增功能包括为备份和恢复 Job 设置自定义环境变量，支持配置额外的 volume 和 volumeMount，以及支持设置自定义 Store 标签。优化提升方面包括增加重试机制解决 DNS 查询异常处理问题，优化 Thanos 的 example yaml，以及在 PD 的扩缩容和容灾过程中增加多 PVC 支持。Bug 修复方面包括修复挂载多 PVC 时容量设置错误的问题，修复 TidbMonitor 外部标签包含无法识别的环境变量的问题，以及修复备份或恢复 Pod 状态没有正常更新为 Failed 的问题。
+- [TiDB Operator 1.2.0-beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-beta.2.md): TiDB Operator 1.2.0-beta.2 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。新功能包括 TidbMonitor 支持监控多个启用了 TLS 的 TidbCluster，以及为所有 TiDB 组件设置安全上下文和拓扑约束。优化提升包括为 TidbMonitor Pod 增加 readiness 探测器和支持不生成 Prometheus 的告警规则。 Bug 修复包括修复 TiDB 实例缩容后仍在 TiDB Dashboard 中展示的问题和解决 TidbCluster CR 同步问题。
+- [TiDB Operator 1.2.0-rc.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-rc.1.md): TiDB Operator 1.2.0-rc.1 发布，滚动升级改动会导致 Pump Pod 删除重建。新增支持为 TidbCluster 中的 Pod 与 service 设置自定义的 label，以及对 Pump 的完整生命周期管理。优化提升包括隐藏数据库密码的展示、支持为 Grafana 配置额外的 volumeMount、为 TidbMonitor 增加额外的信息展示列，以及 TidbMonitor 支持将配置信息直接写入到 PD 的 etcd 中。Bug 修复包括对启用了 TLS 的 DmCluster 进行监控的问题、PD 在扩容过程中 member 数量统计不正确的问题、DM-master 可能无法成功重启的问题、`configUpdateStrategy` 从 `InPlace` 修改为 `RollingUpdate` 后可能造成的 TidbCluster 组件滚动更新的问题，以及使用 Dumpling 备份数据时可能失败的问题。
+- [TiDB Operator 1.2.0-rc.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-rc.2.md): TiDB Operator 1.2.0-rc.2 发布，新增支持透传 TiCDC 的 TOML 格式配置、为 TiCDC 设置存储卷和挂载、自定义 Discovery、TidbMonitor 和 TidbInitializer 的标签和注释、修改 Grafana 仪表盘。优化支持未指定 BR toolImage tag 时将 TiKV 版本作为 tag、扩缩容 TiDB 过程中协调 PVC、增加 liveness 与 readiness 探测器。修复部署异构集群时可能 panic 的问题、TidbCluster spec 未更改时 TiDB service 与 TidbCluster 状态持续更新的问题。
+- [TiDB Operator 1.2.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.1.md): TiDB Operator 1.2.1 版本发布日期为 2021 年 8 月 18 日。滚动升级改动，如果部署 TiCDC 时配置了 hostNetwork 为 true，升级 TiDB Operator 后会导致 TiCDC Pod 删除重建。优化提升包括支持为 TidbCluster 的所有组件配置 hostNetwork，使所有组件都可以使用宿主机网络。
+- [TiDB Operator 1.2.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.2.md): TiDB Operator 1.2.2 版本发布日期为 2021 年 9 月 3 日。滚动升级改动包括升级 TiDB Operator 会导致 TiDBMonitor Pod 和 TiFlash Pod 删除重建。新功能包括 TiDBMonitor 支持动态重新加载配置。Bug 修复包括修复 TiCDC 无法从低版本升级到 v5.2.0 的问题。
+- [TiDB Operator 1.2.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.3.md): TiDB Operator 1.2.3 版本发布日期为 2021 年 9 月 7 日。此版本修复了升级到 TiDB Operator v1.2.2 时导致 TiFlash Pod 滚动重启的问题。
+- [TiDB Operator 1.2.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.4.md): TiDB Operator 1.2.4 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级会导致 TidbMonitor Pod 删除重建。新增 TidbMonitor 支持用户自定义 Prometheus 告警规则和动态重新加载告警规则，以及支持批量删除备份数据。优化了 TiFlash 滚动升级流程，修复了镜像中的安全漏洞和备份数据残留的问题。
+- [TiDB Operator 1.2.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.5.md): TiDB Operator 1.2.5 版本发布，优化了 DM 配置、TiFlash init container 资源配置和 TiDB TLS 客户端认证参数配置。修复了组件启动脚本更新后的滚动更新问题、启用 TLS 后 TidbCluster spec 自动更新问题、TiKV Region leader 数量计算可能导致 goroutine 泄露的问题和一些高级别的安全问题。
+- [TiDB Operator 1.2.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.6.md): TiDB Operator 1.2.6 发布日期 2022 年 1 月 4 日。优化更新 Restore 和 Backup 状态时的重试逻辑。
+- [TiDB Operator 1.2.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.7.md): TiDB Operator 1.2.7 发布，新增 `spec.pd.startUpScriptVersion` 字段，支持在 PD 启动脚本中使用 `dig` 命令解析域名。优化部署或更新组件的 StatefulSet，预先检查配置的 VolumeMount 是否存在，防止集群进行失败的滚动更新。
+- [TiDB Operator 1.3.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.0.md): TiDB Operator 1.3.0 版本发布，包括兼容性改动、新功能、优化提升和 Bug 修复。兼容性改动包括跨集群部署 TiDB 集群升级操作，TiFlash 升级操作需注意。新增功能包括支持内部组件访问 TiDB 时跳过服务端证书验证、设置所有组件 Pod 的 DNS 配置等。优化提升包括部署或更新组件的 StatefulSet 预先检查配置的 VolumeMount 是否存在，跨集群部署 TiDB 集群功能增强。Bug 修复包括修复 Kubernetes v1.23 及之后版本无法部署 tidb scheduler 的问题。
+- [TiDB Operator 1.3.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.0-beta.1.md): TiDB Operator 1.3.0-beta.1 发布日期为 2022 年 1 月 12 日。此版本的兼容性改动包括删除 Pod `ValidatingWebhook` 和 `MutatingWebhook`，升级后不会影响 TiDB 集群管理。升级到 1.3.0-beta.1 版本后，需要按照操作来升级 TiDB Operator。此版本还支持新功能和优化提升，包括支持 TiFlash 的 init container 配置资源使用量，支持持续性能分析，以及优化 TidbMonitor 部署示例等。
+- [TiDB Operator 1.3.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.1.md): TiDB Operator 1.3.1 版本发布日期为 2022 年 2 月 24 日。此版本修复了 TiFlash 丢失元数据的问题，并添加了新的 `spec.dnsPolicy` 字段以支持配置 Pod 的 DNSPolicy。另外，`tidb-lightning` Helm chart 默认后端改为使用 `local`。还修复了 TiFlash 配置中缺少 `tmp_path` 字段时无法使用 TiFlash v5.4.0 及以后版本的问题，以及 Discovery 服务错误导致 TiDB 集群 PD 组件启动失败的问题。
+- [TiDB Operator 1.3.10 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.10.md): TiDB Operator 1.3.10 发布，优化提升包括升级 Golang 版本到 1.19 以修复安全漏洞。
+- [TiDB Operator 1.3.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.2.md): TiDB Operator 1.3.2 版本发布，优化支持在启用 Istio 的 Kubernetes 集群上部署与运行 TiDB，支持多架构 Docker 镜像包括 ARM 系统。
+- [TiDB Operator 1.3.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.3.md): TiDB Operator 1.3.3 发布，新增了 `spec.tidb.service.port` 字段，修复了集群升级过程中可能泄漏的问题，更新了 `tidb-backup-manager` 镜像的基础镜像，修复了不兼容 ARM 架构的问题，修复了当 tidb Service 没有 Endpoint 时可能会 panic 的问题，修复了 Kubernetes 集群访问失败并重试后组件 Pod 的 Labels 和 Annotations 可能丢失的问题。
+- [TiDB Operator 1.3.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.4.md): TiDB Operator 1.3.4 发布，优化提升包括在各个组件的状态信息中添加了 `volumes` 字段，以展示存储卷状态。
+- [TiDB Operator 1.3.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.5.md): TiDB Operator 1.3.5 发布，新增功能支持使用 Azure Blob Storage 备份与恢复 TiDB 集群数据。
+- [TiDB Operator 1.3.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.6.md): TiDB Operator 1.3.6 版本发布日期为 2022 年 7 月 5 日。此版本优化了扩容 PVC 对集群性能的影响，现在扩容 PVC 时按照 Pod 一个个扩容，并且在扩容 TiKV 的 PVC 前会先驱逐该 TiKV 上的 leader。
+- [TiDB Operator 1.3.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.7.md): TiDB Operator 1.3.7 版本发布，新增了暂停组件功能，优化了扩容完成后重建 StatefulSet 的流程，修复了本地存储升级 TiKV 和清理备份文件后残留的问题。
+- [TiDB Operator 1.3.8 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.8.md): TiDB Operator 1.3.8 版本发布，新增了为 `TidbCluster` 添加特殊 Annotation 的功能，支持配置 TiDB、TiKV 和 TiFlash 的 Pod 的最小等待时间。此外，还优化了支持优雅升级版本大于或等于 6.3.0 的 TiCDC pod。
+- [TiDB Operator 1.3.9 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.9.md): TiDB Operator 1.3.9 发布，修复了在已设置 `acrossK8s` 字段但未设置 `clusterDomain` 的情况下，PD 升级流程会卡住的问题。
+- [TiDB Operator 1.4. Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.7.md): TiDB Operator 1.4.7 发布，修复了 BackupSchedule CR 字段中的 `logBackupTemplate` 字段变成可选值的问题。
+- [TiDB Operator 1.4.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0.md): TiDB Operator 1.4.0 版本发布，新增支持独立管理 TiDB Dashboard，配置 TiKV 和 PD 的 Readiness Probe，以及基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复。优化支持 IPv6 网络环境，修复了基于 EBS 快照备份无法恢复到不同 namespace 的问题和日志备份停止占用 Complete 状态的 bug。
+- [TiDB Operator 1.4.0-alpha.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-alpha.1.md): TiDB Operator 1.4.0-alpha.1 发布，包含兼容性改动、滚动升级改动、新功能、优化提升和错误修复。新增自动设置 TiDB 的 location labels、新字段 `spec.tikv.scalePolicy` 与 `spec.tiflash.scalePolicy`、`startScriptVersion` 字段、BR 恢复集群到备份时间点、feature gate `VolumeModifying`、修改存储参数、配置 BR 的 `--check-requirements` 参数、使用字段 `additionalContainers` 自定义 Pod 容器配置。优化了 `TidbMonitor` 使用的 Prometheus 的 remoteWrite 配置和 TiFlash `Service` 添加 metric 端口。修复了集群扩缩容时的问题和 PD spec 为空导致 TiDB Operator 崩溃的问题。
+- [TiDB Operator 1.4.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.1.md): TiDB Operator 1.4.0-beta.1 发布，新增支持基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复（实验特性），修复了日志备份的 checkpoint ts 无法更新的问题。
+- [TiDB Operator 1.4.0-beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.2.md): TiDB Operator 1.4.0-beta.2 发布日期为 2022 年 11 月 11 日。此版本修复了使用 Azure Blob Storage 时未设置前缀的问题，并升级了 AWS SDK 到 v1.44.72 以支持使用 AWS 的 Asia Pacific (Jakarta) 区域 (`ap-southeast-3`)。
+- [TiDB Operator 1.4.0-beta.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.3.md): TiDB Operator 1.4.0-beta.3 发布，新增 TiProxy 实验性支持和基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复 GA。修复了拼写错误和清理卷快照备份失败的问题，以及大规模 TiKV 节点下备份 TiDB 集群失败的问题。
+- [TiDB Operator 1.4.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.1.md): TiDB Operator 1.4.1 版本发布，新增故障自动转移功能，优化了 TiDB Controller Manager 中 Kubernetes 客户端的配置，修复了未配置 PV 权限时 TiDB Controller Manager panic 的问题。
+- [TiDB Operator 1.4.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.2.md): TiDB Operator 1.4.2 发布，修复了开启 `preferIPv6` 时 TiFlash 没有监听 IPv6 地址的问题。
+- [TiDB Operator 1.4.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.3.md): TiDB Operator 1.4.3 发布，修复了开启 `preferIPv6` 时 TiFlash 的 metric server 未监听正确 IPv6 地址的问题，以及在 AWS 环境中打开了 feature gate `VolumeModifying` 且 `StorageClass` 缺少 EBS 相关参数时 TiDB Operator 会一直尝试修改 EBS 参数的问题。
+- [TiDB Operator 1.4.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.4.md): TiDB Operator 1.4.4 发布，新增支持在已部署 TiFlash 的集群上使用卷快照备份和恢复，准确显示备份大小，支持重试快照备份，集成管理日志备份和快照备份。修复了使用非语义版本格式的 TiDB 镜像同步失败的问题，使用卷快照备份一个已缩容的集群后无法恢复数据的问题，卷快照备份可能崩溃的问题，卷快照恢复可能在最后阶段失败的问题。
+- [TiDB Operator 1.4.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.5.md): TiDB Operator 1.4.5 版本发布，优化了 TidbCluster 的错误处理相关 metrics 和 worker 队列相关 metrics，增加了 DM master 组件的 `startUpScriptVersion` 字段，以及跨 Kubernetes 集群滚动重启或缩容 TiCDC 集群的能力。同时修复了定时备份中取消 GC、Backup CR 字段可选值、TiDB Operator 未配置权限时的 panic 问题，以及 TidbCluster 中设置 `AdditionalVolumeMounts` 时可能的 panic 问题。
+- [TiDB Operator 1.4.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.6.md): TiDB Operator 1.4.6 发布，优化默认启用 volume resize 支持，修复备份恢复时报错问题，修复 TiCDC image tag 不符合语义化版本时无法 Graceful Drain TiCDC 的问题。
+- [TiDB Operator 1.5.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.0.md): 了解 TiDB Operator 1.5.0 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator 1.5.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.0-beta.1.md): TiDB Operator 1.5.0-beta.1 发布，新增支持优雅重启 PD 和 TiDB Pod，使用 Advanced StatefulSet 管理 TiCDC 和 TiProxy，新增 TiDB Spec 字段，允许用户定义策略重启失败备份任务，升级 Kubernetes 依赖库至 v1.20 版本，添加与 reconciler 和 worker queue 相关的 Metric，优化滚动升级 TiKV 节点性能，允许用户自定义 Prometheus Scraping 相关配置，TiProxy 支持共享部分 TiDB 证书，配置 `spec.preferIPv6` 为 `true` 时，Service 的 `ipFamilyPolicy` 将配置为 `PreferDualStack`，添加统计协调流程失败计数的 Metric，修复了因为 metric 接口冲突而导致 pprof 接口无法访问的问题。
+- [TiDB Operator 1.5.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.1.md): TiDB Operator 1.5.1 发布，新增支持替换 PD、TiKV 和 TiDB 所使用的 volume。修复了多个 Bug，包括手动触发 TiKV eviction 时 PVC Modifier 报错的问题，替换 TiKV volume 过程中再触发 TiKV eviction 时可能造成 TiDB Operator reconcile 死锁的问题，TidbCluster 在 Upgrade 过程中可能无法回滚的问题，以及 MaxReservedTime 选项没有被 backup schedule gc 使用的问题。
+- [TiDB Operator 1.5.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.2.md): TiDB Operator 1.5.2 版本新增了对 AWS EBS 快照的备份能力的跨多个 K8S 集群的支持。优化了重启 PD、TiKV 时的启动流程，修复了替换 volume 时可能出现的问题。
+- [TiDB Operator 1.5.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.3.md): 了解 TiDB Operator 1.5.3 版本的新功能和 Bug 修复。
+- [TiDB Operator 1.5.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.4.md): 了解 TiDB Operator 1.5.4 版本的优化提升和 Bug 修复。
+- [TiDB Operator 1.5.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.5.md): 了解 TiDB Operator 1.5.5 版本的新功能和优化提升。
+- [TiDB Operator 1.6.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.0.md): 了解 TiDB Operator 1.6.0 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator 1.6.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.0-beta.1.md): 了解 TiDB Operator 1.6.0-beta.1 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator 1.6.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.1.md): 了解 TiDB Operator 1.6.1 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator RBAC 规则](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-operator-rbac.md): 介绍 TiDB Operator 需要的 RBAC 规则。
+- [TiDB Operator v1.6 新特性](https://docs.pingcap.com/tidb-in-kubernetes/stable/whats-new-in-v1.6.md): 了解 TiDB Operator 1.6.0 版本引入的新特性。
+- [TiDB Operator 架构](https://docs.pingcap.com/tidb-in-kubernetes/stable/architecture.md): 了解 TiDB Operator 架构及其工作原理。
+- [TiDB Operator 简介](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-operator-overview.md): 介绍 TiDB Operator 的整体架构及使用方式。
+- [TiDB Scheduler 扩展调度器](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-scheduler.md): 了解 TiDB Scheduler 扩展调度器及其工作原理。
+- [TiDB 集群的监控与告警](https://docs.pingcap.com/tidb-in-kubernetes/stable/monitor-a-tidb-cluster.md): 介绍如何监控 TiDB 集群。
+- [TidbMonitor 分片功能](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-monitor-shards.md): 如何使用 TidbMonitor 分片功能
+- [TidbMonitor 开启动态配置功能](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-monitor-dynamic-configuration.md): 动态更新 TidbMonitor 配置
+- [为 DM 开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-dm.md): 在 Kubernetes 上如何为 DM 开启 TLS。
+- [为 MySQL 客户端开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-mysql-client.md): 在 Kubernetes 上如何为 TiDB 集群的 MySQL 客户端开启 TLS。
+- [为 TiDB 组件间开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-between-components.md): 在 Kubernetes 上如何为 TiDB 集群组件间开启 TLS。
+- [为使用云存储的 TiDB 集群更换节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/replace-nodes-for-cloud-disk.md): 介绍如何为使用云存储的 TiDB 集群更换节点。
+- [为使用本地存储的 TiDB 集群更换节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/replace-nodes-for-local-disk.md): 介绍如何为使用本地存储的 TiDB 集群更换节点。
+- [为已有 TiDB 集群部署 HTAP 存储引擎 TiFlash](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tiflash.md): 了解如何在 Kubernetes 上为已有 TiDB 集群部署 TiDB HTAP 存储引擎 TiFlash。
+- [为已有 TiDB 集群部署异构集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-heterogeneous-tidb-cluster.md): 本文档介绍如何为已有的 TiDB 集群部署一个异构集群。
+- [为已有 TiDB 集群部署负载均衡 TiProxy](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tiproxy.md): 了解如何在 Kubernetes 上为已有 TiDB 集群部署负载均衡 TiProxy。
+- [从 Helm 2 迁移到 Helm 3](https://docs.pingcap.com/tidb-in-kubernetes/stable/migrate-to-helm3.md): 介绍如何将由 Helm 2 管理的组件迁移到由 Helm 3 管理。
+- [以非 root 用户运行容器](https://docs.pingcap.com/tidb-in-kubernetes/stable/containers-run-as-non-root-user.md): 了解如何以非 root 用户运行容器。
+- [使用 BR 备份 TiDB 集群到 GCS](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs-using-br.md): 介绍如何使用 BR 备份 TiDB 集群到 Google Cloud Storage (GCS)。
+- [使用 BR 备份 TiDB 集群数据到 Azure Blob Storage](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-azblob-using-br.md): 介绍如何使用 BR 备份 TiDB 集群数据到 Azure Blob Storage 上。
+- [使用 BR 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-aws-s3-using-br.md): 介绍如何使用 BR 备份 TiDB 集群数据到兼容 Amazon S3 的存储。
+- [使用 BR 恢复 Azure Blob Storage 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-azblob-using-br.md): 介绍如何使用 BR 恢复 Azure Blob Storage 上的备份数据。
+- [使用 BR 恢复 GCS 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-gcs-using-br.md): 介绍如何使用 BR 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
+- [使用 BR 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-aws-s3-using-br.md): 介绍如何使用 BR 恢复 Amazon S3 兼容存储上的备份数据。
+- [使用 Dumpling 备份 TiDB 集群数据到 GCS](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs.md): 介绍如何使用 Dumpling 将 TiDB 集群数据备份到 Google Cloud Storage (GCS)。
+- [使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-s3.md): 介绍如何使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储。
+- [使用 PD Recover 恢复 PD 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/pd-recover.md): 了解如何使用 PD Recover 恢复 PD 集群。
+- [使用 PingCAP Clinic 诊断 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/clinic-user-guide.md): 详细介绍在使用 TiDB Operator 部署的集群上如何安装、使用 PingCAP Clinic 诊断服务进行数据采集和快速检查。
+- [使用 TiDB Lightning 恢复 GCS 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-gcs.md): 介绍如何使用 TiDB Lightning 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
+- [使用 TiDB Lightning 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-s3.md): 了解如何使用 TiDB Lightning 将兼容 S3 存储上的备份数据恢复到 TiDB 集群。
+- [使用多套 TiDB Operator 单独管理不同的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-multiple-tidb-operator.md): 介绍如何部署多套 TiDB Operator 分别管理不同的 TiDB 集群。
+- [修改 TiDB 集群配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/modify-tidb-configuration.md): 了解如何修改部署在 Kubernetes 上的 TiDB 的集群配置。
+- [升级 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster.md): 介绍如何升级 Kubernetes 上的 TiDB 集群。
+- [升级 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/upgrade-tidb-operator.md): 介绍如何升级 TiDB Operator。
+- [同步数据到开启 TLS 的下游服务](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-ticdc-sink.md): 了解在 Kubernetes 上如何同步数据到开启 TLS 的下游服务。
+- [在 ARM64 机器上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-cluster-on-arm64.md): 本文档介绍如何在 ARM64 机器上部署 TiDB 集群
+- [在 AWS EKS 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-aws-eks.md): 介绍如何在 AWS EKS (Elastic Kubernetes Service) 上部署 TiDB 集群。
+- [在 Azure AKS 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-azure-aks.md): 介绍如何在 Azure AKS (Azure Kubernetes Service) 上部署 TiDB 集群。
+- [在 Google Cloud GKE 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-gcp-gke.md): 了解如何在 Google Cloud GKE 上部署 TiDB 集群。
+- [在 Kubernetes 上使用 DM](https://docs.pingcap.com/tidb-in-kubernetes/stable/use-tidb-dm.md): 了解如何在 Kubernetes 上使用 TiDB DM 迁移数据。
+- [在 Kubernetes 上快速上手 TiDB](https://docs.pingcap.com/tidb-in-kubernetes/stable/get-started.md): 介绍如何快速地在 Kubernetes 上使用 TiDB Operator 部署 TiDB 集群
+- [在 Kubernetes 上部署 DM](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-dm.md): 了解如何在 Kubernetes 上部署 TiDB DM 集群。
+- [在 Kubernetes 上部署 TiCDC](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-ticdc.md): 了解如何在 Kubernetes 上部署 TiCDC。
+- [在 Kubernetes 上部署 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-operator.md): 了解如何在 Kubernetes 上部署 TiDB Operator。
+- [在标准 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-general-kubernetes.md): 介绍如何在标准 Kubernetes 集群上通过 TiDB Operator 部署 TiDB 集群。
+- [基于 AWS EBS 卷快照的备份](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-aws-s3-by-snapshot.md): 介绍如何基于 EBS 卷快照使用 TiDB Operator 备份 TiDB 集群数据到 S3。
+- [基于 AWS EBS 卷快照的恢复](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-aws-s3-by-snapshot.md): 介绍如何将存储在 S3 上的备份元数据以及 EBS 卷快照恢复到 TiDB 集群。
+- [基于 EBS 卷快照备份恢复的性能介绍](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-snapshot-perf.md): 了解 EBS 卷快照备份恢复的性能基线。
+- [基于 EBS 卷快照的备份恢复功能架构](https://docs.pingcap.com/tidb-in-kubernetes/stable/volume-snapshot-backup-restore.md): 了解 TiDB EBS 卷快照的备份恢复架构设计。
+- [基于 EBS 快照备份恢复的常见问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-faq.md): 介绍卷快照备份恢复中的常见问题以及解决方案。
+- [增强型 StatefulSet 控制器](https://docs.pingcap.com/tidb-in-kubernetes/stable/advanced-statefulset.md): 介绍如何开启、使用增强型 StatefulSet 控制器
+- [备份 TiDB 集群到持久卷](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-pv-using-br.md): 介绍如何使用 BR 备份 TiDB 集群数据到持久卷。
+- [备份与恢复 CR 介绍](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-cr.md): 介绍用于备份与恢复的 Custom Resource (CR) 资源的各字段。
+- [备份与恢复简介](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-overview.md): 介绍如何使用 BR、Dumpling、TiDB Lightning 工具对 Kubernetes 上的 TiDB 集群进行数据备份和数据恢复。
+- [导入集群数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-data-using-tidb-lightning.md): 使用 TiDB Lightning 导入集群数据。
+- [将 TiDB 迁移至 Kubernetes](https://docs.pingcap.com/tidb-in-kubernetes/stable/migrate-tidb-to-kubernetes.md): 介绍如何将部署在物理机或虚拟机中的 TiDB 迁移至 Kubernetes 集群中
+- [开启 TiDB Operator 准入控制器](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-admission-webhook.md): 介绍如何开启 TiDB Operator 准入控制器以及它的作用。
+- [恢复持久卷上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-pv-using-br.md): 介绍如何将存储在持久卷上的备份数据恢复到 TiDB 集群。
+- [恢复误删的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/recover-deleted-cluster.md): 介绍如何恢复误删的 TiDB 集群。
+- [手动扩缩容 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/scale-a-tidb-cluster.md): 了解如何在 Kubernetes 上对 TiDB 集群手动扩缩容。
+- [挂起 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/suspend-tidb-cluster.md): 了解如何通过配置挂起 Kubernetes 上的 TiDB 集群。
+- [日志收集](https://docs.pingcap.com/tidb-in-kubernetes/stable/logs-collection.md): 介绍收集 TiDB 及相关组件日志的方法。
+- [暂停同步 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/pause-sync-of-tidb-cluster.md): 介绍如何暂停同步 Kubernetes 上的 TiDB 集群
+- [更新和替换 TLS 证书](https://docs.pingcap.com/tidb-in-kubernetes/stable/renew-tls-certificate.md): 介绍如何更新和替换 TiDB 组件间的 TLS 证书。
+- [构建多个网络互通的 AWS EKS 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/build-multi-aws-eks.md): 介绍如何构建多个 AWS EKS 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
+- [构建多个网络互通的 Google Cloud GKE 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/build-multi-gcp-gke.md): 介绍如何构建多个 Google Cloud GKE 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
+- [查看日志](https://docs.pingcap.com/tidb-in-kubernetes/stable/view-logs.md): 介绍如何查看 TiDB 集群各组件日志以及 TiDB 慢查询日志。
+- [灰度升级 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/canary-upgrade-tidb-operator.md): 介绍如何灰度升级 TiDB Operator，避免 TiDB Operator 升级对整个 Kubernetes 集群中的所有 TiDB 集群产生不可预知的影响。
+- [管理 TiDB 集群的 Command Cheat Sheet](https://docs.pingcap.com/tidb-in-kubernetes/stable/cheat-sheet.md): 介绍管理 TiDB 集群的 Command Cheat Sheet。
+- [维护 TiDB 集群所在的 Kubernetes 节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/maintain-a-kubernetes-node.md): 介绍如何维护 TiDB 集群所在的 Kubernetes 节点。
+- [聚合多个 TiDB 集群的监控数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/aggregate-multiple-cluster-monitor-data.md): 通过 Thanos 框架聚合多个 TiDB 集群的监控数据
+- [访问 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/access-tidb.md): 介绍如何访问 Kubernetes 上的 TiDB 集群。
+- [访问 TiDB Dashboard](https://docs.pingcap.com/tidb-in-kubernetes/stable/access-dashboard.md): 介绍如何在 Kubernetes 环境下访问 TiDB Dashboard
+- [跨多个 Kubernetes 集群监控 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-monitor-across-multiple-kubernetes.md): 介绍如何对跨多个 Kubernetes 集群的 TiDB 集群进行监控，并集成到常见 Prometheus 多集群监控体系中
+- [跨多个 Kubernetes 集群部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-cluster-across-multiple-kubernetes.md): 本文档介绍如何实现跨多个 Kubernetes 集群部署 TiDB 集群
+- [远程存储访问授权](https://docs.pingcap.com/tidb-in-kubernetes/stable/grant-permissions-to-remote-storage.md): 介绍如何授权访问远程存储。
+- [部署 TiDB Binlog](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-binlog.md): 了解如何在 Kubernetes 上部署 TiDB 集群的 TiDB Binlog。
+- [配置 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-a-tidb-cluster.md): 了解如何在 Kubernetes 中配置 TiDB 集群。
+- [重启 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/restart-a-tidb-cluster.md): 了解如何重启 Kubernetes 集群上的 TiDB 集群。
+- [销毁 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/destroy-a-tidb-cluster.md): 介绍如何销毁 Kubernetes 集群上的 TiDB 集群。

--- a/static/zh/llms.txt
+++ b/static/zh/llms.txt
@@ -4,6 +4,7 @@
 
 ## TiDB Self-Managed 文档（使用 TiUP 部署）
 
+- [TiDB Self-Managed 文档](https://docs.pingcap.com/zh/tidb/stable.md): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库。产品文档包括了 TiDB 简介、功能概览、TiFlash、快速上手 TiDB、HTAP、开发者手册概览、软硬件环境需求、使用 TiUP 部署 TiDB、数据迁移概览、运维、监控、调优、工具、TiDB 路线图、配置文件参数、命令行参数、TiDB Control、系统变量、发布历史、常见问题。
 - [TiDB 版本周期支持策略](https://cn.pingcap.com/tidb-release-support-policy/): 阐述了 PingCAP 就 TiDB 版本提供支持服务的标准和规则。
 - [50 TiB 数据导入最佳实践](https://docs.pingcap.com/zh/tidb/stable/data-import-best-practices.md): 了解将大规模数据导入 TiDB 的最佳实践。
 - [ADD COLUMN](https://docs.pingcap.com/zh/tidb/stable/sql-statement-add-column.md): TiDB 数据库中 ADD COLUMN 的使用概况。

--- a/static/zh/llms.txt
+++ b/static/zh/llms.txt
@@ -1,0 +1,1305 @@
+# TiDB 文档中心
+
+- [TiDB 文档中心](https://docs.pingcap.com/zh/): 欢迎来到 TiDB 文档中心！我们为您提供了丰富的操作指南和详实的参考资料，助您轻松上手 TiDB 产品，顺利完成数据迁移和基于数据库的应用开发等操作。
+
+## TiDB Self-Managed 文档（使用 TiUP 部署）
+
+- [TiDB 版本周期支持策略](https://cn.pingcap.com/tidb-release-support-policy/): 阐述了 PingCAP 就 TiDB 版本提供支持服务的标准和规则。
+- [50 TiB 数据导入最佳实践](https://docs.pingcap.com/tidb/stable/data-import-best-practices/): 了解将大规模数据导入 TiDB 的最佳实践。
+- [ADD COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-add-column/): TiDB 数据库中 ADD COLUMN 的使用概况。
+- [ADD INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-add-index/): TiDB 数据库中 ADD INDEX 的使用概况。
+- [ADMIN](https://docs.pingcap.com/tidb/stable/sql-statement-admin/): TiDB的 `ADMIN` 语句是用于查看TiDB状态和对表数据进行校验的扩展语法。其中包括 `ADMIN RELOAD`、`ADMIN PLUGIN`、`ADMIN ... BINDINGS`、`ADMIN REPAIR TABLE` 和 `ADMIN SHOW NEXT_ROW_ID` 等扩展语句。这些语句可以用于重新加载表达式下推的黑名单、启用或禁用插件、持久化 SQL Plan 绑定信息、修复表的元信息以及查看表中特殊列的详情。这些功能对于管理和维护 TiDB 数据库非常有用。
+- [ADMIN [SET|SHOW|UNSET] BDR ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-admin-bdr-role/): TiDB 数据库中 ADMIN [SET|SHOW|UNSET] BDR ROLE 的使用概况。
+- [ADMIN ALTER DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-alter-ddl/): TiDB 数据库中 `ADMIN ALTER DDL JOBS` 的使用概况。
+- [ADMIN CANCEL DDL](https://docs.pingcap.com/tidb/stable/sql-statement-admin-cancel-ddl/): TiDB 数据库中 ADMIN CANCEL DDL 的使用概况。
+- [ADMIN CHECK [TABLE|INDEX]](https://docs.pingcap.com/tidb/stable/sql-statement-admin-check-table-index/): TiDB 数据库中 ADMIN CHECK [TABLE|INDEX] 的使用概况。
+- [ADMIN CHECKSUM TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-admin-checksum-table/): TiDB 数据库中 ADMIN CHECKSUM TABLE 的使用概况。
+- [ADMIN CLEANUP INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-admin-cleanup/): TiDB 数据库中 ADMIN CLEANUP 的使用概况。
+- [ADMIN PAUSE DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-pause-ddl/): TiDB 数据库中 ADMIN PAUSE DDL JOBS 的使用概况。
+- [ADMIN RECOVER INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-admin-recover/): TiDB 数据库中 ADMIN RECOVER INDEX 的使用概况。
+- [ADMIN RESUME DDL JOBS](https://docs.pingcap.com/tidb/stable/sql-statement-admin-resume-ddl/): TiDB 数据库中 ADMIN RESUME DDL 的使用概况。
+- [ADMIN SHOW DDL [JOBS|JOB QUERIES]](https://docs.pingcap.com/tidb/stable/sql-statement-admin-show-ddl/): TiDB 数据库中 ADMIN SHOW DDL [JOBS|JOB QUERIES] 的使用概况。
+- [ALTER DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-database/): TiDB 数据库中 ALTER DATABASE 的使用概况。
+- [ALTER INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-alter-index/): TiDB 数据库中 ALTER INDEX 的使用概况。
+- [ALTER INSTANCE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-instance/): TiDB 数据库中 ALTER INSTANCE 的使用概况。
+- [ALTER PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-alter-placement-policy/): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
+- [ALTER RANGE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-range/): TiDB 数据库中 ALTER RANGE 的使用概况。
+- [ALTER RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-alter-resource-group/): TiDB 数据库中 ALTER RESOURCE GROUP 的使用概况。
+- [ALTER SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-sequence/): 介绍 ALTER SEQUENCE 在 TiDB 中的使用概况。
+- [ALTER TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-alter-table/): TiDB 数据库中 ALTER TABLE 的使用概况。
+- [ALTER TABLE ... COMPACT](https://docs.pingcap.com/tidb/stable/sql-statement-alter-table-compact/): TiDB 数据库中 ALTER TABLE ... COMPACT 语句的使用概况。
+- [ALTER USER](https://docs.pingcap.com/tidb/stable/sql-statement-alter-user/): TiDB 数据库中 ALTER USER 的使用概况。
+- [ANALYZE](https://docs.pingcap.com/tidb/stable/sql-statement-analyze-table/): TiDB 数据库中 ANALYZE 的使用概况。
+- [ANALYZE_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-analyze-status/): 了解 information_schema 表 `ANALYZE_STATUS`。
+- [AUTO_INCREMENT](https://docs.pingcap.com/tidb/stable/auto-increment/): 介绍 TiDB 的 `AUTO_INCREMENT` 列属性。
+- [AUTO_RANDOM](https://docs.pingcap.com/tidb/stable/auto-random/): 本文介绍了 TiDB 的 `AUTO_RANDOM` 列属性。
+- [BACKUP](https://docs.pingcap.com/tidb/stable/sql-statement-backup/): TiDB 数据库中 BACKUP 的使用概况。
+- [BATCH](https://docs.pingcap.com/tidb/stable/sql-statement-batch/): TiDB 数据库中 BATCH 的使用概况。
+- [BEGIN](https://docs.pingcap.com/tidb/stable/sql-statement-begin/): TiDB 数据库中 BEGIN 的使用概况。
+- [Bookshop 应用](https://docs.pingcap.com/tidb/stable/dev-guide-bookshop-schema-design/): Bookshop 应用设计、数据导入、连接数据库等操作。
+- [br 命令行手册](https://docs.pingcap.com/tidb/stable/use-br-command-line-tool/): 了解 br 命令行的定义、组成与使用。
+- [CALIBRATE RESOURCE](https://docs.pingcap.com/tidb/stable/sql-statement-calibrate-resource/): TiDB 数据库中 CALIBRATE RESOURCE 的使用概况。
+- [CANCEL IMPORT](https://docs.pingcap.com/tidb/stable/sql-statement-cancel-import-job/): TiDB 数据库中 CANCEL IMPORT 的使用概况。
+- [Cast 函数和操作符](https://docs.pingcap.com/tidb/stable/cast-functions-and-operators/): Cast 函数和操作符用于将某种数据类型的值转换为另一种数据类型。TiDB 支持使用 MySQL 8.0 中提供的所有 Cast 函数和操作符。
+- [CHANGE COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-change-column/): TiDB 数据库中 CHANGE COLUMN 的使用概况。
+- [Changefeed DDL 同步](https://docs.pingcap.com/tidb/stable/ticdc-ddl/): 了解 TiCDC 支持同步的 DDL 和一些特殊情况
+- [Changefeed 日志过滤器](https://docs.pingcap.com/tidb/stable/ticdc-filter/): 了解 TiCDC 的表过滤器和事件过滤器使用方法。
+- [Changefeed 概述](https://docs.pingcap.com/tidb/stable/ticdc-changefeed-overview/): 了解 Changefeed 的基本概念和 Changefeed 状态的定义与流转
+- [CHARACTER_SETS](https://docs.pingcap.com/tidb/stable/information-schema-character-sets/): 了解 INFORMATION_SCHEMA 表 `CHARACTER_SETS`。
+- [CHECK_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-check-constraints/): 了解 INFORMATION_SCHEMA 表 `CHECK_CONSTRAINTS`。
+- [CLIENT_ERRORS_SUMMARY_BY_HOST](https://docs.pingcap.com/tidb/stable/client-errors-summary-by-host/): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_HOST`。
+- [CLIENT_ERRORS_SUMMARY_BY_USER](https://docs.pingcap.com/tidb/stable/client-errors-summary-by-user/): 了解 INFORMATION_SCHEMA 表 `CLIENT_ERRORS_SUMMARY_BY_USER`。
+- [CLIENT_ERRORS_SUMMARY_GLOBAL](https://docs.pingcap.com/tidb/stable/client-errors-summary-global/): 了解 information_schema 表 `CLIENT_ERRORS_SUMMARY_GLOBAL`。
+- [CLUSTER_CONFIG](https://docs.pingcap.com/tidb/stable/information-schema-cluster-config/): 了解 information_schema 表 `CLUSTER_CONFIG`。
+- [CLUSTER_HARDWARE](https://docs.pingcap.com/tidb/stable/information-schema-cluster-hardware/): 了解 TiDB 集群硬件表 `CLUSTER_HARDWARE`。
+- [CLUSTER_INFO](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info/): 了解 TiDB 集群拓扑表 `CLUSTER_INFO`。
+- [CLUSTER_LOAD](https://docs.pingcap.com/tidb/stable/information-schema-cluster-load/): 了解 information_schema 表 `CLUSTER_LOAD`。
+- [CLUSTER_LOG](https://docs.pingcap.com/tidb/stable/information-schema-cluster-log/): 了解 information_schema 表 `CLUSTER_LOG`。
+- [CLUSTER_SYSTEMINFO](https://docs.pingcap.com/tidb/stable/information-schema-cluster-systeminfo/): 了解 TiDB 集群负载表 `CLUSTER_SYSTEMINFO`。
+- [COLLATION_CHARACTER_SET_APPLICABILITY](https://docs.pingcap.com/tidb/stable/information-schema-collation-character-set-applicability/): 了解 INFORMATION_SCHEMA 表 `COLLATION_CHARACTER_SET_APPLICABILITY`。
+- [COLLATIONS](https://docs.pingcap.com/tidb/stable/information-schema-collations/): 了解 information_schema 表 `COLLATIONS`。
+- [COLUMNS](https://docs.pingcap.com/tidb/stable/information-schema-columns/): 了解 INFORMATION_SCHEMA 表 `COLUMNS`。
+- [COMMIT](https://docs.pingcap.com/tidb/stable/sql-statement-commit/): TiDB 数据库中 COMMIT 的使用概况。
+- [CREATE [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/tidb/stable/sql-statement-create-binding/): TiDB 数据库中 CREATE [GLOBAL|SESSION] BINDING 的使用概况。
+- [CREATE DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-create-database/): TiDB 数据库中 CREATE DATABASE 的使用概况。
+- [CREATE INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-create-index/): CREATE INDEX 在 TiDB 中的使用概况
+- [CREATE PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-create-placement-policy/): TiDB 数据库中 CREATE PLACEMENT POLICY 的使用概况。
+- [CREATE RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group/): TiDB 数据库中 CREATE RESOURCE GROUP 的使用概况。
+- [CREATE ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-create-role/): TiDB 数据库中 CREATE ROLE 的使用概况。
+- [CREATE SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-create-sequence/): CREATE SEQUENCE 在 TiDB 中的使用概况
+- [CREATE TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-create-table/): TiDB 数据库中 CREATE TABLE 的使用概况
+- [CREATE TABLE LIKE](https://docs.pingcap.com/tidb/stable/sql-statement-create-table-like/): TiDB 数据库中 CREATE TABLE LIKE 的使用概况。
+- [CREATE USER](https://docs.pingcap.com/tidb/stable/sql-statement-create-user/): TiDB 数据库中 CREATE USER 的使用概况。
+- [CREATE VIEW](https://docs.pingcap.com/tidb/stable/sql-statement-create-view/): TiDB 数据库中 CREATE VIEW 的使用概况。
+- [Data Migration DDL 特殊处理说明](https://docs.pingcap.com/tidb/stable/dm-ddl-compatible/): 数据迁移中，根据不同的 DDL 语句和场景，采用不同处理方式。DM 不支持的 DDL 语句会直接跳过。部分 DDL 语句在同步到下游前会进行改写。在合库合表迁移任务中，DDL 同步行为存在变更。Online DDL 特性也会对 DDL 事件进行特殊处理。
+- [Data Migration 中的 DML 同步机制](https://docs.pingcap.com/tidb/stable/dm-dml-replication-logic/): 了解 DM 核心处理单元 Sync 如何同步 DML 语句。
+- [Data Migration 常见问题](https://docs.pingcap.com/tidb/stable/dm-faq/): 数据迁移常见问题包括：DM 是否支持迁移阿里 RDS 和其他云数据库的数据、task 配置中的黑白名单的正则表达式是否支持非获取匹配、处理不兼容的 DDL 语句、重置数据迁移任务、全量导入过程中遇到报错等。
+- [Data Migration 架构](https://docs.pingcap.com/tidb/stable/dm-arch/): Data Migration 架构包括三个组件：DM-master，DM-worker 和 dmctl。DM-master 负责管理和调度数据迁移任务的各项操作。DM-worker 执行具体的数据迁移任务。dmctl 是用来控制 DM 集群的命令行工具。 DM 集群的拓扑信息、数据迁移任务的运行状态和管理统一入口都由 DM-master 负责。DM-worker 负责持久化保存 binlog 数据、保存数据迁移子任务的配置信息和监控数据迁移子任务的运行状态。dmctl 用来创建、更新或删除数据迁移任务、查看数据迁移任务状态、处理数据迁移任务错误和校验数据迁移任务配置的正确性。 Data Migration 高可用机制可以进一步探索。
+- [Data Migration 高可用机制](https://docs.pingcap.com/tidb/stable/dm-high-availability/): 了解 Data Migration (DM) 高可用的内部机制，以及对迁移任务的影响。
+- [DATA_LOCK_WAITS](https://docs.pingcap.com/tidb/stable/information-schema-data-lock-waits/): 了解 information_schema 表 `DATA_LOCK_WAITS`。
+- [DDL 语句的执行原理及最佳实践](https://docs.pingcap.com/tidb/stable/ddl-introduction/): 介绍 TiDB 中 DDL 语句的实现原理、在线变更过程、最佳实践等内容。
+- [DDL_JOBS](https://docs.pingcap.com/tidb/stable/information-schema-ddl-jobs/): 了解 information_schema 表 `DDL_JOBS`。
+- [DEADLOCKS](https://docs.pingcap.com/tidb/stable/information-schema-deadlocks/): 了解 INFORMATION_SCHEMA 表 `DEADLOCKS`。
+- [DEALLOCATE](https://docs.pingcap.com/tidb/stable/sql-statement-deallocate/): TiDB 数据库中 DEALLOCATE 的使用概况。
+- [DELETE](https://docs.pingcap.com/tidb/stable/sql-statement-delete/): TiDB 数据库中 DELETE 的使用概况。
+- [在 Kubernetes 上部署 DM](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tidb-dm/): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/deploy-tidb-dm
+- [DESC](https://docs.pingcap.com/tidb/stable/sql-statement-desc/): TiDB 数据库中 DESC 的使用概况。
+- [DESCRIBE](https://docs.pingcap.com/tidb/stable/sql-statement-describe/): TiDB 数据库中 DESCRIBE 的使用概况。
+- [Distinct 优化](https://docs.pingcap.com/tidb/stable/agg-distinct-optimization/): 本文介绍了对于 DISTINCT 的优化，包括简单 DISTINCT 和聚合函数 DISTINCT 的优化。简单的 DISTINCT 通常会被优化成 GROUP BY 来执行。而带有 DISTINCT 的聚合函数会在 TiDB 侧单线程执行，可以通过系统变量或 TiDB 配置项控制优化器是否执行。在优化后，DISTINCT 被下推到了 Coprocessor，在 HashAgg 里新增了一个 group by 列。
+- [DM 5.4.0 性能测试报告](https://docs.pingcap.com/tidb/stable/dm-benchmark-v5.4.0/): 了解 DM 5.4.0 版本的性能。
+- [DM Relay Log](https://docs.pingcap.com/tidb/stable/relay-log/): 了解目录结构、初始迁移规则和 DM relay log 的数据清理。
+- [DM Table Selector](https://docs.pingcap.com/tidb/stable/table-selector/): 介绍 DM 的 Table Selector
+- [DM 任务完整配置文件介绍](https://docs.pingcap.com/tidb/stable/task-configuration-file-full/): 本文介绍了 Data Migration (DM) 的任务完整配置文件，包括全局配置和实例配置两部分。全局配置包括任务基本信息配置和功能配置集，功能配置集包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers。实例配置定义了具体的数据迁移子任务，包括路由规则、过滤规则、block-allow-list、mydumpers、loaders 和 syncers 的配置名称。
+- [DM 告警信息](https://docs.pingcap.com/tidb/stable/dm-alert-rules/): 介绍 DM 的告警信息。
+- [DM 增量数据校验](https://docs.pingcap.com/tidb/stable/dm-continuous-data-validation/): 了解增量数据校验的原理，以及如何使用增量数据校验功能。
+- [DM 安全模式](https://docs.pingcap.com/tidb/stable/dm-safe-mode/): 介绍 DM safe mode 作用和原理
+- [DM 数据迁移最佳实践](https://docs.pingcap.com/tidb/stable/dm-best-practices/): 了解使用 TiDB Data Migration (DM) 进行数据迁移的一些最佳实践。
+- [DM 监控指标](https://docs.pingcap.com/tidb/stable/monitor-a-dm-cluster/): 介绍 DM 的监控指标
+- [DM 自定义加解密 key](https://docs.pingcap.com/tidb/stable/dm-customized-secret-key/): 介绍如何自定义密钥，用于加密和解密 DM（Data Migration）数据源和迁移任务配置中的密码。
+- [DM 配置优化](https://docs.pingcap.com/tidb/stable/dm-tune-configuration/): 介绍如何通过优化配置来提高数据迁移性能。
+- [DM 配置简介](https://docs.pingcap.com/tidb/stable/dm-config-overview/): 本文简要介绍了 DM（数据迁移）的配置文件和数据迁移任务的配置。配置文件包括 dm-master.toml、dm-worker.toml 和 source.yaml，分别用于配置 DM-master 进程、DM-worker 进程和上游数据库 MySQL/MariaDB。创建数据迁移任务的具体步骤包括使用 dmctl 加载数据源配置、参考数据任务配置向导创建 your_task.yaml 文件，以及使用 dmctl 创建数据迁移任务。关键概念包括 source-id、DM-master ID 和 DM-worker ID，分别用于唯一确定 MySQL 或 MariaDB 实例、DM-master 和 DM-worker。
+- [DM 集群性能测试](https://docs.pingcap.com/tidb/stable/dm-performance-test/): 了解如何测试 DM 集群的性能。
+- [DM-master 配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-master-configuration-file/): 本文介绍了 DM-master 的配置文件，包括示例配置和配置项说明。示例配置包括日志配置、DM-master 监听地址、集群配置等。配置项说明包括全局配置，如标识 DM-master、日志级别、日志文件、地址等。另外还包括 SSL 证书路径、证书检查 Common Name 列表和加解密密钥路径等内容。
+- [DM-worker 简介](https://docs.pingcap.com/tidb/stable/dm-worker-intro/): DM-worker 是 DM (Data Migration) 的一个组件，负责执行数据迁移任务。主要功能包括注册为 MySQL 或 MariaDB 服务器的 slave，读取 binlog event 并持久化保存在本地，支持迁移一个 MySQL 或 MariaDB 实例的数据到多个 TiDB 实例，以及支持迁移多个 MySQL 或 MariaDB 实例的数据到一个 TiDB 实例。处理单元包括 Relay log、dump、load 和 Binlog replication/sync。上游数据库用户需具有 SELECT、RELOAD、REPLICATION SLAVE 和 REPLICATION CLIENT 权限，下游数据库用户需具有 SELECT、INSERT、UPDATE、DELETE、CREATE、DROP 和 INDEX 权限。处理单元所需的最小权限根据具体情况可能会改变。
+- [DM-worker 配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-worker-configuration-file/): 本文介绍了 DM-worker 的配置文件，包括配置文件示例和配置项说明。配置文件示例包括了 worker 的名称、日志配置、worker 的地址等内容。配置项说明包括了全局配置中的各个配置项的说明，如 name、log-level、log-file 等。同时还介绍了一些新增的配置项，如 relay-keepalive-ttl 和 relay-dir。SSL 相关的配置项也有详细说明。
+- [DO | TiDB SQL Statement Reference](https://docs.pingcap.com/tidb/stable/sql-statement-do/): TiDB 数据库中 DO 的使用概况。
+- [DROP [GLOBAL|SESSION] BINDING](https://docs.pingcap.com/tidb/stable/sql-statement-drop-binding/): TiDB 数据库中 DROP [GLOBAL|SESSION] BINDING 的使用概况。
+- [DROP COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-drop-column/): TiDB 数据库中 DROP COLUMN 的使用概况。
+- [DROP DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-database/): TiDB 数据库中 DROP DATABASE 的使用概况。
+- [DROP INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-drop-index/): TiDB 数据库中 DROP INDEX 的使用概况。
+- [DROP PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-drop-placement-policy/): TiDB 数据库中 ALTER PLACEMENT POLICY 的使用概况。
+- [DROP RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-drop-resource-group/): TiDB 数据库中 DROP RESOURCE GROUP 的使用概况。
+- [DROP ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-role/): TiDB 数据库中 DROP ROLE 的使用概况。
+- [DROP SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-sequence/): TiDB 数据库中 DROP SEQUENCE 的使用概况。
+- [DROP STATS](https://docs.pingcap.com/tidb/stable/sql-statement-drop-stats/): TiDB 数据库中 DROP STATS 的使用概况。
+- [DROP TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-drop-table/): TiDB 数据库中 DROP TABLE 的使用概况。
+- [DROP USER](https://docs.pingcap.com/tidb/stable/sql-statement-drop-user/): TiDB 数据库中 DROP USER 的使用概况。
+- [DROP VIEW](https://docs.pingcap.com/tidb/stable/sql-statement-drop-view/): TiDB 数据库中 DROP VIEW 的使用概况。
+- [ENGINES](https://docs.pingcap.com/tidb/stable/information-schema-engines/): 了解 information_schema 表 `ENGINES`。
+- [EXECUTE](https://docs.pingcap.com/tidb/stable/sql-statement-execute/): TiDB 数据库中 EXECUTE 的使用概况。
+- [EXPLAIN](https://docs.pingcap.com/tidb/stable/sql-statement-explain/): TiDB 数据库中 EXPLAIN 的使用概况。
+- [EXPLAIN ANALYZE](https://docs.pingcap.com/tidb/stable/sql-statement-explain-analyze/): TiDB 数据库中 EXPLAIN ANALYZE 的使用概况。
+- [FLASHBACK CLUSTER](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-cluster/): TiDB 数据库中 FLASHBACK CLUSTER 的使用概况。
+- [FLASHBACK DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-database/): TiDB 数据库中 FLASHBACK DATABASE 的使用概况。
+- [FLASHBACK TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-flashback-table/): TiDB 4.0 引入了 `FLASHBACK TABLE` 语法，可在 GC 生命周期内恢复被 `DROP` 或 `TRUNCATE` 删除的表和数据。使用系统变量 `tidb_gc_life_time` 配置历史版本保留时间，默认为 `10m0s`。查询当前`safePoint`：`SELECT * FROM mysql.tidb WHERE variable_name = 'tikv_gc_safe_point'`。注意，过了 GC 生命周期就无法恢复被删除的数据。
+- [FLUSH PRIVILEGES](https://docs.pingcap.com/tidb/stable/sql-statement-flush-privileges/): TiDB 数据库中 FLUSH PRIVILEGES 的使用概况。
+- [FLUSH STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-flush-status/): TiDB 数据库中 FLUSH STATUS 的使用概况。
+- [FLUSH TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-flush-tables/): TiDB 数据库中 FLUSH TABLES 的使用概况。
+- [Follower Read](https://docs.pingcap.com/tidb/stable/dev-guide-use-follower-read/): 使用 Follower Read 在特定情况下加速查询。
+- [Follower Read](https://docs.pingcap.com/tidb/stable/follower-read/): 了解 Follower Read 的使用与实现。
+- [GBK](https://docs.pingcap.com/tidb/stable/character-set-gbk/): 本文介绍 TiDB 对 GBK 字符集的支持情况。
+- [GC 机制简介](https://docs.pingcap.com/tidb/stable/garbage-collection-overview/): TiDB 的事务实现采用了 MVCC 机制，GC 的任务是清理不再需要的旧数据。整体流程包括 GC leader 控制 GC 的运行，定期触发 GC，以及三个步骤：Resolve Locks 清理锁，Delete Ranges 删除区间，Do GC 进行 GC 清理。Resolve Locks 清理锁有两种执行模式：LEGACY 和 PHYSICAL。Delete Ranges 删除区间会快速物理删除待删除的区间及删除操作的时间戳。Do GC 进行 GC 清理会删除所有 key 的过期版本。GC 每 10 分钟触发一次，默认保留最近 10 分钟内的数据。
+- [GC 配置](https://docs.pingcap.com/tidb/stable/garbage-collection-configuration/): TiDB 的 GC 配置可以通过系统变量进行设置，包括启用 GC、运行间隔、数据保留时限、并发线程数量等。此外，TiDB 还支持 GC 流控，可以限制每秒数据写入量。从 TiDB 5.0 版本开始，建议使用系统变量进行配置，避免异常行为。在 TiDB 6.1.0 版本引入了新的系统变量 `tidb_gc_max_wait_time`，用于控制活跃事务阻塞 GC safe point 推进的最长时间。另外，GC in Compaction Filter 机制可以通过配置文件或在线配置开启，但可能会影响 TiKV 扫描性能。
+- [Gitpod](https://docs.pingcap.com/tidb/stable/dev-guide-playground-gitpod/): Gitpod 是一个开源 Kubernetes 应用程序，可在浏览器中获得完整的开发环境，并立即编写代码。它能够为云中的每个任务提供全新的自动化开发环境，无需本地配置。Gitpod 提供了完整的、自动化的、预配置的云原生开发环境，让你可以直接在浏览器中开发、运行、测试代码。
+- [GRANT <privileges>](https://docs.pingcap.com/tidb/stable/sql-statement-grant-privileges/): TiDB 数据库中 GRANT <privileges> 的使用概况。
+- [GRANT <role>](https://docs.pingcap.com/tidb/stable/sql-statement-grant-role/): TiDB 数据库中 GRANT <role> 的使用概况。
+- [GROUP BY 修饰符](https://docs.pingcap.com/tidb/stable/group-by-modifier/): 了解如何使用 TiDB GROUP BY 修饰符。
+- [GROUP BY 聚合函数](https://docs.pingcap.com/tidb/stable/aggregate-group-by-functions/): TiDB支持的聚合函数包括 COUNT、COUNT(DISTINCT)、SUM、AVG、MAX、MIN、GROUP_CONCAT、VARIANCE、VAR_POP、STD、STDDEV、VAR_SAMP、STDDEV_SAMP 和 JSON_OBJECTAGG。除了 GROUP_CONCAT 和 APPROX_PERCENTILE 外，这些聚合函数可以作为窗口函数使用。另外，TiDB 的 GROUP BY 子句支持 WITH ROLLUP 修饰符，还支持 SQL 模式 ONLY_FULL_GROUP_BY。与 MySQL 的区别在于 TiDB 对标准 SQL 有一些扩展，允许在 HAVING 子句中使用别名和非列表达式。
+- [HAProxy 在 TiDB 中的最佳实践](https://docs.pingcap.com/tidb/stable/haproxy-best-practices/): HAProxy 是 TiDB 中实现负载均衡的最佳实践。它提供 TCP 协议下的负载均衡能力，通过连接 HAProxy 提供的浮动 IP 对数据进行操作，实现 TiDB Server 层的负载均衡。HAProxy 提供高可用性、负载均衡、健康检查、会话保持、SSL 支持和监控统计等核心功能。部署 HAProxy 需要满足一定的硬件和软件要求，配置和启动 HAProxy 后即可实现数据库负载均衡。
+- [HTAP 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-htap/): 本文介绍如何快速上手体验 TiDB 的 HTAP 功能。
+- [HTAP 查询](https://docs.pingcap.com/tidb/stable/dev-guide-hybrid-oltp-and-olap-queries/): 介绍 TiDB 中的 HTAP 查询功能。
+- [HTAP 深入探索指南](https://docs.pingcap.com/tidb/stable/explore-htap/): 本文介绍如何深入探索并使用 TiDB 的 HTAP 功能。
+- [IMPORT INTO](https://docs.pingcap.com/tidb/stable/sql-statement-import-into/): TiDB 数据库中 IMPORT INTO 的使用概况。
+- [IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性](https://docs.pingcap.com/tidb/stable/tidb-lightning-compatibility-and-scenarios/): 了解 IMPORT INTO 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性及使用场景。
+- [IMPORT INTO 和 TiDB Lightning 对比](https://docs.pingcap.com/tidb/stable/import-into-vs-tidb-lightning/): 了解 `IMPORT INTO` 和 TiDB Lightning 的差异。
+- [Information Schema](https://docs.pingcap.com/tidb/stable/information-schema/): Information Schema 是一种查看系统元数据的 ANSI 标准方法。TiDB 提供了许多自定义的 `INFORMATION_SCHEMA` 表，包括与 MySQL 兼容的表和 TiDB 中的扩展表。这些表提供了关于字符集、排序规则、列、存储引擎、索引、表大小、慢查询等信息，帮助用户进行系统监控和优化。
+- [INSERT](https://docs.pingcap.com/tidb/stable/sql-statement-insert/): TiDB 数据库中 INSERT 的使用概况。
+- [INSPECTION_RESULT](https://docs.pingcap.com/tidb/stable/information-schema-inspection-result/): 了解 TiDB 系统表 `INSPECTION_RESULT`。
+- [INSPECTION_RULES](https://docs.pingcap.com/tidb/stable/information-schema-inspection-rules/): 了解 information_schema 表 `INSPECTION_RULES`。
+- [INSPECTION_SUMMARY](https://docs.pingcap.com/tidb/stable/information-schema-inspection-summary/): 了解 TiDB 系统表 `INSPECTION_SUMMARY`。
+- [Join Reorder 算法简介](https://docs.pingcap.com/tidb/stable/join-reorder/): Join Reorder 算法决定了多表 Join 的顺序，影响执行效率。TiDB 中有贪心算法和动态规划算法两种实现。贪心算法选择行数最小的表与其他表做 Join，直到所有节点完成 Join。动态规划算法枚举所有可能的 Join 顺序，选择最优的。算法受系统变量控制，且存在一些限制，如无法保证一定选到合适的 Join 顺序。
+- [JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions/): TiDB 支持 MySQL 8.0 中提供的大部分 JSON 函数。
+- [JSON 效用函数](https://docs.pingcap.com/tidb/stable/json-functions-utility/): 了解 JSON 效用函数。
+- [JSON 数据类型](https://docs.pingcap.com/tidb/stable/data-type-json/): JSON 类型存储半结构化数据，使用 Binary 格式序列化，加快查询和解析速度。JSON 字段不能创建索引，但可以对 JSON 文档中的子字段创建索引。TiDB 仅支持下推部分 JSON 函数到 TiFlash，不建议使用 BR 恢复包含 JSON 列的数据到 v6.3.0 之前的 TiDB 集群。请勿同步非标准 JSON 类型的数据。MySQL 误标记二进制类型数据为 STRING 类型，TiDB 保持正确的二进制类型。ENUM 或 SET 数据类型转换为 JSON 时，TiDB 会检查格式正确性。TiDB 支持使用 ORDER BY 对 JSON Array 或 JSON Object 进行排序。在 INSERT JSON 列时，TiDB 会将值隐式转换为 JSON。
+- [KEY_COLUMN_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-key-column-usage/): 了解 information_schema 表 `KEY_COLUMN_USAGE`。
+- [KEYWORDS](https://docs.pingcap.com/tidb/stable/information-schema-keywords/): 了解 INFORMATION_SCHEMA 表 `KEYWORDS`。
+- [KILL](https://docs.pingcap.com/tidb/stable/sql-statement-kill/): TiDB 数据库中 KILL 的使用概况。
+- [Load Base Split](https://docs.pingcap.com/tidb/stable/configure-load-base-split/): 介绍 Load Base Split 功能。
+- [LOAD DATA](https://docs.pingcap.com/tidb/stable/sql-statement-load-data/): TiDB 数据库中 LOAD DATA 的使用概况。
+- [LOAD STATS](https://docs.pingcap.com/tidb/stable/sql-statement-load-stats/): TiDB 数据库中 LOAD STATS 的使用概况。
+- [LOCK STATS](https://docs.pingcap.com/tidb/stable/sql-statement-lock-stats/): TiDB 数据库中 LOCK STATS 的使用概况。
+- [LOCK TABLES 和 UNLOCK TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-lock-tables-and-unlock-tables/): TiDB 数据库中 LOCK TABLES 和 UNLOCK TABLES 的使用概况。
+- [Max/Min 函数消除规则](https://docs.pingcap.com/tidb/stable/max-min-eliminate/): SQL 中的 max/min 函数消除规则能够将 max/min 聚合函数转换为 TopN 算子，利用索引进行查询。当只有一个 max/min 函数时，会重写为 select max(a) from (select a from t where a is not null order by a desc limit 1) t，利用索引只扫描一行数据。存在多个 max/min 函数时，会先检查列是否有索引能够保序，然后重写为两个子查询的笛卡尔积，最终避免对整个表的扫描。
+- [MEMORY_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-memory-usage/): 了解 information_schema 表 `MEMORY_USAGE`。
+- [MEMORY_USAGE_OPS_HISTORY](https://docs.pingcap.com/tidb/stable/information-schema-memory-usage-ops-history/): 了解 information_schema 表 `MEMORY_USAGE_OPS_HISTORY`。
+- [Metrics Schema](https://docs.pingcap.com/tidb/stable/metrics-schema/): 了解 TiDB `METRICS SCHEMA` 系统数据库。
+- [METRICS_SUMMARY](https://docs.pingcap.com/tidb/stable/information-schema-metrics-summary/): 了解 TiDB 系统表 `METRICS_SUMMARY`。
+- [METRICS_TABLES](https://docs.pingcap.com/tidb/stable/information-schema-metrics-tables/): 了解 TiDB 系统表 `METRICS_TABLES`。
+- [MODIFY COLUMN](https://docs.pingcap.com/tidb/stable/sql-statement-modify-column/): TiDB 数据库中 MODIFY COLUMN 的使用概况。
+- [mysql Schema](https://docs.pingcap.com/tidb/stable/mysql-schema/): 了解 TiDB 系统表。
+- [mysql.tidb_mdl_view](https://docs.pingcap.com/tidb/stable/mysql-schema-tidb-mdl-view/): 了解 `mysql` schema 中的 `tidb_mdl_view` 视图。
+- [mysql.user](https://docs.pingcap.com/tidb/stable/mysql-schema-user/): 了解 `mysql` 系统表 `user`。
+- [OLTP 负载性能优化实践](https://docs.pingcap.com/tidb/stable/performance-tuning-practices/): 本文档介绍了如何对 OLTP 负载进行性能分析和优化。
+- [Online Unsafe Recovery 使用文档](https://docs.pingcap.com/tidb/stable/online-unsafe-recovery/): 如何使用 Online Unsafe Recovery。
+- [Optimizer Fix Controls](https://docs.pingcap.com/tidb/stable/optimizer-fix-controls/): 了解 Optimizer Fix Controls 以及如何使用 `tidb_opt_fix_control` 细粒度地控制 TiDB 优化器的行为。
+- [Optimizer Hints](https://docs.pingcap.com/tidb/stable/optimizer-hints/): 介绍 TiDB 中 Optimizer Hints 的语法和不同生效范围的 Hint 的使用方法。
+- [Oracle 与 TiDB 函数和语法差异对照](https://docs.pingcap.com/tidb/stable/oracle-functions-to-tidb/): 了解 Oracle 与 TiDB 函数和语法差异对照。
+- [Overview 面板重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-overview-dashboard/): TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview。重要监控指标包括服务在线节点数量、PD 角色、存储容量、Region 数量、TiDB 执行数量、CPU 使用率、内存大小、网络流量等。详细监控说明可参见文章。
+- [Partitioned Raft KV](https://docs.pingcap.com/tidb/stable/partitioned-raft-kv/): 了解 TiKV 的 Partitioned Raft KV 特性。
+- [PARTITIONS](https://docs.pingcap.com/tidb/stable/information-schema-partitions/): 了解 INFORMATION_SCHEMA 表 `PARTITIONS`。
+- [PD Control 使用说明](https://docs.pingcap.com/tidb/stable/pd-control/): PD Control 是 PD 的命令行工具，用于获取集群状态信息和调整集群。
+- [PD Recover 使用文档](https://docs.pingcap.com/tidb/stable/pd-recover/): PD Recover 是用于恢复无法正常启动或服务的 PD 集群的工具。安装方式包括从源代码编译和下载 TiDB 工具包。恢复集群的方式有两种：从存活的 PD 节点重建和完全重建。从存活的 PD 节点重建集群需要停止所有节点，启动存活的 PD 节点，并使用 pd-recover 修复元数据。完全重建 PD 集群需要获取 Cluster ID 和已分配 ID，部署新的 PD 集群，使用 pd-recover 修复，然后重启整个集群。
+- [PD 微服务](https://docs.pingcap.com/tidb/stable/pd-microservices/): 介绍如何开启 PD 微服务模式，以提高服务质量。
+- [PD 微服务部署拓扑](https://docs.pingcap.com/tidb/stable/pd-microservices-deployment-topology/): 了解在部署最小拓扑集群的基础上，部署 PD 微服务的拓扑结构。
+- [PD 调度策略最佳实践](https://docs.pingcap.com/tidb/stable/pd-scheduling-best-practices/): 了解 PD 调度策略的最佳实践和调优方式
+- [PD 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-pd-configuration/): PD 配置参数可以通过命令行参数或环境变量配置。包括外部访问 PD 的 URL 列表，其他 PD 节点访问某个 PD 节点的 URL 列表，PD 监听的客户端 URL 列表，PD 节点监听其他 PD 节点的 URL 列表，配置文件，PD 存储数据路径，初始化 PD 集群配置，动态加入 PD 集群，Log 级别，Log 文件，是否开启日志切割，当前 PD 的名字，CA 文件路径，包含 X509 证书的 PEM 文件路径，包含 X509 key 的 PEM 文件路径，指定 Prometheus Pushgateway 的地址，强制使用当前节点创建新的集群，输出版本信息并退出。
+- [PD 配置文件描述](https://docs.pingcap.com/tidb/stable/pd-configuration-file/): PD 配置文件包含了许多参数，如节点名称、数据路径、客户端 URL、广告客户端 URL、节点 URL 等。还包括了一些实验性特性的配置项，如内存限制、GC 触发阈值、GOGC Tuner 等。此外，还有监控、调度、副本、标签、Dashboard、同步模式和资源控制等相关配置项。
+- [PD 重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-pd-dashboard/): PD 重要监控指标详解：使用 TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构参见 [TiDB 监控框架概述]。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。通过观察 PD 面板上的 Metrics，可以了解 PD 当前的状态。监控包括 PD role、Storage capacity、Current storage size、Current storage usage、Normal stores、Number of Regions、Abnormal stores、Region health、Current peer count 等。Cluster、Operator、Statistics - Balance、Statistics - hot write、Statistics - hot read、Scheduler、gRPC、etcd、TiDB、Heartbeat、Region storage 等指标也很重要。
+- [Performance Overview 面板重要监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-performance-overview-dashboard/): 本文介绍 Performance Overview 面板上监控指标的含义。
+- [Performance Schema](https://docs.pingcap.com/tidb/stable/performance-schema/): 了解 TiDB `performance_schema` 系统数据库。
+- [PingCAP Clinic 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-clinic/): 了解如何使用 PingCAP Clinic 诊断服务快速采集、上传、查看集群诊断数据。
+- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/tidb/stable/clinic-data-instruction-for-tiup/): 详细说明 PingCAP Clinic 诊断服务在使用 TiUP 部署的 TiDB 集群和 DM 集群中能够采集哪些诊断数据。
+- [PingCAP Clinic 诊断服务简介](https://docs.pingcap.com/tidb/stable/clinic-introduction/): 介绍 PingCAP Clinic 诊断服务，包括工具组件、使用场景和工作原理。
+- [Pipelined DML](https://docs.pingcap.com/tidb/stable/pipelined-dml/): 介绍 Pipelined DML 的使用场景、使用方法、使用限制和使用该功能的常见问题。Pipelined DML 增强了 TiDB 批量处理的能力，使得事务大小不再受到 TiDB 内存限制。
+- [Placement Rules in SQL](https://docs.pingcap.com/tidb/stable/placement-rules-in-sql/): 了解如何通过 SQL 接口调度表和分区的放置位置。
+- [Placement Rules 使用文档](https://docs.pingcap.com/tidb/stable/configure-placement-rules/): 如何配置 Placement Rules
+- [PLACEMENT_POLICIES](https://docs.pingcap.com/tidb/stable/information-schema-placement-policies/): 了解 information_schema 表 `PLACEMENT_POLICIES`。
+- [PREPARE](https://docs.pingcap.com/tidb/stable/sql-statement-prepare/): TiDB 数据库中 PREPARE 的使用概况。
+- [Prepare 语句执行计划缓存](https://docs.pingcap.com/tidb/stable/sql-prepared-plan-cache/): Prepare 语句执行计划缓存功能默认打开，可通过变量启用或关闭。缓存功能仅针对 Prepare/Execute 请求，对普通查询无效。缓存功能会有一定内存开销，可通过监控查看内存使用情况。可手动清空计划缓存，但不支持一次性清空整个集群的计划缓存。忽略 COM_STMT_CLOSE 指令和 DEALLOCATE PREPARE 语句，可解决计划被立即清理的问题。监控 Queries Using Plan Cache OPS 和 Plan Cache Miss OPS，以确保 SQL 执行计划缓存正常工作。Prepared Statement Count 图表显示非零值，表示应用使用了预处理语句。
+- [PROCESSLIST](https://docs.pingcap.com/tidb/stable/information-schema-processlist/): 了解 information_schema 表 `PROCESSLIST`。
+- [ProxySQL 集成指南](https://docs.pingcap.com/tidb/stable/dev-guide-proxysql-integration/): 了解如何将本地部署的 TiDB 或 TiDB Cloud 集群与 ProxySQL 集成。
+- [QUERY WATCH](https://docs.pingcap.com/tidb/stable/sql-statement-query-watch/): TiDB 数据库中 QUERY WATCH 的使用概况。
+- [RECOVER TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-recover-table/): RECOVER TABLE 是用来恢复被删除的表及其数据的功能。在 DROP TABLE 后，在 GC life time 时间内，可以使用 RECOVER TABLE 语句来恢复被删除的表以及其数据。如果删除表后并过了 GC lifetime，就不能再用 RECOVER TABLE 来恢复被删除的表了。
+- [REFERENTIAL_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-referential-constraints/): 了解 INFORMATION_SCHEMA 表 `REFERENTIAL_CONSTRAINTS`。
+- [Region 性能调优](https://docs.pingcap.com/tidb/stable/tune-region-performance/): 了解如何通过调整 Region 大小等方法对 Region 进行性能调优以及如何在大 Region 下使用 bucket 进行并发查询优化。
+- [RENAME INDEX](https://docs.pingcap.com/tidb/stable/sql-statement-rename-index/): TiDB 数据库中 RENAME INDEX 的使用概况。
+- [RENAME TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-rename-table/): TiDB 数据库中 RENAME TABLE 的使用概况。
+- [RENAME USER](https://docs.pingcap.com/tidb/stable/sql-statement-rename-user/): TiDB 数据库中 RENAME USER 的使用概况。
+- [REPLACE](https://docs.pingcap.com/tidb/stable/sql-statement-replace/): TiDB 数据库中 REPLACE 的使用概况。
+- [RESOURCE_GROUPS](https://docs.pingcap.com/tidb/stable/information-schema-resource-groups/): 了解 information_schema 表 `RESOURCE_GROUPS`。
+- [RESTORE](https://docs.pingcap.com/tidb/stable/sql-statement-restore/): TiDB 数据库中 RESTORE 的使用概况。
+- [REVOKE <privileges>](https://docs.pingcap.com/tidb/stable/sql-statement-revoke-privileges/): TiDB 数据库中 REVOKE <privileges> 的使用概况。
+- [REVOKE <role>](https://docs.pingcap.com/tidb/stable/sql-statement-revoke-role/): TiDB 数据库中 REVOKE <role> 的使用概况。
+- [RocksDB 简介](https://docs.pingcap.com/tidb/stable/rocksdb-overview/): RocksDB 是 Facebook 基于 LevelDB 开发的 LSM-tree 架构引擎，提供键值存储与读写功能。数据先写入磁盘上的 WAL，再写入内存中的跳表。内存数据达到阈值后刷到磁盘生成 SST 文件，分为多层，90% 数据存储在最后一层。RocksDB 允许创建多个 ColumnFamily，共享同一个 WAL 文件。为提高读取性能，文件按大小切分成 block，存在 BlockCache 中。后台线程执行 MemTable 转化为 SST 文件和合并操作。L0 文件数量过多会触发 WriteStall 阻塞写入。
+- [ROLLBACK](https://docs.pingcap.com/tidb/stable/sql-statement-rollback/): TiDB 数据库中 ROLLBACK 的使用概况。
+- [RUNAWAY_WATCHES](https://docs.pingcap.com/tidb/stable/information-schema-runaway-watches/): 了解 INFORMATION_SCHEMA 表 `RUNAWAY_WATCHES`。
+- [Runtime Filter](https://docs.pingcap.com/tidb/stable/runtime-filter/): 介绍 Runtime Filter 的原理及使用方式。
+- [SaaS 多租户场景最佳实践](https://docs.pingcap.com/tidb/stable/saas-best-practices/): 介绍 TiDB 在 SaaS (Software as a service) 多租户场景的最佳实践，特别适用于单集群表数量超过百万级别的场景。
+- [SAVEPOINT](https://docs.pingcap.com/tidb/stable/sql-statement-savepoint/): TiDB 数据库中 SAVEPOINT 的使用概况。
+- [Scale A Tidb Cluster](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/scale-a-tidb-cluster): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/scale-a-tidb-cluster
+- [Scheduling 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-scheduling-configuration/): Scheduling 配置参数可以通过命令行参数或环境变量配置。
+- [Scheduling 配置文件描述](https://docs.pingcap.com/tidb/stable/scheduling-configuration-file/): Scheduling 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
+- [Schema 对象名](https://docs.pingcap.com/tidb/stable/schema-object-names/): 本文介绍 TiDB SQL 语句中的模式对象名。
+- [Schema 缓存](https://docs.pingcap.com/tidb/stable/schema-cache/): TiDB 对于 schema 信息采用基于 LRU 的缓存机制，在大量数据库和表的场景下能够显著减少 schema 信息的内存占用以及提高性能。
+- [schema_unused_indexes](https://docs.pingcap.com/tidb/stable/sys-schema-unused-indexes/): 了解 TiDB `sys` 系统数据库中的 `schema_unused_indexes` 表。
+- [SCHEMATA](https://docs.pingcap.com/tidb/stable/information-schema-schemata/): 了解 information_schema 表 `SCHEMATA`。
+- [SELECT](https://docs.pingcap.com/tidb/stable/sql-statement-select/): TiDB 数据库中 SELECT 的使用概况。
+- [SEQUENCES](https://docs.pingcap.com/tidb/stable/information-schema-sequences/): 了解 INFORMATION_SCHEMA 表 `SEQUENCES`。
+- [SESSION_CONNECT_ATTRS](https://docs.pingcap.com/tidb/stable/performance-schema-session-connect-attrs/): 了解 performance_schema 表 `SESSION_CONNECT_ATTRS`。
+- [SESSION_VARIABLES](https://docs.pingcap.com/tidb/stable/information-schema-session-variables/): 了解 INFORMATION_SCHEMA 表 `SESSION_VARIABLES`。
+- [SET [GLOBAL|SESSION] <variable>](https://docs.pingcap.com/tidb/stable/sql-statement-set-variable/): TiDB 数据库中 SET [GLOBAL|SESSION] <variable> 的使用概况。
+- [SET [NAMES|CHARACTER SET]](https://docs.pingcap.com/tidb/stable/sql-statement-set-names/): TiDB 数据库中 SET [NAMES|CHARACTER SET] 的使用概况。
+- [SET DEFAULT ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-set-default-role/): TiDB 数据库中 SET DEFAULT ROLE 的使用概况。
+- [SET PASSWORD](https://docs.pingcap.com/tidb/stable/sql-statement-set-password/): TiDB 数据库中 SET PASSWORD 的使用概况。
+- [SET RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-set-resource-group/): TiDB 数据库中 SET RESOURCE GROUP 的使用概况。
+- [SET ROLE](https://docs.pingcap.com/tidb/stable/sql-statement-set-role/): TiDB 数据库中 SET ROLE 的使用概况。
+- [SET TRANSACTION](https://docs.pingcap.com/tidb/stable/sql-statement-set-transaction/): TiDB 数据库中 SET TRANSACTION 的使用概况。
+- [SHARD_ROW_ID_BITS](https://docs.pingcap.com/tidb/stable/shard-row-id-bits/): 介绍 TiDB 的 `SHARD_ROW_ID_BITS` 表属性。
+- [SHOW [BACKUPS|RESTORES]](https://docs.pingcap.com/tidb/stable/sql-statement-show-backups/): TiDB 数据库中 SHOW [BACKUPS|RESTORES] 的使用概况。
+- [SHOW [FULL] COLUMNS FROM](https://docs.pingcap.com/tidb/stable/sql-statement-show-columns-from/): TiDB 数据库中 SHOW [FULL] COLUMNS FROM 的使用概况。
+- [SHOW [FULL] FIELDS FROM](https://docs.pingcap.com/tidb/stable/sql-statement-show-fields-from/): TiDB 数据库中 SHOW [FULL] FIELDS FROM 的使用概况。
+- [SHOW [FULL] PROCESSLIST](https://docs.pingcap.com/tidb/stable/sql-statement-show-processlist/): TiDB 数据库中 SHOW [FULL] PROCESSLIST 的使用概况。
+- [SHOW [FULL] TABLES](https://docs.pingcap.com/tidb/stable/sql-statement-show-tables/): TiDB 数据库中 SHOW [FULL] TABLES 的使用概况。
+- [SHOW [GLOBAL|SESSION] BINDINGS](https://docs.pingcap.com/tidb/stable/sql-statement-show-bindings/): TiDB 数据库中 SHOW [GLOBAL|SESSION] BINDINGS 的使用概况。
+- [SHOW [GLOBAL|SESSION] STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-status/): TiDB 数据库中 SHOW [GLOBAL|SESSION] STATUS 的使用概况。
+- [SHOW [GLOBAL|SESSION] VARIABLES](https://docs.pingcap.com/tidb/stable/sql-statement-show-variables/): TiDB 数据库中 SHOW [GLOBAL|SESSION] VARIABLES 的使用概况。
+- [SHOW ANALYZE STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-analyze-status/): TiDB 数据库中 SHOW ANALYZE STATUS 的使用概况。
+- [SHOW BUILTINS](https://docs.pingcap.com/tidb/stable/sql-statement-show-builtins/): TiDB 数据库中 SHOW BUILTINS 的使用概况。
+- [SHOW CHARACTER SET](https://docs.pingcap.com/tidb/stable/sql-statement-show-character-set/): TiDB 数据库中 SHOW CHARACTER SET 的使用概况。
+- [SHOW COLLATION](https://docs.pingcap.com/tidb/stable/sql-statement-show-collation/): TiDB 数据库中 SHOW COLLATION 的使用概况。
+- [SHOW COLUMN_STATS_USAGE](https://docs.pingcap.com/tidb/stable/sql-statement-show-column-stats-usage/): TiDB 数据库中 SHOW COLUMN_STATS_USAGE 的使用概况。
+- [SHOW CONFIG](https://docs.pingcap.com/tidb/stable/sql-statement-show-config/): TiDB 数据库中 SHOW CONFIG 的使用概况。
+- [SHOW CREATE DATABASE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-database/): TiDB 数据库中 SHOW CREATE DATABASE 的使用概况。
+- [SHOW CREATE PLACEMENT POLICY](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-placement-policy/): TiDB 数据库中 SHOW CREATE PLACEMENT POLICY 的使用概况。
+- [SHOW CREATE RESOURCE GROUP](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-resource-group/): TiDB 数据库中 SHOW CREATE RESOURCE GROUP 的使用概况。
+- [SHOW CREATE SEQUENCE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-sequence/): TiDB 数据库中 SHOW CREATE SEQUENCE 的使用概况。
+- [SHOW CREATE TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-table/): TiDB 数据库中 SHOW CREATE TABLE 的使用概况。
+- [SHOW CREATE USER](https://docs.pingcap.com/tidb/stable/sql-statement-show-create-user/): TiDB 数据库中 SHOW CREATE USER 的使用概况。
+- [SHOW DATABASES](https://docs.pingcap.com/tidb/stable/sql-statement-show-databases/): TiDB 数据库中 SHOW DATABASES 的使用概况。
+- [SHOW ENGINES](https://docs.pingcap.com/tidb/stable/sql-statement-show-engines/): TiDB 数据库中 SHOW ENGINES 的使用概况。
+- [SHOW ERRORS](https://docs.pingcap.com/tidb/stable/sql-statement-show-errors/): TiDB 数据库中 SHOW ERRORS 的使用概况。
+- [SHOW GRANTS](https://docs.pingcap.com/tidb/stable/sql-statement-show-grants/): TiDB 数据库中 SHOW GRANTS 的使用概况。
+- [SHOW IMPORT](https://docs.pingcap.com/tidb/stable/sql-statement-show-import-job/): TiDB 数据库中 SHOW IMPORT 的使用概况。
+- [SHOW INDEXES [FROM|IN]](https://docs.pingcap.com/tidb/stable/sql-statement-show-indexes/): TiDB 数据库中 SHOW INDEXES [FROM|IN] 的使用概况。
+- [SHOW MASTER STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-master-status/): TiDB 数据库中 SHOW MASTER STATUS 的使用概况。
+- [SHOW PLACEMENT](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement/): TiDB 数据库中 SHOW PLACEMENT 的使用概况。
+- [SHOW PLACEMENT FOR](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-for/): TiDB 数据库中 SHOW PLACEMENT FOR 的使用概况。
+- [SHOW PLACEMENT LABELS](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-labels/): TiDB 数据库中 SHOW PLACEMENT LABELS 的使用概况。
+- [SHOW PLUGINS](https://docs.pingcap.com/tidb/stable/sql-statement-show-plugins/): TiDB 数据库中 SHOW PLUGINS 的使用概况。
+- [SHOW PRIVILEGES](https://docs.pingcap.com/tidb/stable/sql-statement-show-privileges/): TiDB 数据库中 SHOW PRIVILEGES 的使用概况。
+- [SHOW PROFILES](https://docs.pingcap.com/tidb/stable/sql-statement-show-profiles/): TiDB 数据库中 SHOW PROFILES 的使用概况。
+- [SHOW SCHEMAS](https://docs.pingcap.com/tidb/stable/sql-statement-show-schemas/): TiDB 数据库中 SHOW SCHEMAS 的使用概况。
+- [SHOW STATS_BUCKETS](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-buckets/): TiDB 数据库中 SHOW STATS_BUCKETS 的使用概况。
+- [SHOW STATS_HEALTHY](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-healthy/): TiDB 数据库中 SHOW STATS_HEALTHY 的使用概况。
+- [SHOW STATS_HISTOGRAMS](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-histograms/): TiDB 数据库中 SHOW STATS_HISTOGRAMS 语句的简单说明。
+- [SHOW STATS_LOCKED](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-locked/): TiDB 数据库中 SHOW STATS_LOCKED 的使用概况。
+- [SHOW STATS_META](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-meta/): TiDB 数据库中 SHOW STATS_META 语句的简单说明。
+- [SHOW STATS_TOPN](https://docs.pingcap.com/tidb/stable/sql-statement-show-stats-topn/): TiDB 数据库中 SHOW STATS_TOPN 的使用概况。
+- [SHOW TABLE NEXT_ROW_ID](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-next-rowid/): TiDB 数据库中 SHOW TABLE NEXT_ROW_ID 的使用概况。
+- [SHOW TABLE REGIONS](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-regions/): 了解如何使用 TiDB 数据库中的 SHOW TABLE REGIONS。
+- [SHOW TABLE STATUS](https://docs.pingcap.com/tidb/stable/sql-statement-show-table-status/): TiDB 数据库中 SHOW TABLE STATUS 的使用概况。
+- [SHOW WARNINGS](https://docs.pingcap.com/tidb/stable/sql-statement-show-warnings/): TiDB 数据库中 SHOW WARNINGS 的使用概况。
+- [SHUTDOWN](https://docs.pingcap.com/tidb/stable/sql-statement-shutdown/): TiDB 数据库中 SHUTDOWN 的使用概况。
+- [SLOW_QUERY](https://docs.pingcap.com/tidb/stable/information-schema-slow-query/): 了解 INFORMATION_SCHEMA 表 `SLOW_QUERY`。
+- [Split Region 使用文档](https://docs.pingcap.com/tidb/stable/sql-statement-split-region/): TiDB 中的 Split Region 功能可以解决表数据超过默认 Region 大小限制后的热点问题。预切分 Region 可以根据指定的参数，预先为某个表切分出多个 Region，并打散到各个 TiKV 上去。使用 `SPLIT` 语句可以实现均匀切分和不均匀切分，返回结果包括新增预切分的 Region 数量和打散完成的比率。需要注意 `tidb_wait_split_region_finish` 和 `tidb_wait_split_region_timeout` 会影响 `SPLIT` 语句的行为。
+- [SQL 优化流程简介](https://docs.pingcap.com/tidb/stable/sql-optimization-concepts/): TiDB 中的 SQL 优化流程包括查询文本解析、逻辑等价变化和最终执行计划生成。经过 parser 解析和合法性验证后，TiDB 会对查询进行逻辑上的等价变化，使得查询在逻辑执行计划上更易处理。之后根据数据分布和执行开销生成最终执行计划。同时，TiDB 在执行 PREPARE 语句时可以选择开启缓存来降低执行计划生成的开销。
+- [SQL 基本操作](https://docs.pingcap.com/tidb/stable/basic-sql-operations/): TiDB 是一个兼容 MySQL 的数据库，可以执行 DDL、DML、DQL 和 DCL 操作。可以使用 SHOW DATABASES 查看数据库列表，使用 CREATE DATABASE 创建数据库，使用 DROP DATABASE 删除数据库。使用 CREATE TABLE 创建表，使用 SHOW CREATE TABLE 查看建表语句，使用 DROP TABLE 删除表。使用 CREATE INDEX 创建索引，使用 SHOW INDEX 查看表内所有索引，使用 DROP INDEX 删除索引。使用 INSERT 向表内插入记录，使用 UPDATE 修改记录，使用 DELETE 删除记录。使用 SELECT 检索表内数据，使用 WHERE 子句进行筛选。使用 CREATE USER 创建用户，使用 GRANT 授权用户，使用 DROP USER 删除用户。
+- [SQL 开发规范](https://docs.pingcap.com/tidb/stable/dev-guide-sql-development-specification/): TiDB 的 SQL 开发规范。
+- [SQL 性能调优](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql/): 介绍 TiDB 的 SQL 性能调优方案和分析办法。
+- [SQL 性能调优](https://docs.pingcap.com/tidb/stable/sql-tuning-overview/): SQL 性能调优是重要的，TiDB 会优化 SQL 语句的执行，以最省时的方式返回结果。这个过程类似于 GPS 导航，利用统计信息和实时交通信息规划最佳路线。了解 TiDB 执行计划、SQL 优化流程和控制执行计划可以帮助提高查询性能。
+- [SQL 或事务问题](https://docs.pingcap.com/tidb/stable/dev-guide-troubleshoot-overview/): 学习诊断在应用开发过程中可能产生的 SQL 或事务问题的方法。
+- [SQL 操作常见问题](https://docs.pingcap.com/tidb/stable/sql-faq/): 介绍 SQL 操作相关的常见问题。
+- [SQL 模式](https://docs.pingcap.com/tidb/stable/sql-mode/): TiDB 服务器采用不同 SQL 模式来操作，可以使用 `SET [SESSION | GLOBAL] sql_mode='modes'` 语句设置 SQL 模式。`GLOBAL` 级别的 SQL 模式需要 `SUPER` 权限，影响新连接；`SESSION` 级别的 SQL 模式只影响当前客户端。重要的 sql_mode 值包括 `ANSI`、`STRICT_TRANS_TABLES` 和 `TRADITIONAL`。SQL mode 列表包括 `PIPES_AS_CONCAT`、`ANSI_QUOTES`、`IGNORE_SPACE`、`ONLY_FULL_GROUP_BY` 等。
+- [SQL 诊断](https://docs.pingcap.com/tidb/stable/information-schema-sql-diagnostics/): 了解 SQL 诊断功能。
+- [SQL 语句概述](https://docs.pingcap.com/tidb/stable/sql-statement-overview/): 介绍 TiDB 支持的 SQL 语句。
+- [Stale Read](https://docs.pingcap.com/tidb/stable/dev-guide-use-stale-read/): 使用 Stale Read 在特定情况下加速查询。
+- [Stale Read 功能的使用场景](https://docs.pingcap.com/tidb/stable/stale-read/): 介绍 Stale Read 功能和使用场景。
+- [START TRANSACTION](https://docs.pingcap.com/tidb/stable/sql-statement-start-transaction/): TiDB 数据库中 START TRANSACTION 的使用概况。
+- [Statement Summary Tables](https://docs.pingcap.com/tidb/stable/statement-summary-tables/): MySQL 的 `performance_schema` 提供了 `statement summary tables`，用于监控和统计 SQL 性能。TiDB 在 `information_schema` 中提供了类似功能的系统表，包括 `statements_summary`、`statements_summary_history`、`cluster_statements_summary` 和 `cluster_statements_summary_history`。这些表用于保存 SQL 监控指标聚合后的结果，帮助用户定位 SQL 问题。同时，还提供了参数配置来控制 statement summary 的功能，如清空周期、保存历史的数量等。
+- [STATISTICS](https://docs.pingcap.com/tidb/stable/information-schema-statistics/): 了解 information_schema 表 `STATISTICS`。
+- [Storage sink 消费程序开发指引](https://docs.pingcap.com/tidb/stable/ticdc-storage-consumer-dev-guide/): 了解如何设计与实现一个消费程序来消费 storage sink 中的变更数据。
+- [Store Limit](https://docs.pingcap.com/tidb/stable/configure-store-limit/): 介绍 Store Limit 功能。
+- [sync-diff-inspector 用户文档](https://docs.pingcap.com/tidb/stable/sync-diff-inspector-overview/): sync-diff-inspector 是一个用于校验 MySQL/TiDB 中数据一致性的工具，提供修复数据的功能。它支持对比表结构和数据，生成用于修复数据的 SQL 语句。需要注意的是，在校验数据时会消耗一定的服务器资源，需要避免在业务高峰期间校验。生成的 SQL 文件仅作为修复数据的参考，需要确认后再执行这些 SQL 修复数据。
+- [sys Schema](https://docs.pingcap.com/tidb/stable/sys-schema/): 了解 TiDB `sys` 系统数据库。
+- [TABLE](https://docs.pingcap.com/tidb/stable/sql-statement-table/): TiDB 数据库中 TABLE 语句的使用概况。
+- [TABLE_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-table-constraints/): 了解 information_schema 表 `TABLE_CONSTRAINTS`。
+- [TABLE_STORAGE_STATS](https://docs.pingcap.com/tidb/stable/information-schema-table-storage-stats/): 了解 INFORMATION_SCHEMA 表 `TABLE_STORAGE_STATS`。
+- [TABLES](https://docs.pingcap.com/tidb/stable/information-schema-tables/): 了解 information_schema 表 `TABLES`。
+- [TiCDC Avro Protocol](https://docs.pingcap.com/tidb/stable/ticdc-avro-protocol/): 了解 TiCDC Avro Protocol 的概念和使用方法。
+- [TiCDC Canal-JSON Protocol](https://docs.pingcap.com/tidb/stable/ticdc-canal-json/): 了解 TiCDC Canal-JSON Protocol 的概念和使用方法。
+- [TiCDC Changefeed 命令行参数和配置参数](https://docs.pingcap.com/tidb/stable/ticdc-changefeed-config/): 了解 TiCDC Changefeed 详细的命令行参数和配置文件定义。
+- [TiCDC CSV Protocol](https://docs.pingcap.com/tidb/stable/ticdc-csv/): 了解 TiCDC CSV Protocol 的概念和使用方法。
+- [TiCDC Debezium Protocol](https://docs.pingcap.com/tidb/stable/ticdc-debezium/): 了解 TiCDC Debezium Protocol 的概念和使用方法。
+- [TiCDC Open Protocol](https://docs.pingcap.com/tidb/stable/ticdc-open-protocol/): 了解 TiCDC Open Protocol 的概念和使用方法。
+- [TiCDC OpenAPI v1](https://docs.pingcap.com/tidb/stable/ticdc-open-api/): 了解如何使用 OpenAPI 接口来管理集群状态和数据同步。
+- [TiCDC OpenAPI v2](https://docs.pingcap.com/tidb/stable/ticdc-open-api-v2/): 了解如何使用 OpenAPI v2 接口来管理集群状态和数据同步。
+- [TiCDC Server 配置](https://docs.pingcap.com/tidb/stable/ticdc-server-config/): 了解 TiCDC 详细的命令行参数和配置文件定义。
+- [TiCDC Simple Protocol](https://docs.pingcap.com/tidb/stable/ticdc-simple-protocol/): 本文介绍了 TiCDC Simple Protocol 的使用方法和数据格式实现。
+- [TiCDC 兼容性](https://docs.pingcap.com/tidb/stable/ticdc-compatibility/): 了解 TiCDC 兼容性相关限制和问题处理。
+- [TiCDC 单行数据正确性校验](https://docs.pingcap.com/tidb/stable/ticdc-integrity-check/): 介绍 TiCDC 数据正确性校验功能的实现原理和使用方法。
+- [TiCDC 双向复制](https://docs.pingcap.com/tidb/stable/ticdc-bidirectional-replication/): 了解 TiCDC 双向复制的使用方法。
+- [TiCDC 基本监控指标](https://docs.pingcap.com/tidb/stable/ticdc-summary-monitor/): 了解 TiCDC 基本的监控指标。
+- [TiCDC 安装部署与集群运维](https://docs.pingcap.com/tidb/stable/deploy-ticdc/): 了解 TiCDC 软硬件环境要求以及如何安装部署和运维 TiCDC 集群。
+- [TiCDC 客户端鉴权](https://docs.pingcap.com/tidb/stable/ticdc-client-authentication/): 介绍使用 TiCDC 命令行工具或通过 OpenAPI 访问 TiCDC 时，如何进行客户端鉴权。
+- [TiCDC 常见问题解答](https://docs.pingcap.com/tidb/stable/ticdc-faq/): 了解 TiCDC 相关的常见问题。
+- [TiCDC 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/ticdc-performance-tuning-methods/): 本文介绍了 Performance Overview 面板中的 TiCDC 部分，帮助你了解和监控 TiCDC 工作负载。
+- [TiCDC 拆分 UPDATE 事件行为说明](https://docs.pingcap.com/tidb/stable/ticdc-split-update-behavior/): 介绍 TiCDC changefeed 拆分 UPDATE 事件的行为变更，说明变更原因以及影响范围。
+- [TiCDC 故障处理](https://docs.pingcap.com/tidb/stable/troubleshoot-ticdc/): 了解如何解决使用 TiCDC 时经常遇到的问题。
+- [TiCDC 术语表](https://docs.pingcap.com/tidb/stable/ticdc-glossary/): 了解 TiCDC 相关的术语及定义。
+- [TiCDC 架构设计与原理](https://docs.pingcap.com/tidb/stable/ticdc-architecture/): 了解 TiCDC 软件的架构设计和运行原理。
+- [TiCDC 简介](https://docs.pingcap.com/tidb/stable/ticdc-overview/): TiCDC 是一款 TiDB 增量数据同步工具，适用于多 TiDB 集群的高可用和容灾方案，以及实时同步变更数据到异构系统。其主要特性包括数据容灾复制、双向复制、低延迟的增量数据同步能力等。TiCDC 架构包括 TiKV Server、TiCDC 和 PD，支持将数据同步到 TiDB、MySQL 数据库、Kafka 以及存储服务。目前暂不支持单独使用 RawKV 的 TiKV 集群，创建 SEQUENCE 的 DDL 操作和在同步过程中对 TiCDC 正在同步的表和库进行 BR 数据恢复和 TiDB Lightning 导入。
+- [TiCDC 详细监控指标](https://docs.pingcap.com/tidb/stable/monitor-ticdc/): 了解 TiCDC 详细的监控指标。
+- [TiCDC 部署拓扑](https://docs.pingcap.com/tidb/stable/ticdc-deployment-topology/): 介绍 TiCDC 部署 TiDB 集群的拓扑结构。
+- [TiCDC 集群监控报警规则](https://docs.pingcap.com/tidb/stable/ticdc-alert-rules/): 了解 TiCDC 集群监控报警规则以及处理方法。
+- [TiDB 1.0 release notes](https://docs.pingcap.com/tidb/stable/release-1.0-ga/): TiDB 1.0 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 优化了 SQL 查询优化器、内部数据格式、MySQL 兼容性，并支持 `NO_SQL_CACHE` 语法。PD 支持基于读流量的热点调度和设置 Store 权重。TiKV 支持更多下推函数和手动触发数据 Compact。TiSpark Beta 版本支持可配置框架和 ThriftSever/JDBC 和 Spark SQL 脚本入口。感谢参与项目的企业和团队，以及提供出色开源软件/服务的组织/个人。
+- [TiDB 1.1 Alpha Release Notes](https://docs.pingcap.com/tidb/stable/release-1.1-alpha/): TiDB 1.1 Alpha 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。包括 SQL parser 兼容更多语法，SQL 查询优化器优化统计信息、代价估算，使用 `Count-Min Sketch` 更精确地估算点查的代价，SQL 执行器重构执行器算子，优化 `INSERT IGNORE` 语句性能，下推更多类型和函数，支持更多 `SQL_MODE`，优化 `Load Data` 性能，支持对物理算子内存使用进行统计。PD 增加更多 API，支持 TLS，调度适应不同的 Region size，修复调度 bug。TiKV 支持 Raft learner，优化 Raft Snapshot，支持 TLS，优化 RocksDB 配置，优化 Coprocessor 性能，增加 Failpoint 和稳定性测试 case，解决 PD 和 TiKV 重连问题，增强数据恢复工具功能，Region 支持按 table 分裂，支持 `Delete Range` 功能，支持设置 snapshot 导致的 I/O 上限，完善流控机制。
+- [TiDB 1.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-1.1-beta/): TiDB 1.1 Beta 版本在 MySQL 兼容性和系统稳定性方面有多项改进。TiDB 新增监控项和优化日志，兼容更多 MySQL 语法，支持显示建表时间，加快查询速度，控制 Join 产生的中间结果集大小，修复多项问题，优化 SQL 引擎查询性能。PD 新增调试接口和 metrics，提高 TiKV 宕机时数据恢复优先级和恢复速度，优化 Region heartbeat 性能，修复热点调度问题。TiKV 消除潜在的 GC 问题，支持批量 resolve lock 和并行 GC，使用 RocksDB compaction listener 更新 Region Size，设置 Raft snapshot max size，支持更多修复操作，优化有序流式聚合操作，完善 metrics，修复 bug。
+- [TiDB 2.0 RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.1/): TiDB 2.0 RC1 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持限制单条 SQL 语句内存使用，下推流式聚合算子到 TiKV，配置文件合法性检测，HTTP API 获取参数信息。Parser 兼容更多 MySQL 语法，提升对 Navicat 的兼容性。优化器提升，提取多个 OR 条件的公共表达式，选取更优执行计划。PD 优化检查 Region 状态的代码逻辑，异常情况下日志信息输出，修复监控中 TiKV 节点磁盘空间不足统计。TiKV 修复 PD leader 切换 gRPC call 问题，增加获取 metrics 的 gRPC API，启动时检查是否使用 SSD，使用 ReadPool 优化读性能。
+- [TiDB 2.0 RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.3/): TiDB 2.0 RC3 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 修复了 MAX/MIN 结果错误、Sort Merge Join 排序问题、uint 和 int 比较错误等。PD 支持 Region Merge 和忽略有大量 pending peer 的节点。TiKV 支持 Region Merge、Raft snapshot 通知 PD 加速调度、增加 Raw DeleteRange API 等。
+- [TiDB 2.0 RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.4/): TiDB 2.0 RC4 版本发布，改进了 MySQL 兼容性、系统稳定性和优化器。TiDB 支持了一些新的语法和修复了一些问题。PD 支持手动 split Region 和优化了 metrics 及代码结构。TiKV 限制了接收 snapshot 时的内存使用，支持导数据模式和改善了在被隔离的情况下的输出问题。
+- [TiDB 2.0 RC5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0-rc.5/): TiDB 2.0 RC5 版本发布，对 MySQL 兼容性、系统稳定性和优化器做了很多改进。TiDB 修复了多个问题，并优化了性能。PD 添加了 Raft Learner 支持，优化了 Balance Region Scheduler，并修复了多个问题。TiKV 支持了更多功能，并解决了多个问题。
+- [TiDB 2.0 release notes](https://docs.pingcap.com/tidb/stable/release-2.0-ga/): TiDB 2.0 GA 版本发布，对 MySQL 兼容性、系统稳定性、优化器和执行器做了很多改进。包括 SQL 优化器、SQL 执行引擎、Server、兼容性、DDL、PD、TiKV 和 TiSpark 的功能、性能和稳定性优化。
+- [TiDB 2.0.1 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.1/): TiDB 2.0.1 版本对 MySQL 兼容性和系统稳定性做出了改进。TiDB 新增了实时更新 `Add Index` 进度到 DDL 任务信息中的功能，添加了 Session 变量 `tidb_auto_analyze_ratio` 控制统计信息自动更新阈值的功能。修复了事务提交失败时可能未清理所有残留状态的问题，以及其他 Bug 和兼容性问题。PD 新增了 `Scatter Range` 调度和 learner 相关的 metrics，修复了多个问题。TiKV 修复了多个问题，优化了慢查询的日志，减少了 `thread_yield` 的调用次数。
+- [TiDB 2.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.10/): TiDB 2.0.10 版本发布，修复了系统兼容性和稳定性问题。包括取消 DDL 任务可能导致的问题，ORDER BY 和 UNION 语句无法引用带表名的列的问题，UNCOMPRESS 函数错误输入长度的问题等。PD 修复了 RaftCluster 退出时可能的死锁问题，TiKV 修复了迁移 Leader 到新节点时造成请求延时问题和多余的 Region 心跳问题。
+- [TiDB 2.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.11/): TiDB 2.0.11 版本发布，对系统兼容性和稳定性做出改进。修复了多个问题，包括 PD 异常处理问题、Rename 行为问题、ADMIN CHECK TABLE 误报问题、前缀索引错误问题和添加列导致 UPDATE 语句 panic 问题。TiKV 修复了两个 Region merge 相关问题。
+- [TiDB 2.0.2 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.2/): TiDB 2.0.2 版本发布，改进了系统稳定性。TiDB 修复了 Decimal 除法内置函数下推的问题，支持 `Delete` 语句中使用 `USE INDEX` 的语法，禁止在带有 `Auto-Increment` 的列中使用 `shard_row_id_bits` 特性，并增加了写入 Binlog 的超时机制。PD 使 balance leader scheduler 过滤失连节点，更改 transfer leader operator 的超时时间为 10 秒，修复 label scheduler 在集群 Regions 不健康状态下不调度的问题，修复 evict leader scheduler 调度不当的问题。TiKV 修复了 Raft 日志没有打出来的问题，支持配置更多 gRPC 相关参数，支持配置选举超时的取值范围，修复过期 learner 没有删掉的问题，修复 snapshot 中间文件被误删的问题。
+- [TiDB 2.0.3 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.3/): TiDB 2.0.3 版本在 2.0.2 版的基础上做出了改进，包括系统兼容性和稳定性的改进。TiDB 支持在线更改日志级别和 `COM_CHANGE_USER` 命令，优化查询条件代价估算和修复多个问题。PD 修复了特定条件下的问题，TiKV 修复了错误上报和除数为 0 的问题。
+- [TiDB 2.0.4 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.4/): TiDB 2.0.4 版本发布，改进了系统兼容性和稳定性。TiDB 支持了新的语法和变量设置，优化了监控项和查询代价估计精度。PD 改进了调度参数行为，TiKV 新增了调试接口和命令，优化了问题和修复了崩溃。
+- [TiDB 2.0.5 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.5/): TiDB 2.0.5 版本发布，改进了系统兼容性和稳定性。新增系统变量 `tidb_disable_txn_auto_retry`，调整计算 `Selection` 代价的方式，优化查询条件匹配唯一索引或主键，修复多个 bug。PD 修复副本迁移导致 TiKV 磁盘空间耗尽和 `AdjacentRegionScheduler` 导致的崩溃问题。TiKV 修复 decimal 运算中的溢出和 merge 过程中的脏读问题。
+- [TiDB 2.0.6 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.6/): TiDB 2.0.6 版本在系统兼容性和稳定性方面有所改进。包括日志长度精简、记录 ADD INDEX 执行过程中的慢操作、减少更新统计信息操作中的事务冲突等。此外，修复了多个 bug，包括 DROP USER 语句和 MySQL 行为不兼容、tidb_batch_insert 打开后 INSERT/LOAD DATA 语句在某些场景下 OOM 的问题等。TiKV 方面扩大了默认 scheduler slots 值以减少假冲突现象，修复了字符串转 Decimal 时出现的 crash。
+- [TiDB 2.0.7 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.7/): TiDB 2.0.7 版本在系统兼容性和稳定性方面有改进。TiDB 新增了在 `information_schema` 中添加 `PROCESSLIST` 表的功能。还对语句执行细节进行了改进，并在 `SLOW QUERY` 日志中输出更多信息。修复了多个 bug，包括 `PRIMARY KEY` 为整数的表无法使用 `USE INDEX(PRIMARY)` 的问题，以及 `Merge Join` 和 `Index Join` 在 inner row 为 `NULL` 时输出多余结果的问题。TiKV 方面，空集群默认打开 `dynamic-level-bytes` 参数减少空间放大，并在 Region merge 之后更新 Region 的 `approximate size` 和 keys。
+- [TiDB 2.0.8 release notes](https://docs.pingcap.com/tidb/stable/release-2.0.8/): TiDB 2.0.8 版本在 2.0.7 版的基础上做出了改进，包括功能改进和 Bug 修复。TiKV 也修复了节点宕机时内存持续上升的问题。
+- [TiDB 2.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.0.9/): TiDB 2.0.9 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括统计信息、DDL JOB、Commit 操作、Limit 值、字符集支持、内建函数、主键选择率估算、Session 变量、Union 语句、统计信息清除、事务运行时间、表创建语句、取消 DDL 任务、全局环境变量等。PD 修复了 etcd 启动失败和 pd-ctl 读取 Region key 的问题。TiKV 增加了 kv_scan 接口扫描上界的限制，废弃了 max-tasks-xxx 配置，并修复了 RocksDB CompactFiles 的问题。
+- [TiDB 2.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-beta/): TiDB 2.1 Beta 版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。SQL 优化器优化了 Index Join 选择范围和关联子查询，下推 Filter 和扩大索引选择范围。SQL 执行引擎实现了并行 Hash Aggregate 和 Project 算子，提高了执行性能。Server 添加了 HTTP API 控制功能和支持 Server side cursor。兼容性方面支持更多 MySQL 语法和 SHOW PRIVILEGES 语句。PD 优化了 Balance Scheduler 和热点调度器，TiKV 升级了 Rust 版本和优化了性能。
+- [TiDB 2.1 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-ga/): TiDB 2.1 GA 版本发布，对系统稳定性、性能、兼容性、易用性做了大量改进。包括 SQL 优化器、SQL 执行引擎、统计信息、表达式、Server、DDL、兼容性等方面的优化。PD (Placement Driver) 进行了可用性优化、调度器优化、API 及运维工具优化、监控和性能优化。TiKV 进行了 Coprocessor、Transaction、Raftstore、存储引擎和 tikv-ctl 方面的优化。同时支持全量数据快速导入工具 TiDB Lightning。升级兼容性说明包括存储引擎更新不支持回退至 2.0.x 或更旧版本，以及升级前需要确认集群中是否存在正在运行中的 DDL 操作。
+- [TiDB 2.1 RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.1/): TiDB 2.1 RC1 版本于 2018 年 8 月 24 日发布。该版本对系统稳定性、优化器、统计信息以及执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、DML、DDL 等方面的改进。PD 方面新增了版本控制机制，支持集群滚动兼容升级等功能。TiKV 方面新增了支持 batch split 等新特性，以及对性能和功能进行了优化和改进。
+- [TiDB 2.1 RC2 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.2/): TiDB 2.1 RC2 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。具体包括 SQL 优化器、SQL 执行引擎、统计信息、Server、兼容性、表达式、DML、DDL、TiKV 和 PD 的新特性、功能改进和 Bug 修复。
+- [TiDB 2.1 RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.3/): TiDB 2.1 RC3 版本对系统稳定性、兼容性、优化器和执行引擎做了很多改进。包括修复了多个 SQL 优化器和执行引擎的问题，增强了部分执行器的性能，修复了配置文件内存配额选项不生效的问题，支持使用 `admin show slow` 语句来获取 SLOW QUERY LOG，修复了一些兼容性问题，增加了一些内建函数的支持，修复了一些 DML 和 DDL 的问题。PD 新增了获取按大小逆序排序的 Region 列表 API，Region API 返回更详细的信息，修复了 PD 切换 leader 后可能导致 crash 的问题。TiKV 进行了性能优化，并新增了一些函数的支持，同时修复了一些 Bug。
+- [TiDB 2.1 RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.4/): TiDB 2.1 RC4 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个 SQL 优化器和执行引擎的问题，重构了 Latch，提升了并发事务的执行性能。PD 修复了多个 TiKV 下线后的问题。TiKV 优化了 apply snapshot 导致的 RocksDB Write stall 的问题，并增加了 raftstore tick 相关 metrics。
+- [TiDB 2.1 RC5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1-rc.5/): TiDB 2.1 RC5 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括修复了多个问题，提升了性能，增加了环境变量设置功能。PD 修复了多个问题，TiKV 优化了报错信息和接口限制。
+- [TiDB 2.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.1/): TiDB 2.1.1 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括时间四舍五入错误、uncompress 函数未检查数据长度、PD 故障获取错误 TSO、不规范语句导致启动失败等。DDL 改变了表的默认字符集和排序规则，增加了控制添加索引速度的变量。PD 修复了配置项无法设置为 0 的问题，避免了 transfer leader 至新创建的 Peer 产生的延迟增加问题。TiKV 也避免了相同的问题。 Lightning 优化了对导入表的 analyze 机制，提升了导入速度。 TiDB Binlog 修复了 pb files 输出 bug。
+- [TiDB 2.1.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.10/): TiDB 2.1.10 发布，修复了多个 bug 和兼容性问题，增强了安全性。PD 修复了 Leader 优先级不生效的问题。TiKV 修复了多个问题，包括 transfer leader 中可能发生的脏读问题。TiDB Lightning 新增了发送数据到 importer 失败时进行重试的功能。TiDB Binlog 优化了 Pump storage 组件 log。TiDB Ansible 更新了配置文件，新增了 tidb_lightning_ctl 脚本。
+- [TiDB 2.1.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.11/): TiDB 2.1.11 发布，修复多表 join 删除错误 schema 问题，更新统计信息合并反馈信息，修复函数返回错误字段类型问题，修复时间计算错误问题，修复与 MySQL 8.0 不兼容问题，支持 SHOW OPEN TABLES 语句，修复 goroutine 泄露问题，修复设置 tidb_snapshot 变量时间格式解析出错问题。PD 修复热点 Region 调度问题，新增热点调度优先级配置项。TiKV 修复 leader, learner 读到空 index 问题，处理锁命令放在高优先级线程池中。TiDB Binlog 新增 GC 删数据限速功能。TiDB Ansible 新增 Drainer 参数。
+- [TiDB 2.1.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.12/): TiDB 2.1.12 发布，修复了多个 bug，包括类型不匹配导致进程 panic、字符集改变导致类型变化、事务中的 GRANT 误报错误等问题。同时提升了与 MySQL 的兼容性，修复了 TiDB 跟 TiKV 在 gRPC 最大封包设置不一致导致的超大封包报错问题。PD 修复了极端情况下 etcd Leader 选举阻塞的问题，TiKV 修复了 Leader 迁移过程中 Region 不可用的问题和异常掉电导致丢数据的问题。
+- [TiDB 2.1.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.13/): TiDB 2.1.13 发布，新增了列属性包含 `AUTO_INCREMENT` 时利用 `SHARD_ROW_ID_BITS` 打散行 ID 功能，优化无效 DDL 元信息存活时间，修复了在大并发场景下 OOM 的问题，新增了 `update-stats` 配置项，新增了 3 个 TiDB 特有语法，修复了某些情况下 `KILL` 语句导致的 panic 问题，增强了 `ADD_DATE` 在某些情况下跟 MySQL 的兼容性，修复了 index join 中内表过滤条件在某些情况下的选择率估计错误的问题。TiKV 修复了因迭代器未检查状态导致系统生成残缺 snapshot 的问题，新增了检查 `block-size` 配置的有效性功能。TiDB Binlog 修复了 Pump 因写入失败时未检查返回值导致偏移量错误问题，Drainer 新增了 `advertise-addr` 配置，支持容器环境中使用桥接模式。
+- [TiDB 2.1.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.14/): TiDB 2.1.14 发布说明：修复查询结果不正确的问题，支持自动调整 Auto ID 分配的步长，新增全局系统变量 `max_execution_time`，修复内存配额超出时返回结果不正确的问题，禁用 `TRACE` 语句，新增系统表控制函数下推，优化 Raftstore 消息处理，调整无效配置项日志级别，新增 Binlog 配置项，修复 Binlog 更新失败问题，新增 Ansible 命令预检查功能。
+- [TiDB 2.1.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.15/): TiDB 2.1.15 发布，修复了多个函数处理微秒、空值比较、插入参数、索引建立等问题，并新增了多个 SQL 语句和监控项。TiKV 统一日志格式，提高了调度准确度。PD 也统一了日志格式。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修复了导入错误问题。TiDB Ansible 新增监控项用于监测 SQL 语句解析耗时和执行计划编译耗时。
+- [TiDB 2.1.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.16/): TiDB 2.1.16 发布，修复了 SQL 优化器和执行引擎的多个问题。TiKV 支持逆向 raw_scan 和 raw_batch_scan 接口。TiDB Binlog 和 TiDB Lightning 做了一些功能增强和 bug 修复。TiDB Ansible 也有多个 bug 修复和功能优化。
+- [TiDB 2.1.17 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.17/): TiDB 2.1.17 发布，新增了 `SHOW TABLE REGIONS` 语法的 `WHERE` 条件子句，以及 TiKV、PD 的 `config-check` 功能。PD 优化调度流程，TiKV 优化启动流程。TiDB 慢日志中的 `start ts` 和 `Index_ids` 字段有改动。SQL 优化器和执行引擎修复了多个问题。DDL 改进了 `SPLIT TABLE` 语法的行为。TiKV 解决了一些问题并新增了 `config-check` 选项。PD 新增了 `config-check` 选项和 `remove-tombstone` 命令。Reparo 新增了配置项，用于控制恢复速率。TiDB Ansible 更新了 Spark 版本和修复了连接等待问题。
+- [TiDB 2.1.18 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.18/): TiDB 2.1.18 发布，修复了多项 SQL 优化器和执行引擎的问题，改进了 Server、DDL 和 Monitor 功能，同时 TiDB Ansible 也有多项更新。
+- [TiDB 2.1.19 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.19/): TiDB 2.1.19 发布，包含了对 SQL 优化器、SQL 执行引擎、Server、DDL、TiKV、PD 和 TiDB Ansible 的多项修复和优化。修复了多个查询和更新语句中可能出现的错误，提升了系统稳定性和性能。
+- [TiDB 2.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.2/): TiDB 2.1.2 版本发布，改进了系统兼容性和稳定性。修复了多个问题，包括索引 panic、优化器执行计划、字符集检查和时间类型字段错误。PD 修复了 Region Merge 相关问题，TiKV 支持日为时间单位的配置格式，并解决了配置兼容性问题，修复了 Approximate Size Split 和两个 Region merge 相关问题。TiDB Lightning 支持最小 TiDB 集群版本为 2.1.0，修复了解析 JSON 类型数据文件内容出错和使用 checkpoint 重启后的错误。TiDB Binlog 消除了往 Kafka 写数据的瓶颈点，支持写 Kafka 版本的 TiDB Binlog。
+- [TiDB 2.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.3/): TiDB 2.1.3 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个问题，包括 Prepared Plan Cache panic、Range 计算错误、统计信息溢出、Generated Column 在 Update 中 Panic 等。还支持了一些新特性，如对 `_tidb_rowid` 构造查询的 Range、`CASE` 子句返回 JSON 类型等。PD 修复了 Leader 选举相关的 Watch 问题，TiKV 支持了使用 HTTP 方式获取监控信息，并修复了一些问题。TiDB Binlog 也修复了一些启动或重启时的问题。
+- [TiDB 2.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.4/): TiDB 2.1.4 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了很多改进。修复了多个函数处理结果不正确的问题，优化了服务器日志和 DDL 操作。TiKV 修复了关闭时可能发生重复写的问题和事件监听器处理异常的问题。工具方面优化了内存使用，减少了对 dump 文件的解析，提高了导入稳定性。数据同步对比统计支持使用 TiDB 统计信息来划分 chunk。
+- [TiDB 2.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.5/): TiDB 2.1.5 版本对系统稳定性、优化器、统计信息和执行引擎做了很多改进。包括优化器 / 执行器、Server、DDL、PD、TiKV 和 Tools 的改进和修复。
+- [TiDB 2.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.6/): TiDB 2.1.6 版本发布，对系统稳定性、优化器、统计信息和执行引擎做了改进。修复了多个问题，包括索引扫描选择问题、聚合函数兼容性问题、变量设置导致的 Panic 问题等。TiKV 修复了解析 protobuf 失败导致的错误。Lightning 修复了多个导入相关的问题，并支持 CSV 格式。
+- [TiDB 2.1.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.7/): TiDB 2.1.7 发布，修复了 DDL 取消导致升级程序启动时间变长的问题，提升了内置函数的兼容性，新增了系统表管理 Table 与 Index 之间的关系，支持在 DO 语句中使用子查询，修复了对 JSON 数据的聚合函数在计算过程中 Panic 的问题。PD 修改副本数为 1 时 balance-region 无法迁移 leader 的问题。Tools 支持 binlog 同步 generated column。TiDB Ansible 将 Prometheus 监控数据默认保留时间改成 30d。
+- [TiDB 2.1.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.8/): TiDB 2.1.8 发布，修复了多个函数和语句的兼容性问题，优化了日志格式规范和统计信息估算准确性。PD 和 TiKV 也有多项修复和优化。工具方面，Lightning 和 Binlog Pump 等新增了多项配置和性能优化。TiDB Ansible 修改了操作系统版本限制和滚动升级版本限制。
+- [TiDB 2.1.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-2.1.9/): TiDB 2.1.9 发布，修复了多个函数和权限检查问题，支持指定 collation 为 utf8mb4_0900_ai_ci，改进了慢日志输出和 PD 服务支持。 TiKV 修复了在 transfer leader 时的问题。 TiDB Binlog 和 TiDB Lightning 也有多个修复和改进。 TiDB Ansible 更新了文档链接和移除了一个参数。
+- [TiDB 3.0 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0-beta/): TiDB 3.0 Beta 版本发布，新增支持 View、窗口函数、Range 分区、Hash 分区等特性。SQL 优化器做了很多改进，包括重新支持聚合消除、优化 `NOT EXISTS` 子查询、支持 Index Join 等。SQL 执行引擎优化了 Merge Join 算子、日志打印等功能。权限管理增加了对 `ANALYZE`、`USE`、`SET GLOBAL`、`SHOW PROCESSLIST` 语句的权限检查。Server 支持了 `Trace` 功能、插件框架、`unix_socket` 和 TCP 连接等功能。兼容性方面支持了 `ALLOW_INVALID_DATES` SQL mode、load data 对 CSV 文件的容错能力等。DDL 支持了快速恢复误删除的表、动态调整 ADD INDEX 的并发数等功能。Tools 方面 TiDB Lightning 大幅优化了 SQL 转 KV 的处理速度。PD 和 TiKV 也做了很多功能增加和优化。
+- [TiDB 3.0 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0-ga/): TiDB 3.0 GA 版本于 2019 年 6 月 28 日发布，对应的 TiDB Ansible 版本为 3.0.0。V3.0.0 版本相比 V2.1 在稳定性、易用性、性能和新功能方面有重要改进。新增功能包括窗口函数、视图、分区表、插件系统、悲观锁、SQL Plan Management 等。SQL 优化器和执行引擎也有多项优化，包括对 `NOT EXISTS` 子查询、`Outer Join`、`IN` 子查询、Index Join 等的性能提升。PD 新增了从单个节点重建集群的功能，将 Region 元信息从 etcd 移至 go-leveldb 存储引擎。TiKV 新增了分布式 GC、并行 Resolve Lock、多线程 Raftstore 和 Apply 等功能，以及对 Engine、Server、RaftStore 和 Coprocessor 的优化。Tools 方面 TiDB Lightning 新增了多项功能，TiDB Binlog 新增了多项功能，sync-diff-inspector 也新增了多项功能。TiDB Ansible 升级了监控组件版本，新增了多项监控面板和功能。
+- [TiDB 3.0.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-beta.1/): TiDB 3.0.0 Beta.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、SQL 执行引擎、权限管理、Server、DDL、PD、TiKV 和 Tools 的更新。
+- [TiDB 3.0.0-rc.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.1/): TiDB 3.0.0-rc.1 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Tools 和 TiDB Ansible 的更新和修复。
+- [TiDB 3.0.0-rc.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.2/): TiDB 3.0.0-rc.2 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL 和 PD 的更新。TiKV 的更新包括 Engine、Server、Raftstore 和 Coprocessor 的改进。工具方面，TiDB Binlog 增加下游同步延迟监控项，TiDB Lightning 支持数据库合并和新增 KV 写入失败重试机制。
+- [TiDB 3.0.0-rc.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.0-rc.3/): TiDB 3.0.0-rc.3 发布，对系统稳定性、易用性、功能、优化器、统计信息和执行引擎做了很多改进。包括 SQL 优化器、执行引擎、Server、DDL、PD、TiKV、Transaction、tikv-ctl、Misc 等方面的修复和新增功能。TiDB Ansible 新增预测集群最大 QPS 的监控项。
+- [TiDB 3.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.1/): TiDB 3.0.1 发布，新增多项功能和修复了多个问题。TiKV 新增了对 Blob 文件大小的统计和死锁检测性能的提升。PD 优化了热点 Region 调度策略和 Region Merge 处理逻辑。TiDB Binlog 优化了 Pump GC 策略。TiDB Lightning 修正了导入错误的问题。TiDB Ansible 新增了预检查功能和更新了监控信息。
+- [TiDB 3.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.10/): TiDB 3.0.10 发布，修复了多个 bug 和性能问题。TiKV 修复了 Region merge 失败导致系统 Panic 的问题。PD 自动更新 Region 缓存信息，解决缓存失效问题。TiDB Binlog 支持 relay log。TiDB Lightning 优化配置项和修复 web 界面无法打开的问题。TiDB Ansible 修复获取不到 PD Leader 导致命令执行失败的问题，并新增多个监控项。
+- [TiDB 3.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.11/): TiDB 3.0.11 发布，包含兼容性变化、新功能和 Bug 修复。新增配置项 `max-index-length` 控制索引最大长度，显示分区表的分区元信息，以及 TiDB 集群之间数据双向复制功能。Bug 修复包括查询结果不正确、Goroutine 泄露等问题。TiKV 也进行了日志输出优化和问题修复。TiDB Ansible 修复了失效文档链接和未定义变量问题。
+- [TiDB 3.0.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.12/): TiDB 3.0.12 发布日期为 2020 年 3 月 16 日。该版本存在一些已知问题，建议使用最新版本。兼容性变化包括修复慢日志中记录 prewrite binlog 时间计时不准确的问题。新功能包括动态加载已被替换的证书文件，添加配置项，限流功能，以及在 binlog 写入失败时 TiDB 退出。Bug 修复包括保证原子性，悲观锁加锁问题修复，建索引长度超过限制时的报错信息显示，FROM_UNIXTIME 函数小数点位数不正确的问题修复，以及其他问题的修复。
+- [TiDB 3.0.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.13/): TiDB 3.0.13 发布日期为 2020 年 04 月 22 日。此版本修复了 TiDB 和 TiKV 中的一些 bug。其中 TiDB 修复了由于未检查 `MemBuffer`，事务内执行 `INSERT ... ON DUPLICATE KEY UPDATE` 语句插入多行重复数据可能出错的问题。TiKV 修复了重复多次执行 `Region Merge` 导致系统被阻塞的问题，阻塞期间服务不可用。
+- [TiDB 3.0.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.14/): TiDB 3.0.14 发布日期为 2020 年 5 月 9 日。该版本兼容性变化包括 `performance_schema` 和 `metrics_schema` 由读写改为只读。重点修复的 Bug 包括 join 条件在 handle 列上存在多个等值条件时，index join 查询结果错误等问题。新功能包括 `admin show ddl jobs` 查询结果中添加库名和表名列等功能。Bug 修复包括 `WEEKEND` 函数在 SQL mode 为 `ALLOW_INVALID_DATES` 时结果与 MySQL 不兼容等问题。TiKV 也有相关 Bug 修复，如节点隔离恢复之后无法被正确删掉等问题。
+- [TiDB 3.0.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.15/): TiDB 3.0.15 发布，新增禁止分区表查询使用 plan cache 功能、支持 admin recover index、admin check index 语句、优化统计信息 CMSketch 的内存分配机制等功能。PD 新增按照 Leader 个数调度的策略。修复了多处 Bug，包括 Hash 聚合函数中的深拷贝方式、点查整数溢出处理逻辑、CHAR() 函数查询条件处理逻辑等问题。TiKV 修复了长时间运行后碎片整理不再有效、系统意外重启后删除 snapshot 文件导致系统 panic、消息包过大导致 gRPC 连接断开的问题。
+- [TiDB 3.0.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.16/): TiDB 3.0.16 发布，优化了 hash partition pruning 和 Region 设置，修复了多个 Bug，包括锁住的 primary key 造成的结果不一致问题和 JSON 数据中 int 和 float 类型比较的问题。TiKV 也进行了稳定性优化和 Bug 修复。PD 修复了查询 Region 报 404 错误的问题。
+- [TiDB 3.0.17 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.17/): TiDB 3.0.17 发布，修复了多个 bug，包括查询返回错误和函数处理问题。优化了配置项和 HTTP API 访问速度。TiKV 修复了数据读取和调度问题，新增了配置支持。TiDB Lightning 解决了参数不生效的问题，并新增了更简单易用的过滤规则。
+- [TiDB 3.0.18 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.18/): TiDB 3.0.18 发布，提升了 TiDB Binlog 工具的细粒度 Pump GC 时间支持。修复了 TiDB 中 Hash 函数对 Decimal 类型的错误处理问题，以及对 Set 和 Enum 类型的错误处理问题。还修复了 Duplicate Key 检测在悲观事务下失效的问题，以及其他执行结果错误的问题。TiKV 将 GC 的失败日志级别改为 Warning。TiDB Lightning 修复了多个命令行参数和使用 TiDB backend 时的问题。
+- [TiDB 3.0.19 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.19/): TiDB 3.0.19 发布，兼容性变化包括更改 PD 的导入路径和版权信息。提升改进方面，缓解故障恢复对 QPS 的影响，支持调整 `union` 运算符的并发数。Bug 修复包括解决 `slow-log` 文件不存在导致查询出错的问题，添加权限检查命令，修复类型转换问题等。TiKV 修复了 status server 解析响应出错导致 panic 的问题。TiDB Lightning 修复了严格模式下 CSV 中遇到不合法 UTF 字符集没有及时退出进程的问题。
+- [TiDB 3.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.2/): TiDB 3.0.2 发布日期为 2019 年 8 月 7 日。该版本修复了多个 SQL 优化器和执行引擎的问题，包括修复了查询结果列名称不正确、LIKE 表达式被隐式转换为 0、SHOW 语句中使用子查询等问题。此外，还修复了 TiKV panic、悲观事务下 Insert 行为不正确等问题。PD 也修复了 Scatter Region 调度器不能工作等 bug。TiDB Ansible 也有多个修复和更新，包括修复了 Disk Performance 监控单位错误、新增了 TiDB Summary Dashboard 等。
+- [TiDB 3.0.20 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.20/): TiDB 3.0.20 发布，兼容性更改包括废弃 `enable-streaming` 配置项。改进提升包括优化 `LOAD DATA` 语句执行报错信息。Bug 修复包括缓存悲观事务提交状态问题、查询统计信息不准确问题等。TiKV 修复事务删除 key 报错问题，PD 修复启动时打印过量日志问题。
+- [TiDB 3.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.3/): TiDB 3.0.3 发布，包含了多项 SQL 优化器和执行引擎的修复，以及 Server、DDL、Monitor、TiKV、PD、Tools 和 TiDB Ansible 的更新和修复。
+- [TiDB 3.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.4/): TiDB 3.0.4 发布日期为 2019 年 10 月 8 日。此版本新增了系统表 `performance_schema.events_statements_summary_by_digest` 用于排查 SQL 性能问题。同时，TiDB 的 `SHOW TABLE REGIONS` 语法新增了 `WHERE` 条件子句。此外，Reparo 新增了 `worker-count` 和 `txn-batch` 配置项，用于控制恢复速率。还修复了一些问题，如特殊语法 `PRE_SPLIT_REGIONS` 没有使用注释的方式向下游同步的问题。
+- [TiDB 3.0.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.5/): TiDB 3.0.5 发布，包含 SQL 优化器和执行引擎的多项修复和改进，支持事务 TTL 修改接口函数，以及对 Region Cache TTL 的配置修改。TiKV 新特性包括悲观事务 Cleanup 接口支持和 Raftstore 性能优化。PD 提高了 Region 占用空间的精度和 label 监控可读性。TiDB Binlog 和 TiDB Lightning 也有多项修复和功能增强。TiDB Ansible 更新了监控表达式和配置文件内容。
+- [TiDB 3.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.6/): TiDB 3.0.6 发布，包含多项 SQL 优化器和执行引擎的修复和优化，以及 Server、DDL、TiKV、PD 和 Tools 的更新和修复。TiKV 修复了悲观锁支持和 GC worker 写入量限制等问题。PD 添加了新维度和降低日志级别。Tools 中 TiDB Binlog 和 TiDB Lightning 也有多项修复和新增配置。
+- [TiDB 3.0.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.7/): TiDB 3.0.7 发布，修复了多个问题，包括本地时间落后导致锁的 TTL 过大、解析日期时时区不正确、整型数据转换精度丢失等问题。TiKV 也修复了死锁检测和内存泄漏问题。
+- [TiDB 3.0.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.8/): TiDB 3.0.8 发布，修复了 SQL 优化器、SQL 执行引擎、DDL、Server、Transaction、Monitor 等方面的多个问题。TiKV 也进行了多项修复和优化。PD 新增了一些功能，并升级了 etcd 版本。TiDB Ansible 进行了配置项回滚和优化，TiSpark 版本升级到 2.1.8。
+- [TiDB 3.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.0.9/): TiDB 3.0.9 发布日期为 2020 年 1 月 14 日。该版本修复了一些已知问题，并提升了性能。包括 Executor 修复了聚合函数作用于枚举和集合列时结果不正确的问题，Server 支持了系统变量 `auto_increment_increment` 和 `auto_increment_offset`，新增了监控项等。TiKV 提升了 Raft 成员变更的速度，新增了监控项用于监控 `waiter` 的生命周期等。PD 新增了一些功能和修复了一些问题。Tools 方面也有一些新增和优化。TiDB Ansible 优化了 Lightning 部署。
+- [TiDB 3.1 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta/): TiDB 3.1 Beta 发布说明：发版日期为 2019 年 12 月 20 日，TiDB 版本为 3.1.0-beta，TiDB Ansible 版本为 3.1.0-beta。TiDB 新增 SQL 优化器和丰富的 SQL hint 功能。另外，TiDB 还支持 Follower Read 功能。TiKV 新增支持分布式备份恢复功能和 Follower Read 功能。PD 也新增支持分布式备份恢复功能。
+- [TiDB 3.1 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.1/): TiDB 3.1 Beta.1 发布日期为 2020 年 1 月 10 日。TiDB 版本为 3.1.0-beta.1，TiDB Ansible 版本也为 3.1.0-beta.1。TiKV 新增了备份功能和 SST 文件恢复修复。Tools 中 BR 组件修复了备份进度信息不准确的问题，并新增了自动调度 PD schedulers 功能。TiDB Ansible 新增了初始化阶段自动关闭操作系统 THP 的功能和 BR 组件的 Grafana 监控。
+- [TiDB 3.1 Beta.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-beta.2/): TiDB 3.1 Beta.2 发布日期为 2020 年 3 月 9 日。该版本存在已知问题，建议使用最新版本。兼容性变化包括 TiDB Lightning 配置项优化和新增命令行参数。新功能包括支持在列属性上添加 `AutoRandom` 关键字，新增通过 DDL 语句为表创建、删除列存储副本的功能等。Bug 修复包括修复静默 Region 读数据处理不当导致无法处理读请求的问题等。
+- [TiDB 3.1 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-ga/): TiDB 3.1 GA 发布说明：兼容性变化包括支持报告状态配置项和 BR 不支持旧版 TiKV 集群恢复。新功能包括展示 coprocessor 任务信息和减少日志冗余信息。PD 优化热点 Region 调度，TiFlash 添加读写负载信息和支持函数下推。TiDB Ansible 新增 TiFlash 监控和优化配置参数。Bug 修复包括修复 merge join 和计算选择率问题。TiKV 修复 replica read 和 restore 问题，TiFlash 修复同步 schema 和数据丢失问题。TiDB Binlog 修复因 TiFlash 相关 DDL job 导致同步中断问题，BR 修复 checksum 和增量备份失败问题。
+- [TiDB 3.1 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.0-rc/): TiDB 3.1 RC 发布日期为 2020 年 4 月 2 日。该版本存在已知问题，建议使用最新版本 3.1.x。新功能包括性能提升、数据恢复、TLS 证书动态更新等。Bug 修复包括信息 schema 错误、DDL 卡住、冲突检测失效等。PD 修复了数据竞争、规则未遵守等问题。工具方面优化了性能、修复了数据错误和无法恢复的问题。
+- [TiDB 3.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.1/): TiDB 3.1.1 发布，新增了 auto_rand_base 表选项和 Feature ID 注释。TiFlash 优化了读写负载相关图表和 chunk encode decimal 数据的流程。修复了隔离读设置不生效、hash 分区表上的分区选择语法报错、update sql 中包含 view 仍然报错等问题。TiFlash 修复了非 normal 状态时读取数据错误、表名映射方式支持 recover table/flashback table、数据存储路径问题、读模型优化和特殊字符导致无法启动的问题。BR 修复了恢复带有 auto_random 属性的表后插入数据触发 duplicate entry 错误的问题。
+- [TiDB 3.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-3.1.2/): TiDB 3.1.2 发布日期为 2020 年 6 月 4 日。此版本修复了 TiKV 和 Tools 中的一些错误，包括 S3 和 GCS 备份恢复时的错误处理问题，备份过程中的 DefaultNotFound 错误，以及 BR 在备份恢复到 S3 和 GCS 存储时的稳定性提升等问题。同时还修复了 BR 在恢复数据时出现的一些错误，并增加了备份恢复 S3 时的 AWS KMS 服务端加密支持。
+- [TiDB 4.0 Beta Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta/): TiDB 4.0 Beta 发布说明：TiDB 版本 4.0.0-beta 和 TiDB Ansible 版本 4.0.0-beta 已发布。更新内容包括性能优化、新功能支持、bug 修复等。详细信息请查阅官方发布说明。
+- [TiDB 4.0 GA Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0-ga/): TiDB 4.0 GA 发布日期为 2020 年 5 月 28 日。该版本包含兼容性变化、重点修复的 Bug、新功能、Bug 修复等内容。其中 TiDB 新增了多项配置项和语法支持，TiFlash 修复了多项功能不一致的问题，TiKV 修复了多个备份和系统 panic 相关的问题，PD 修复了删除调度器和 presplit 功能无法正常使用的问题，Tools 中 BR 修复了从云存储恢复数据失败的问题，TiCDC 修复了多个系统 panic 和资源泄露的问题。
+- [TiDB 4.0 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc/): TiDB 4.0 RC 发布日期为 2020 年 4 月 8 日，版本为 4.0.0-rc，TiUP 版本为 0.0.3。该版本存在已知问题，建议使用最新版本 4.0.x。兼容性变化包括 TiDB、TiKV 和 Tools 的更新。重点修复了 TiDB 的 Bug，并新增了一些功能。TiKV 修复了启用 Follower Read 功能导致系统 Panic 的问题。Tools 中 TiDB Lightning 修复了字符转换错误导致数据错误的问题，TiCDC 新增了一些功能。
+- [TiDB 4.0 RC.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.1/): TiDB 4.0 RC.1 发布说明：TiDB 4.0.0-rc.1 版本兼容性变化包括 TiKV 默认关闭 hibernate region，TiDB Binlog 增加对 Sequence DDL 的支持。重点修复了多个 Bug，包括 TiDB 事务内执行 INSERT ... ON DUPLICATE KEY UPDATE 语句插入多行重复数据可能出错的问题等。新增功能包括 TiDB 支持发送 batch coprocessor 请求给 TiFlash 等。Bug 修复包括 TiDB 系统表由于 unsigned 列定义导致无法正确显示负数的问题等。
+- [TiDB 4.0 RC.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-rc.2/): TiDB 4.0 RC.2 发布说明：兼容性变化包括事务容量上限统一为 10GB，查询 CLUSTER_LOG 表需指定时间范围，CREATE TABLE 创建分区表时指定未支持的选项将创建非分区普通表。重点修复了多个 Bug。新增了备份和恢复语句，支持预检查单个 Region 提交数据量。TiKV 新增了加密存储适配和配置 gRPC 消息大小上限。PD 修复了 pd-ctl 命令错误和缺失监控的问题。TiFlash 优化了系统负载和新增了容量配置参数。Tools 方面修复了多个问题和优化了功能。
+- [TiDB 4.0.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.1/): TiDB 4.0.0 Beta.1 发布，包含兼容性变化、新功能和 Bug 修复。兼容性变化包括配置项类型修改和默认值调整。新增慢日志系统表支持查询任意时间段的日志，SQL 性能诊断功能和 Sequence 功能。Bug 修复包括视图创建、时区修改和函数表达式问题。TiKV 和 PD 也有新增功能和 Bug 修复。TiDB Ansible 新增部署多个 Grafana/Prometheus/Alertmanager 的功能和 TiFlash 监控 Dashboard。
+- [TiDB 4.0.0 Beta.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.0-beta.2/): TiDB 4.0.0 Beta.2 发布日期为 2020 年 3 月 18 日。该版本修复了 TiDB Binlog 在配置 `disable-dispatch`、`disable-causality` 时系统直接报错并退出的问题。新增了 TiKV 和 PD 支持将动态修改配置的结果持久化存储到硬盘的功能。另外，TiDB Binlog 新增了 TiDB 集群之间数据双向复制功能，TiDB Lightning 新增了配置 TLS 功能，新增了 TiCDC 工具，提供了进程级别的高可用能力。此外，BR 开启了增量备份、支持将备份文件存储在 AWS S3 等实验性功能。TiDB Ansible 新增了将节点信息注册到 etcd 的功能，新增支持在 ARM 平台上部署 TiDB 服务的功能。修复了 TiKV、PD 和 Tools 中的多个 bug。
+- [TiDB 4.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.1/): TiDB 4.0.1 发布日期为 2020 年 6 月 12 日。新功能包括 TiKV 添加 `--advertise-status-addr` 启动参数，PD 支持内部代理和客户端自定义超时设置，TiFlash 支持新的排序规则框架和函数下推，以及 BR 增加集群版本检查。Bug 修复方面，TiKV 修复了多个问题，PD 修复了错误配置和 panic 问题，TiFlash 修复了默认值解析和时区计算错误的问题。
+- [TiDB 4.0.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.10/): TiDB 4.0.10 发布日期为 2021 年 1 月 15 日。新功能包括 PD 添加了配置项 `enable-redact-log` 和 TiFlash 添加了配置项 `security.redact_info_log`。改进提升方面，TiDB 添加了 `txn-entry-size-limit` 配置项，PD 优化了 `store-state-filter` 监控，Tools 中 TiCDC 默认开启了 old value 特性。Bug 修复方面，TiDB 修复了多个并发导致的问题，TiKV 修复了 peer 和 ready 之间的错误映射，PD 修复了 ID 分配不是单调递增的问题，TiFlash 修复了多个启动和函数调用的问题，Tools 中 TiCDC 修复了多个协议和内存问题，Dumpling 修改了默认设置的行为。 Backup & Restore (BR) 修复了多个备份和恢复问题，TiDB Binlog 修复了启用 `AMEND TRANSACTION` 特性时的问题，TiDB Lightning 修复了多个备份和使用问题。
+- [TiDB 4.0.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.11/): TiDB 4.0.11 发布，新增支持 `uft8_unicode_ci` 和 `utf8mb4_unicode_ci` 排序规则。TiKV 支持 `utf8mb4_unicode_ci` 和 `cast_year_as_time` 排序规则。TiFlash 增加排队处理 Coprocessor 任务的线程池。改进包括重排由 `outer join` 简化的 `inner join` 顺序，Grafana 面板支持多集群，Bug 修复包括修复异常的 `unicode_ci` 常数传递等。PD 修复成员健康的监控显示不正确的问题。TiFlash 修复 Decimal 类型的 `min`/`max` 计算结果错误等。Tools 修复 TiCDC 服务在同时发生 `ErrTaskStatusNotExists` 和 `capture` 会话关闭的情况下的非预期的退出等。
+- [TiDB 4.0.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.12/): TiDB 4.0.12 发布，新增 TiFlash 工具用于检测状态。优化了 EXPLAIN 语句输出信息，在 metrics 监控中记录了 PREPARE 执行失败的问题。TiKV 修复了多个问题，包括处理 JSON 向字符串转换时空格缺失的问题。PD 修复了 store 缺失 label 的隔离级别错误问题。TiFlash 修复了多个查询结果错误的问题。TiCDC 修复了多个数据丢失和资源释放问题。BR 修复了多个备份和恢复问题。TiDB Lightning 修复了多个数据错误和文件损坏问题。
+- [TiDB 4.0.13 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.13/): TiDB 4.0.13 发布，新增 `AUTO_INCREMENT` 变更为 `AUTO_RANDOM` 功能，引入 `infoschema.client_errors_summary` 表。提升内存中统计信息缓存，减少 CPU 使用率。TiKV 提高 `store used size` 计算准确性，返回更多的 Region 以降低 Region miss。PD 优化 TSO 处理时间统计指标，更新 Dashboard 版本。TiFlash 自动清除过期历史数据。BR 支持备份恢复系统库，检查集群版本和备份数据版本。TiCDC 增加流程控制，清理陈旧临时文件，增加 HTTP 接口调用。修复多个 Bug。
+- [TiDB 4.0.14 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.14/): TiDB 4.0.14 发布，包含兼容性更改、功能增强、改进提升和 Bug 修复。兼容性更改包括默认值修改和配置项更新。功能增强包括监控项添加和新功能支持。改进提升包括算子优化和系统变量支持。Bug 修复包括查询结果错误和函数参数错误修复。PD、TiDB Dashboard、TiFlash 和 Tools 也有相关更新和修复。
+- [TiDB 4.0.15 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.15/): TiDB 4.0.15 发布，修复了执行 `SHOW VARIABLES` 速度慢的问题，以及多个 Bug 和兼容性变化。TiKV 支持动态修改 TiCDC 配置。TiDB 基于直方图的 row count 来触发 auto-analyze。TiKV 分离处理读写的 ready 状态以减少读延迟。PD 提升了同步 Region 信息的性能。BR 支持并发执行分裂和打散 Region 的操作。Dumpling 提升了 `SHOW TABLE STATUS` 的过滤效率。TiCDC 支持导入数据到带有表达式索引或带有基于虚拟生成列的索引的表中。修复了多个 Bug 和问题。
+- [TiDB 4.0.16 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.16/): TiDB 4.0.16 发布，包含兼容性更改、提升改进和 Bug 修复。TiKV 改进了对非法 UTF-8 字符串的处理，Tools 中 TiCDC 改变了 Kafka Sink 默认值。TiDB 升级了 Grafana，TiKV 使用 zstd 算法压缩 SST 文件。Bug 修复包括统计信息模块的查询崩溃、`ENUM` 类型控制函数返回结果不正确等问题。TiKV 修复了多个问题，包括 Decimal 除法计算结果为负、监控项中 gRPC 平均延迟时间不准确等问题。PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了无法启动的问题。Tools 中 TiDB Binlog 修复了 Drainer 传输事务超过 1 GB 时退出的问题，TiCDC 修复了多个问题。
+- [TiDB 4.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.2/): TiDB 4.0.2 发布，兼容性改进和新功能增加。TiDB 默认收集使用情况信息，并分享给 PingCAP 用于改善产品。新增功能包括支持 INSERT 语句中使用 MEMORY_QUOTA() hint，基于 TLS 证书 SAN 属性的登录认证，以及其他函数和表的新增配置项。Bug 修复包括执行计划不正确、运行时错误、内存统计过大等问题。PD、TiKV、TiFlash 和 TiCDC 也有相关改进和修复。Tools 中 Backup & Restore (BR) 提升了多表场景下的恢复数据性能。
+- [TiDB 4.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.3/): TiDB 4.0.3 发布了新版本，包括 TiDB Dashboard、TiFlash、Tools 和改进提升等多个方面的更新和修复。新增功能包括 TiDB Dashboard 显示详细信息、TiFlash 支持文件加密、Tools 支持多种算法压缩备份文件等。改进提升方面包括增加全局变量控制日志记录、加速执行速度、默认打开执行信息收集等。此外，还修复了多个 Bug，包括 gRPC transportReader 异常、数据不完整、无法正确设置 safepoint 等问题。
+- [TiDB 4.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.4/): TiDB 4.0.4 发布日期为 2020 年 7 月 31 日。此版本修复了多个 bug，包括查询 `information_schema.columns` 卡死的问题、`PointGet` 和 `BatchPointGet` 在遇到 `in(null)` 条件时出错的问题、`BatchPointGet` 算子结果不正确的问题以及 `HashJoin` 算子在遇到 `set`、`enum` 类型时查询结果不正确的问题。
+- [TiDB 4.0.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.5/): TiDB 4.0.5 发布，兼容性变化包括修改参数和添加状态检查。新增功能包括为错误定义错误码和支持统一的 log 格式。优化提升包括减少 GC 锁扫描次数和降低统计信息对性能的影响。Bug 修复包括函数错误处理和查询结果错误等。PD 修复了 TSO 不可用和 Region 调度问题。TiFlash 修复了进程启动和升级问题。Tools 修复了恢复缓慢和同步任务问题。
+- [TiDB 4.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.6/): TiDB 4.0.6 发布日期为 2020 年 9 月 15 日。新功能包括 TiFlash 中支持在广播 Join 中使用外连接，TiDB Dashboard 添加了多个页面和功能。TiCDC 从 v4.0.6 起成为正式功能。优化提升方面，TiDB 提升了分区表的写性能，支持调整 Union 执行算子的并发度等。Bug 修复方面，TiDB 修复了多个查询结果不正确的问题。TiKV 修复了统计信息估算错误的问题等。PD 修复了 store limit 的单位问题等。TiFlash 修复了多个启动失败和异常问题。Tools 方面也有多个问题得到解决。
+- [TiDB 4.0.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.7/): TiDB 4.0.7 发布，新增 PD 客户端函数 `GetAllMembers` 和 TiDB Dashboard 统计指标关系图支持。TiDB 优化了 `join` 算子执行信息和协处理器缓存命中率信息，支持将 `ROUND` 函数下推至 TiFlash，并修复了多个 bug。TiKV 支持日志输出为 JSON 格式，修复了 TLS 握手失败导致 Status API 不可用的问题。PD 修复了多个问题，TiFlash 修正了 right outer join 结果错误。Backup & Restore (BR) 修复了恢复数据后导致 TiDB 配置变更的错误，Dumpling 修复了 metadata 解析失败的问题。
+- [TiDB 4.0.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.8/): TiDB 4.0.8 发布，新增聚合函数 `APPROX_PERCENTILE` 和 `CAST` 函数下推支持。优化了索引组合计算表达式选择率的贪心算法，记录更多的 RPC 信息，提升慢查询性能。修复了多个 BUG，如分区表可能遇到非预期 Panic、外连接时 Index Merge Join 结果不正确等。 PD 修复了 TiDB Dashboard 引起 PD panic 的错误。TiFlash 修复了多个问题，如日志信息中时间戳错误、重启后可能提示数据文件损坏等。Backup & Restore (BR) 修复了 Restore 期间可能发生的 `send on closed channel` panic 问题。
+- [TiDB 4.0.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-4.0.9/): TiDB 4.0.9 发布日期为 2020 年 12 月 21 日。该版本包含兼容性更改、新功能、优化提升、Bug 修复等内容。兼容性更改包括废弃配置文件中的某些配置项。新功能包括 TiFlash 支持存储引擎的新数据分布在多个硬盘上等。优化提升方面包括避免生成 (index) merge join 以得到更好的执行计划等。Bug 修复方面包括修复了前缀索引和 `OR` 条件一起使用时结果不正确的问题等。
+- [TiDB 5.0 RC Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.0-rc/): TiDB 5.0.0-rc 版本是 5.0 版本的前序版本。在 5.0 版本中，我们专注于帮助企业基于 TiDB 数据库快速构建应用程序，提升数据库性能、降低写入数据延迟、稳定性、可用性、容灾、SQL 语句效率等问题。新增聚簇索引、异步提交事务、Raft Joint Consensus 算法、不可见索引、`EXCEPT`/`INTERSECT` 操作符、悲观事务执行成功概率、字符集和排序规则优化、错误信息和日志信息脱敏、优化器选择索引稳定性、调度功能优化、备份与恢复、数据导入导出、`EXPLAIN` 功能优化、TiUP 增强功能等特性。
+- [TiDB 5.0.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.1/): TiDB 5.0.1 发布日期为 2021 年 4 月 24 日。此版本包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括 TiDB 配置文件的默认值改变。改进提升方面，TiDB 支持 `VITESS_HASH()` 函数，TiKV 使用 `zstd` 压缩 Region Snapshot，PD 调整 Region 分数公式等。Bug 修复方面，TiDB 修复了多个查询结果可能错误的问题，TiKV 修复了多个导致问题的 Bug。Tools 方面也有多个 Bug 修复。
+- [TiDB 5.0.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.2/): TiDB 5.0.2 发布日期为 2021 年 6 月 10 日。此版本包含兼容性更改、新功能、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具中的参数废弃和 TiKV 默认开启 Hibernate Region 特性。新功能包括 BR 支持 S3 兼容的存储和 TiFlash 优化锁操作。提升改进方面，TiDB 避免后台作业频繁读取表造成高 CPU 使用率，TiKV 添加背压功能和减少扫描的内存使用量。Bug 修复方面，修复了多个问题，包括索引导致的 panic、事务中的语句不正确使用、排序规则写入错误值等。
+- [TiDB 5.0.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.3/): TiDB 5.0.3 发布日期为 2021 年 7 月 2 日。此版本包含兼容性更改、功能增强、提升改进和 Bug 修复。兼容性更改包括 `tidb_multi_statement_mode` 变量默认值变更和兼容 MySQL 5.7 的 noop 变量配置。功能增强方面，TiCDC 增加了 HTTP API 获取 changefeed 信息和节点健康信息。TiDB 提升了多个内置函数的支持和优化了聚合算子的代价常数。Bug 修复方面，修复了多个查询和函数使用时可能出现的问题。PD 升级了 TiDB Dashboard。TiFlash 支持了多个新功能和修复了多个问题。TiCDC、BR 和 TiDB Lightning 也进行了多项修复和优化。
+- [TiDB 5.0.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.4/): TiDB 5.0.4 发布日期为 2021 年 9 月 27 日。此版本包含兼容性更改、功能增强、提升改进、Bug 修复等内容。兼容性更改包括修复了 `SHOW VARIABLES` 速度慢的问题，系统变量 `tidb_stmt_summary_max_stmt_count` 默认值修改为 `3000` 等。功能增强包括支持将系统变量 `tidb_enforce_mpp` 的值设为 `1` 以忽略优化器代价估算，强制使用 MPP 模式。提升改进包括基于直方图的 row count 来触发 auto-analyze、支持 MPP 查询的重试等。Bug 修复包括修复了查询分区表且分区键带有 `IS NULL` 条件时 TiDB 可能 panic 的问题等。
+- [TiDB 5.0.5 Release Note](https://docs.pingcap.com/tidb/stable/release-5.0.5/): TiDB 5.0.5 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。详细信息请查看 issue
+- [TiDB 5.0.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.0.6/): TiDB 5.0.6 发布日期为 2021 年 12 月 31 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiCDC 工具的错误输出改为标准错误，以及 Kafka sink 模块的默认值设置。提升改进方面，TiDB 改进了 coprocessor 遇到锁时的调试日志显示，TiKV 提高了插入 SST 文件的速度，PD 优化了调度器退出的速度。Bug 修复方面，TiDB 修复了多个问题，包括乐观事务冲突、MPP 查询相关日志、DML 和 DDL 语句并发执行等。TiKV 修复了多个节点停机导致的问题，PD 修复了节点缩容后可能导致 Panic 的问题。TiFlash 修复了多个数据不一致的问题。TiCDC 修复了多个同步任务推进停滞的问题。Backup & Restore (BR) 修复了平均速度不准确的问题。Dumpling 修复了导出速度过慢的问题。
+- [TiDB 5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.0/): TiDB 5.1 版本新增了许多关键特性，包括对 MySQL 8 中的公共表表达式和动态权限的支持，以及对数据表列类型的在线变更。此外，还引入了新的统计信息类型和锁视图功能，以提升查询稳定性和性能。同时，TiDB 5.1 修复了许多 Bug，包括投影消除、列包含 NULL 值时查询结果错误等问题。这些改进和修复将提升 TiDB 的性能和稳定性。
+- [TiDB 5.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.1/): TiDB 5.1.1 发布，兼容性更改包括默认值修改和权限变更。功能增强方面新增 OIDC SSO 支持和 DAG 请求中的 `HAVING()` 函数。改进提升包括 Stale Read 成为正式功能、加快数据插入速度、稳定结果模式支持等。Bug 修复方面修复了多个问题，包括数据丢失、panic、数据不一致等。 Tools 方面也有多个修复，包括 TiCDC、Backup & Restore、TiDB Lightning。
+- [TiDB 5.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.2/): TiDB 5.1.2 发布，包含兼容性更改、改进提升、Bug 修复等内容。兼容性更改包括修复多个 Bug，改进提升包括根据直方图行数触发 auto-analyze、支持动态更改 TiCDC 配置项等。Bug 修复涉及 hash 列为 ENUM 类型时 index hash join 的结果可能出错、TiKV 从 v3.x 升级至较高版本后出现 Panic 等问题。Tools 方面的改进包括 BR 修复备份数据和恢复数据时显示的平均速度数值不准确的问题、Dumpling 修复特定 MySQL 版本下导致 dump 阶段卡死的问题等。
+- [TiDB 5.1.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.1.3/): TiDB 5.1.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
+- [TiDB 5.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.4/): TiDB 5.1.4 发布日期为 2022 年 2 月 22 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括系统变量 `tidb_analyze_version` 默认值修改为 `1`，以及 TiKV 在开启 `storage.enable-ttl` 后拒绝 TiDB 请求。提升改进方面，TiDB 支持在 Range 类型分区表中对 `IN` 表达式进行分区裁剪，TiKV 升级了 proc filesystem 版本。Bug 修复方面，修复了多个 TiDB 和 TiKV 的问题，包括内存泄露、配置项不生效、panic 等。Tools 方面也有多个修复和改进，包括 TiCDC、Backup & Restore、TiDB Binlog 和 TiDB Lightning。
+- [TiDB 5.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.1.5/): TiDB 5.1.5 发布日期为 2022 年 12 月 28 日。此版本包含 PD 默认关闭编译 swagger server 的兼容性变更以及 TiDB、TiKV、PD、TiFlash 和 Tools 中的多项 Bug 修复。修复内容涵盖了窗口函数执行、动态模式、函数传入值计算、left join 删除数据、SQL 语句计算、连接错误、索引错误、HTTP 服务异常、并发列类型变更、空闲链接、SESSION 变量、Region 合并、KV client 连接、TiDB Binlog 错误、TiKV 运行、Raftstore 线程、Region merge、Follower Read、Async Commit、网络问题、Unified Read Pool CPU 表达式、TLS、并行聚合、查询错误、日期格式、MPP query、数据回收、逻辑运算符、备份系统表、增量扫描、Sorter 组件监控数据和 ddl schema 缓存优化。
+- [TiDB 5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.0/): TiDB 5.2 版本于 2021 年 8 月 27 日发布。该版本新增了许多功能和改进，包括支持基于部分函数创建表达式索引、提升优化器的估算准确度、锁视图成为 GA 特性等。此外，还修复了多个 bug，提升了稳定性和性能。
+- [TiDB 5.2.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.1/): TiDB 5.2.1 发布日期为 2021 年 9 月 9 日。此版本修复了 TiDB 在分区中下推聚合算子时的执行计划和执行报错问题。同时，TiKV 修复了 Region 迁移时出现的死锁导致 TiKV 不可用的问题。用户可通过关闭调度并重启出问题的 TiKV 来临时应对。
+- [TiDB 5.2.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.2/): TiDB 5.2.2 发布日期为 2021 年 10 月 29 日。此版本包含了对 TiDB、TiKV、PD 和 Tools 的多项提升改进和 bug 修复。其中 TiDB 修复了多项问题，如 `plan cache` 无法感知 `unsigned` 标志变化、分区功能出现 `out of range` 时 `partition pruning` 出错等。TiKV 修复了因 Congest 错误而导致的 CDC 频繁增加 scan 重试的问题等。PD 修复了因超过副本配置数量而导致错误删除带有数据且处于 pending 状态的副本的问题等。TiFlash 修复了在部分平台上由于缺失 `nsl` 库而无法启动的问题。Tools 中的 TiCDC 也进行了多项修复，如当上游 TiDB 实例意外退出时，TiCDC 同步任务推进可能停滞的问题等。
+- [TiDB 5.2.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.2.3/): TiDB 5.2.3 发布日期为 2021 年 12 月 3 日，修复了 TiKV 中的 `GcKeys` 任务被多个键调用时无法正常进行的问题。这可能导致 Compaction Filter GC 不删除 MVCC deletion 信息。
+- [TiDB 5.2.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.2.4/): TiDB 5.2.4 发布日期为 2022 年 4 月 26 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB、TiKV 和 Tools 的调整。提升改进主要针对 TiKV 和 Tools 进行了优化。Bug 修复方面涉及 TiDB、TiKV、PD、TiFlash 和 Tools 的修复。
+- [TiDB 5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.0/): TiDB 5.3.0 版本发布了许多重要的功能和改进，包括临时表、表属性设置、TiDB Dashboard 安全性提升、PD 时间戳处理流程优化、DM 同步性能提升、TiDB Lightning 分布式并行导入等。此外，还修复了许多 bug，提升了稳定性和性能。
+- [TiDB 5.3.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.1/): TiDB 5.3.1 发布日期为 2022 年 3 月 3 日。此版本包含兼容性更改、提升改进和 Bug 修复。兼容性更改包括 TiDB Lightning 工具的默认值调整。提升改进包括 TiDB、TiKV 和 PD 的优化。Bug 修复包括 TiDB、TiKV、PD、TiFlash、Backup & Restore (BR)、TiCDC、TiDB Data Migration (DM) 和 TiDB Lightning 工具的问题修复。
+- [TiDB 5.3.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.2/): TiDB 5.3.2 发布日期为 2022 年 6 月 29 日。该版本存在 bug，建议升级至 v5.3.3。兼容性变更包括修复了 auto ID 超出范围时的问题。TiKV 提升了 Raft 客户端的效率，并修复了多个 bug。TiDB 修复了多个 bug，包括 Amazon S3 数据计算错误和网络连接问题。PD 也修复了多个 bug。TiFlash 修复了存储目录配置错误和数据不一致的问题。BR 和 TiCDC 也有多个 bug 修复。DM 和 TiDB Lightning 也有 bug 修复。
+- [TiDB 5.3.3 Release Note](https://docs.pingcap.com/tidb/stable/release-5.3.3/): TiDB 5.3.3 发布日期为 2022 年 9 月 14 日。此版本修复了 TiKV 存在的 bug，该 bug 导致在执行 SQL 语句时出现持续报错的问题。影响版本为 v5.3.2 和 v5.4.2，已在 v5.3.3 上修复。如果使用 v5.3.2 的 TiDB 集群，可以升级至 v5.3.3。除升级外，还可以重启无法向 PD 发送 Region 心跳的 TiKV 节点，直至不再有待发送的 Region 心跳为止。
+- [TiDB 5.3.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.3.4/): TiDB 5.3.4 发布，提升了 TiKV 的自动 TLS 证书重新加载功能。修复了 TiDB、PD 和 TiFlash 的多个 bug，包括 Region 合并、权限清理、连接失败等问题。同时修复了工具 Dumpling 和 TiCDC 的导出数据和同步任务状态不正确的问题。
+- [TiDB 5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.0/): TiDB 5.4.0 版本发布日期为 2022 年 2 月 15 日。此版本新增了许多功能和改进，包括支持 GBK 字符集、索引合并、有界限过期数据读取、统计信息采集配置持久化等。同时还修复了许多 bug，提升了稳定性和性能。
+- [TiDB 5.4.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.1/): TiDB 5.4.1 发布日期为 2022 年 5 月 13 日。该版本未引入产品设计上的兼容性变化，但 Bug 修复可能带来兼容性变更。提升改进包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个方面的改进。Bug 修复方面包括对 TiDB、TiKV、PD、TiFlash 和 Tools 的多个问题的修复。
+- [TiDB 5.4.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.2/): TiDB 5.4.2 发布日期为 2022 年 7 月 8 日。该版本存在 bug，建议升级至 v5.4.3。此版本提升了 TiDB、TiKV、PD 和 Tools 的稳定性和可用性，并修复了多个 bug。
+- [TiDB 5.4.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-5.4.3/): TiDB 5.4.3 发布，提升了 TiKV 和 Tools 的功能，修复了多个 Bug。包括 TiKV 支持更小的 RocksDB write stall 参数，TiDB 修复了多个查询和执行时可能出现的问题。PD 也修复了一些请求和权限问题。TiFlash 修复了一些函数和并行聚合的错误。Tools 中的 TiDB Lightning 修复了一些数据导入和连接问题，DM 修复了一些数据同步和连接问题，BR 修复了备份恢复和 Region 不均衡的问题，Dumpling 修复了 IPv6 的支持问题。
+- [TiDB 6.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.0.0-dmr/): 了解 TiDB 6.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.0/): 了解 TiDB 6.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.1/): TiDB 6.1.1 发布日期为 2022 年 9 月 1 日。该版本兼容性变更包括大小写敏感语句不再敏感，以及默认关闭持续性能分析特性。其他变更包括新增内容和不同操作系统和 CPU 架构的支持。提升改进方面，引入了新的优化器提示和支持通过 gzip 压缩 metrics 响应减少 HTTP body 大小。Bug 修复方面，修复了多个 TiDB、TiKV、PD 和 TiFlash 的问题。 Tools 方面，TiDB Lightning 修复了多个问题，TiDB Data Migration (DM) 修复了多个问题，TiCDC 修复了多个问题，Backup & Restore (BR) 修复了多个问题，Dumpling 修复了一个问题，TiDB Binlog 修复了一个问题。
+- [TiDB 6.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.2/): TiDB 6.1.2 发布，包括 TiDB、TiKV、Tools 和 Bug 修复。提升改进包括允许在一张表上同时设置数据放置规则和 TiFlash 副本。Bug 修复包括修复数据库级别的权限清理不正确的问题。
+- [TiDB 6.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.3/): TiDB 6.1.3 发布日期为 2022 年 12 月 5 日。此版本兼容性变更包括 TiCDC 的默认值修改和事务拆分功能的优化。提升改进方面，PD 优化了锁的粒度，TiCDC 默认关闭 safeMode 并开启大事务拆分功能。此外，为了提升 TiDB 稳定性，Go 编译器版本从 go1.18 升级到了 go1.19。Bug 修复方面，修复了多个 TiDB、PD、TiKV、TiFlash 和 Tools 的问题。
+- [TiDB 6.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.4/): 了解 TiDB 6.1.4 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.5/): 了解 TiDB 6.1.5 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.6/): 了解 TiDB 6.1.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.1.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.1.7/): 了解 TiDB 6.1.7 版本的改进提升与错误修复。
+- [TiDB 6.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.2.0/): 了解 TiDB 6.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.3.0/): 了解 TiDB 6.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.4.0/): 了解 TiDB 6.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.0/): 了解 TiDB 6.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.1/): 了解 TiDB 6.5.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.10 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.10/): 了解 TiDB 6.5.10 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.11 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.11/): 了解 TiDB 6.5.11 版本的改进提升和错误修复。
+- [TiDB 6.5.12 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.12/): 了解 TiDB 6.5.12 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.2/): 了解 TiDB 6.5.2 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.3/): 了解 TiDB 6.5.3 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.4/): 了解 TiDB 6.5.4 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.5/): 了解 TiDB 6.5.5 版本的改进提升与错误修复。
+- [TiDB 6.5.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.6/): 了解 TiDB 6.5.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.7 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.7/): 了解 TiDB 6.5.7 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.8 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.8/): 了解 TiDB 6.5.8 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.5.9 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.5.9/): 了解 TiDB 6.5.9 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 6.6.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-6.6.0/): 了解 TiDB 6.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.0.0/): 了解 TiDB 7.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.0/): 了解 TiDB 7.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.1/): 了解 TiDB 7.1.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.2/): 了解 TiDB 7.1.2 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.3/): 了解 TiDB 7.1.3 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.4/): 了解 TiDB 7.1.4 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.5/): 了解 TiDB 7.1.5 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.1.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.1.6/): 了解 TiDB 7.1.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.2.0/): 了解 TiDB 7.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.3.0/): 了解 TiDB 7.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.4.0/): 了解 TiDB 7.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.0/): 了解 TiDB 7.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.1/): 了解 TiDB 7.5.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.2/): 了解 TiDB 7.5.2 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.3 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.3/): 了解 TiDB 7.5.3 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.4 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.4/): 了解 TiDB 7.5.4 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.5 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.5/): 了解 TiDB 7.5.5 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.5.6 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.5.6/): 了解 TiDB 7.5.6 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 7.6.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-7.6.0/): 了解 TiDB 7.6.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.0.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.0.0/): 了解 TiDB 8.0.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.1.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.0/): 了解 TiDB 8.1.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.1.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.1/): 了解 TiDB 8.1.1 版本的兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.1.2 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.1.2/): 了解 TiDB 8.1.2 版本的改进提升和错误修复。
+- [TiDB 8.2.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.2.0/): 了解 TiDB 8.2.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.3.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.3.0/): 了解 TiDB 8.3.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.4.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.4.0/): 了解 TiDB 8.4.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.5.0 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.5.0/): 了解 TiDB 8.5.0 版本的新功能、兼容性变更、改进提升，以及错误修复。
+- [TiDB 8.5.1 Release Notes](https://docs.pingcap.com/tidb/stable/release-8.5.1/): 了解 TiDB 8.5.1 版本的操作系统支持变更、改进提升，以及错误修复。
+- [TiDB Control 使用说明](https://docs.pingcap.com/tidb/stable/tidb-control/): TiDB Control 是 TiDB 的命令行工具，用于获取 TiDB 状态信息和调试。可通过 TiUP 安装或从源代码编译安装。使用介绍包括命令、选项和参数组成，以及全局参数和各子命令的功能。其中包括获取帮助信息、解码 base64 数据、解码 row key 和 value、操作 etcd、格式化日志文件，以及查询关键 key range 信息。注意：TiDB Control 主要用于诊断调试，不保证和 TiDB 未来引入的新特性完全兼容。
+- [TiDB Dashboard SQL 语句分析列表页面](https://docs.pingcap.com/tidb/stable/dashboard-statement-list/): 查看所有 SQL 语句在集群上执行情况
+- [TiDB Dashboard SQL 语句分析执行详情页面](https://docs.pingcap.com/tidb/stable/dashboard-statement-details/): 查看单个 SQL 语句执行的详细情况
+- [TiDB Dashboard Top SQL 页面](https://docs.pingcap.com/tidb/stable/top-sql/): 使用 Top SQL 找到 CPU 开销较大的 SQL 语句
+- [TiDB Dashboard 介绍](https://docs.pingcap.com/tidb/stable/dashboard-intro/): TiDB Dashboard 是 TiDB 4.0 版本后提供的图形化界面，用于监控和诊断集群。它内置于 TiDB 的 PD 组件中，无需独立部署。可以查看集群整体运行概况、组件及主机运行状态、集群读写流量分布、SQL 查询的执行信息、耗时较长的 SQL 语句执行信息、诊断集群问题并生成报告、查询所有组件日志、预估资源管控容量、收集分析各个组件的性能数据。
+- [TiDB Dashboard 实例性能分析 - 手动分析页面](https://docs.pingcap.com/tidb/stable/dashboard-profiling/): 了解如何收集集群各个实例当前性能数据，从而分析复杂问题
+- [TiDB Dashboard 实例性能分析 - 持续分析页面](https://docs.pingcap.com/tidb/stable/continuous-profiling/): 了解如何持续地收集 TiDB、TiKV、PD 各个实例的性能数据，缩短平均故障恢复时间
+- [TiDB Dashboard 常见问题](https://docs.pingcap.com/tidb/stable/dashboard-faq/): TiDB Dashboard 常见问题汇总，包括访问、界面功能方面的常见问题与解决办法。若无法解决，请获取官方或社区支持。
+- [TiDB Dashboard 慢查询页面](https://docs.pingcap.com/tidb/stable/dashboard-slow-query/): 了解如何在 TiDB Dashboard 中查看慢查询。
+- [TiDB Dashboard 日志搜索页面](https://docs.pingcap.com/tidb/stable/dashboard-log-search/): 在集群中搜索所有节点上的日志
+- [TiDB Dashboard 概况页面](https://docs.pingcap.com/tidb/stable/dashboard-overview/): TiDB Dashboard 概况页面显示整个集群的 QPS、查询延迟、Top SQL 语句、最近的慢查询、实例状态和监控及告警信息。登录后默认进入该页面，也可通过左侧导航条点击概况进入。包含最近一小时整个集群的 QPS 和查询延迟，以及最近一段时间内累计耗时最多的 SQL 语句和运行时间超过一定阈值的慢查询。还显示各个实例的节点数和状态，以及提供了便捷的链接方便用户查看详细监控或告警。
+- [TiDB Dashboard 流量可视化页面](https://docs.pingcap.com/tidb/stable/dashboard-key-visualizer/): TiDB Dashboard 的流量可视化页面可用于分析 TiDB 集群的使用模式和排查流量热点。通过登录 TiDB Dashboard 或在浏览器中访问指定链接，可以查看流量可视化页面。页面展示了流量热力图，可观察到整体访问流量随时间的变化情况，以及热力图某个坐标的详细信息。流量可视化页面涉及的基本概念包括 Region、热点、热力图和 Region 压缩。使用介绍包括设置、观察时间段或 Region 范围、调整亮度、选择指标、刷新与自动刷新以及查看详情。常见热力图解读包括均衡结果、X 轴明暗交替、Y 轴明暗交替和明亮斜线。解决热点问题可参考 TiDB 高并发写入场景最佳实践。
+- [TiDB Dashboard 用户管理](https://docs.pingcap.com/tidb/stable/dashboard-user/): 了解如何创建 SQL 用户用于访问 TiDB Dashboard
+- [TiDB Dashboard 监控关系图](https://docs.pingcap.com/tidb/stable/dashboard-metrics-relation/): 了解 TiDB Dashboard 监控关系图
+- [TiDB Dashboard 监控页面](https://docs.pingcap.com/tidb/stable/dashboard-monitoring/): 介绍如何通过 TiDB Dashboard 监控页面查看 Performance Overview 面板，以及如何理解面板上的关键指标项。
+- [TiDB Dashboard 诊断报告](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-report/): TiDB Dashboard 诊断报告介绍了诊断报告的内容和查看技巧。报告包括基本信息、诊断信息、负载信息、概览信息、TiDB/PD/TiKV 监控信息和配置信息。对比报告显示两个时间段的差异，通过 DIFF_RATIO 和 Maximum Different Item 报表可以快速发现监控项的差异。
+- [TiDB Dashboard 资源管控页面](https://docs.pingcap.com/tidb/stable/dashboard-resource-manager/): 介绍如何使用 TiDB Dashboard 的资源管控页面查看资源管控相关信息，以便预估集群容量，更好地进行资源配置。
+- [TiDB Dashboard 集群信息页面](https://docs.pingcap.com/tidb/stable/dashboard-cluster-info/): 查看整个集群中 TiDB、TiKV、PD、TiFlash 组件的运行状态及其所在主机的运行状态
+- [TiDB Dashboard 集群诊断页面](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-access/): TiDB Dashboard 集群诊断页面是用于诊断集群问题并生成诊断报告的工具。可以通过 TiDB Dashboard 或浏览器访问诊断页面。生成诊断报告的步骤包括设置时间范围和长度，然后点击开始。还可以生成对比报告来比较异常时间段和正常时间段的情况。已生成的报告会显示在主页列表中，可随时查看。
+- [TiDB Data Migration 1.0.x 到 2.0+ 手动升级](https://docs.pingcap.com/tidb/stable/manually-upgrade-dm-1.0-to-2.0/): 了解如何从 TiDB Data Migration 1.0.x 手动升级到 2.0+。
+- [TiDB Data Migration Binlog 事件过滤](https://docs.pingcap.com/tidb/stable/dm-binlog-event-filter/): 了解 DM 的关键特性 binlog 事件过滤 (Binlog event filter) 的使用方法和注意事项。
+- [TiDB Data Migration 上游数据库配置文件介绍](https://docs.pingcap.com/tidb/stable/dm-source-configuration-file/): TiDB Data Migration (DM) 上游数据库配置文件包括示例与配置项说明。示例配置文件包括上游数据库的配置项，如是否开启 GTID、是否开启 relay log、拉取上游 binlog 的起始文件名等。配置项说明包括全局配置、relay log 清理策略配置、任务状态检查配置和 Binlog event filter。配置项包括标识一个 MySQL 实例、是否使用 GTID 方式、是否开启 relay log、存储 relay log 的目录等。从 DM v2.0.2 开始，Binlog event filter 也可以在上游数据库配置文件中进行配置。
+- [TiDB Data Migration 任务前置检查](https://docs.pingcap.com/tidb/stable/dm-precheck/): 了解 DM 执行数据迁移任务时将进行的前置检查。
+- [TiDB Data Migration 兼容性目录](https://docs.pingcap.com/tidb/stable/dm-compatibility-catalog/): 了解 DM 各版本与上下游各类型数据库的兼容关系
+- [TiDB Data Migration 分库分表合并](https://docs.pingcap.com/tidb/stable/dm-shard-merge/): 了解 DM 的分库分表合并功能。
+- [TiDB Data Migration 命令行参数](https://docs.pingcap.com/tidb/stable/dm-command-line-flags/): 介绍 DM 各组件的主要命令行参数。
+- [TiDB Data Migration 处理告警](https://docs.pingcap.com/tidb/stable/dm-handle-alerts/): 了解 DM 中各主要告警信息的处理方法。
+- [TiDB Data Migration 对 online DDL 工具的支持](https://docs.pingcap.com/tidb/stable/dm-online-ddl-tool-support/): 了解 DM 对常见 online DDL 工具的支持情况，使用方法和注意事项。
+- [TiDB Data Migration 导出和导入集群的数据源和任务配置](https://docs.pingcap.com/tidb/stable/dm-export-import-config/): 了解 TiDB Data Migration 导出和导入集群的数据源和任务配置。
+- [TiDB Data Migration 快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-dm/): 了解如何使用 TiUP Playground 快速部署试用 TiDB Data Migration 数据迁移工具。
+- [TiDB Data Migration 性能问题及处理方法](https://docs.pingcap.com/tidb/stable/dm-handle-performance-issues/): 了解 DM 可能存在的常见性能问题及其处理方法。
+- [TiDB Data Migration 故障及处理方法](https://docs.pingcap.com/tidb/stable/dm-error-handling/): 了解 DM 的错误系统及常见故障的处理方法。
+- [TiDB Data Migration 数据迁移任务配置向导](https://docs.pingcap.com/tidb/stable/dm-task-configuration-guide/): 本文介绍了如何配置 TiDB Data Migration (DM) 的数据迁移任务。包括配置数据源、目标 TiDB 集群、需要迁移的表、需要过滤的操作、数据源表到目标 TiDB 表的映射以及分库分表合并等配置。详细配置规则可参考相关链接。
+- [TiDB Data Migration 日常巡检](https://docs.pingcap.com/tidb/stable/dm-daily-check/): 了解 DM 工具的日常巡检。
+- [TiDB Data Migration 术语表](https://docs.pingcap.com/tidb/stable/dm-glossary/): 学习 TiDB Data Migration 相关术语
+- [TiDB Data Migration 查询任务状态](https://docs.pingcap.com/tidb/stable/dm-query-status/): 深入了解 TiDB Data Migration 如何查询数据迁移任务状态
+- [TiDB Data Migration 版本发布历史](https://docs.pingcap.com/tidb/stable/dm-release-notes/): TiDB Data Migration 版本发布历史从 DM v5.4.0 起，TiDB Data Migration 的 Release Notes 合并入相同版本号的 TiDB Release Notes。如需阅读 v5.4.0 及之后版本的 DM Release Notes，请查看对应版本的 TiDB Release Notes 中 DM 相关的内容。如需阅读 v5.3.0 及更早版本的 DM Release Notes，请参考以下链接：5.3.0, 2.0.7, 2.0.6, 2.0.5, 2.0.4, 2.0.3, 2.0.2, 2.0.1, 2.0 GA, 2.0.0-rc.2, 2.0.0-rc, 1.0.7, 1.0.6, 1.0.5, 1.0.4, 1.0.3, 1.0.2.
+- [TiDB Data Migration 生成自签名证书](https://docs.pingcap.com/tidb/stable/dm-generate-self-signed-certificates/): 了解如何生成自签名证书。
+- [TiDB Data Migration 简介](https://docs.pingcap.com/tidb/stable/dm-overview/): 了解 TiDB Data Migration
+- [TiDB Data Migration 表路由](https://docs.pingcap.com/tidb/stable/dm-table-routing/): 了解 DM 的关键特性表路由 (Table Routing) 的使用方法和注意事项。
+- [TiDB Data Migration 集群软硬件环境需求](https://docs.pingcap.com/tidb/stable/dm-hardware-and-software-requirements/): 了解部署 DM 集群的软件和硬件要求。
+- [TiDB Data Migration 黑白名单过滤](https://docs.pingcap.com/tidb/stable/dm-block-allow-table-lists/): 了解 DM 的关键特性黑白名单过滤 (Block & Allow List) 的使用方法和注意事项。
+- [TiDB Lightning Web 界面](https://docs.pingcap.com/tidb/stable/tidb-lightning-web-interface/): 了解 TiDB Lightning 的服务器模式——通过 Web 界面来控制 TiDB Lightning。
+- [TiDB Lightning 前置检查](https://docs.pingcap.com/tidb/stable/tidb-lightning-prechecks/): 本文档介绍了 TiDB Lightning 前置检查功能，确保 TiDB Lightning 能够顺利执行任务。
+- [TiDB Lightning 命令行参数](https://docs.pingcap.com/tidb/stable/tidb-lightning-command-line-full/): 使用命令行配置 TiDB Lightning。
+- [TiDB Lightning 常见问题](https://docs.pingcap.com/tidb/stable/tidb-lightning-faq/): TiDB Lightning 常见问题的摘要：TiDB Lightning 对TiDB/TiKV/PD 的最低版本要求，支持导入多个库，对下游数据库的账号权限要求，导数据过程中某个表报错不会影响其他表，正确重启 TiDB Lightning 的步骤，校验导入数据的正确性方法，支持的数据源格式，禁止导入不合规数据的方法，结束 tidb-lightning 进程的操作，使用千兆网卡的建议，TiDB Lightning 预留空间的原因，清除与 TiDB Lightning 相关的中间数据的步骤，获取 TiDB Lightning 运行时的 goroutine 信息的方法，TiDB Lightning 不兼容 Placement Rules in SQL 的原因，使用 TiDB Lightning 和 Dumpling 复制 schema 的步骤。
+- [TiDB Lightning 并行导入](https://docs.pingcap.com/tidb/stable/tidb-lightning-distributed-import/): 本文档介绍了 TiDB Lightning 并行导入的概念、使用场景和使用方法。
+- [TiDB Lightning 快速上手](https://docs.pingcap.com/tidb/stable/get-started-with-tidb-lightning/): TiDB Lightning 可快速将 MySQL 数据导入到 TiDB 集群中。首先使用 Dumpling 导出数据，然后部署 TiDB 集群。安装最新版本的 TiDB Lightning 并启动，最后检查数据导入情况。详细功能和使用请参考 TiDB Lightning 简介。
+- [TiDB Lightning 故障处理](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-lightning/): 本文档总结了使用 TiDB Lightning 过程中常见的运行故障及解决方案。
+- [TiDB Lightning 数据源](https://docs.pingcap.com/tidb/stable/tidb-lightning-data-source/): 了解 TiDB Lightning 支持的各类型数据源。
+- [TiDB Lightning 断点续传](https://docs.pingcap.com/tidb/stable/tidb-lightning-checkpoints/): TiDB Lightning 提供了“断点续传”的功能，即使 `tidb-lightning` 崩溃，在重启时仍然接着之前的进度继续工作。断点续传可通过配置启用，存储方式包括本地文件和 MySQL 数据库。在出现不可恢复的错误时，可以使用 `tidb-lightning-ctl` 工具来控制断点的处理，包括重置断点状态、清除出错状态和移除断点。
+- [TiDB Lightning 术语表](https://docs.pingcap.com/tidb/stable/tidb-lightning-glossary/): 了解 TiDB Lightning 相关的术语及定义。
+- [TiDB Lightning 监控告警](https://docs.pingcap.com/tidb/stable/monitor-tidb-lightning/): TiDB Lightning 支持使用Prometheus采集监控指标。监控配置需手动部署，配置方法在 tidb-lightning.toml 中。Grafana 面板可用于监控速度、进度、资源使用和存储空间。监控指标包括计数器和直方图，用于计算引擎文件数量、闲置 worker、KV 编码器、处理过的表、引擎文件和 Chunks的状态，以及导入每个表所需时间等。
+- [TiDB Lightning 目标数据库要求](https://docs.pingcap.com/tidb/stable/tidb-lightning-requirements/): 了解 TiDB Lightning 运行时对目标数据库的必需条件。
+- [TiDB Lightning 简介](https://docs.pingcap.com/tidb/stable/tidb-lightning-overview/): TiDB Lightning 是用于导入 TB 级数据到 TiDB 的工具。了解 TiDB Lightning 的基本原理和使用方法。
+- [TiDB Lightning 配置参数](https://docs.pingcap.com/tidb/stable/tidb-lightning-configuration/): 使用配置文件或命令行配置 TiDB Lightning。
+- [TiDB Lightning 错误处理功能](https://docs.pingcap.com/tidb/stable/tidb-lightning-error-resolution/): 介绍了如何解决导入数据过程中的类型转换和冲突错误。
+- [TiDB OOM 故障排查](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-oom/): TiDB OOM 故障排查总结了 OOM 常见问题的解决思路、故障现象、原因、解决方法和需要收集的诊断信息。排查思路包括确认是否属于 OOM 问题和进一步排查触发 OOM 的原因。常见故障原因包括部署问题、数据库问题和客户端问题。处理 OOM 问题需要收集操作系统内存配置、数据库版本和内存配置、Grafana TiDB 内存使用情况等信息。详细排查方法请参考相关章节。
+- [TiDB Operator](https://docs.pingcap.com/tidb/stable/tidb-operator-overview/): 了解 Kubernetes 上的 TiDB 集群自动部署运维工具 TiDB Operator。
+- [TiDB Pre-GA Release Notes](https://docs.pingcap.com/tidb/stable/release-pre-ga/): TiDB Pre-GA 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。TiDB 改进了 SQL 查询优化器、大量 MySQL 兼容性相关功能、支持 Natural Join、JSON 类型支持、裁剪无用数据、支持在 SQL 语句中设置优先级、完成表达式重构。PD 支持手动切换 PD 集群 Leader。TiKV 改进了 Raft Log 使用独立的 RocksDB 实例、使用 DeleteRange 加快删除副本速度、Coprocessor 支持更多运算符下推、提升性能和稳定性。TiSpark Beta Release 支持谓词下推、支持聚合下推、支持范围裁剪。
+- [TiDB RC1 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.1/): TiDB RC1 于 2016 年 12 月 23 日发布，TiKV 提升了写入速度和稳定性，支持百 TB 级别数据，集群规模支持 200 个节点。PD 优化了调度策略框架，添加了 label 支持，提供了 PD Control。TiDB 新增了 SQL 查询优化器和更多 MySQL 内建函数，重构了 time 相关类型的实现，提升了和 MySQL 的兼容性。工具方面，Loader 兼容 Percona 的 Mydumper 数据格式，提供了多线程导入、出错重试、断点续传等功能，并且针对 TiDB 有优化。完成了一键部署工具。
+- [TiDB RC2 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.2/): TiDB RC2 版本发布，提升了 MySQL 兼容性、SQL 优化器、系统稳定性和性能。对于 OLTP 场景，读取性能提升 60%，写入性能提升 30%。新增权限管理功能，支持基本权限管理和大量 MySQL 内建函数。完善监控，修复 Bug 和内存泄漏问题。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，支持更多下推功能，加入更多统计，修复 Bug。
+- [TiDB RC3 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.3/): TiDB RC3 版本发布，对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了负载均衡调度策略和流程，完善权限管理功能，DDL 速度显著提升。开源了 TiDB Ansible 项目，可以一键部署 / 升级 / 启停 TiDB 集群。PD 支持 Label 对副本进行 Location 调度，基于 region 数量的快速调度，pd-ctl 支持更多功能。TiKV 支持 Async Apply 提升整体写入性能，优化单行读事务性能，修复 Bug。
+- [TiDB RC4 Release Notes](https://docs.pingcap.com/tidb/stable/release-rc.4/): TiDB RC4 版本对 MySQL 兼容性、SQL 优化器、系统稳定性、性能做了大量工作。重点优化了写入速度，计算任务调度支持优先级，避免分析型大事务影响在线事务。SQL 优化器全新改版，查询代价估算更准确，且能自动选择 Join 物理算子。功能方面进一步 MySQL 兼容性。同时开源了 TiSpark 项目，可以通过 Spark 读取和分析 TiKV 中的数据。PD 支持通过 PD 设置 TiKV location labels，调度优化，优化数据加载，加快 failover 速度。 TiKV 支持查询优先级设置，支持 RC 隔离级别，完善 Jepsen，支持 Document Store，提升性能，提升稳定性。TiSpark Beta Release 支持谓词下推，支持聚合下推，支持范围裁剪。
+- [Tidb Roadmap](https://docs.pingcap.com/zh/tidb/dev/tidb-roadmap): External documentation: https://docs.pingcap.com/zh/tidb/dev/tidb-roadmap
+- [TiDB 中的 TimeStamp Oracle (TSO)](https://docs.pingcap.com/tidb/stable/tso/): 了解 TiDB 中的 TimeStamp Oracle (TSO)。
+- [TiDB 中的各种超时](https://docs.pingcap.com/tidb/stable/dev-guide-timeouts-in-tidb/): 简单介绍 TiDB 中的各种超时，为排查错误提供依据。
+- [TiDB 乐观事务模型](https://docs.pingcap.com/tidb/stable/optimistic-transaction/): 了解 TiDB 的乐观事务模型。
+- [TiDB 事务概览](https://docs.pingcap.com/tidb/stable/transaction-overview/): 了解 TiDB 中的事务。
+- [TiDB 事务隔离级别](https://docs.pingcap.com/tidb/stable/transaction-isolation-levels/): 了解 TiDB 事务的隔离级别。
+- [TiDB 产品常见问题](https://docs.pingcap.com/tidb/stable/tidb-faq/): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理，具备水平扩容、高可用、实时 HTAP、云原生的特性。TiDB 不是基于 MySQL 开发的，而是由 PingCAP 团队完全自主开发的产品。TiDB 易用性很高，支持绝大部分 MySQL 8.0 的语法，但不支持触发器、存储过程、自定义函数等。TiDB 支持分布式事务，兼容 MySQL Client/Driver 的编程语言，支持其他存储引擎，如 TiKV、UniStore 和 MockTiKV。获取 TiDB 知识的途径包括官方文档、官方博客、AskTUG 社区论坛和 PingCAP Education。用户名长度限制为 32 个字符，最大列数为 1017，单行大小不超过 6MB。TiDB 不支持 XA，但支持对列存储引擎的高并发 INSERT 或 UPDATE 操作。
+- [TiDB 产品常见问题解答汇总](https://docs.pingcap.com/tidb/stable/faq-overview/): 汇总 TiDB 产品的常见问题解答。
+- [TiDB 使用限制](https://docs.pingcap.com/tidb/stable/tidb-limitations/): TiDB 中的使用限制包括标识符长度限制、数据库、表、视图、连接总个数限制、单个数据库和表的限制、单行限制、数据类型限制、SQL 语句限制和 TiKV 版本限制。
+- [TiDB 全局排序](https://docs.pingcap.com/tidb/stable/tidb-global-sort/): 了解 TiDB 全局排序功能的使用场景、限制、使用方法和实现原理。
+- [TiDB 内存控制文档](https://docs.pingcap.com/tidb/stable/configure-memory-usage/): TiDB 内存控制文档介绍了如何追踪和控制 SQL 查询过程中的内存使用情况，以及配置内存使用阈值和 tidb-server 实例的内存使用阈值。还介绍了使用 INFORMATION_SCHEMA 系统表查看内存使用情况，以及降低写入事务内存使用的方法。另外还介绍了流量控制和数据落盘的内存控制策略，以及通过设置环境变量 GOMEMLIMIT 缓解 OOM 问题。
+- [TiDB 分布式执行框架](https://docs.pingcap.com/tidb/stable/tidb-distributed-execution-framework/): 了解 TiDB 分布式执行框架的使用场景、限制、使用方法和实现原理。
+- [TiDB 功能概览](https://docs.pingcap.com/tidb/stable/basic-features/): 了解 TiDB 的功能概览。
+- [TiDB 增量备份与恢复使用指南](https://docs.pingcap.com/tidb/stable/br-incremental-guide/): 了解 TiDB 的增量备份与恢复功能使用。
+- [TiDB 备份与恢复功能使用概述](https://docs.pingcap.com/tidb/stable/br-use-overview/): 了解如何部署和使用 TiDB 集群的备份与恢复。
+- [TiDB 备份与恢复功能架构概述](https://docs.pingcap.com/tidb/stable/backup-and-restore-design/): 了解 TiDB 的备份与恢复功能的架构设计。
+- [TiDB 备份与恢复实践示例](https://docs.pingcap.com/tidb/stable/backup-and-restore-use-cases/): 介绍 TiDB 备份与恢复的具体使用示例，包括推荐环境配置、存储配置、备份策略及如何进行备份与恢复。
+- [TiDB 备份与恢复概述](https://docs.pingcap.com/tidb/stable/backup-and-restore-overview/): 了解不同场景下如何使用 TiDB 的备份与恢复功能，以及不同功能、版本间的兼容性。
+- [TiDB 安全配置最佳实践](https://docs.pingcap.com/tidb/stable/best-practices-for-security-configuration/): 介绍 TiDB 安全配置的最佳实践，帮助你降低潜在的安全风险。
+- [TiDB 安装部署常见问题](https://docs.pingcap.com/tidb/stable/deploy-and-maintain-faq/): 介绍 TiDB 集群安装部署的常见问题、原因及解决方法。
+- [TiDB 容灾方案概述](https://docs.pingcap.com/tidb/stable/dr-solution-introduction/): 了解 TiDB 提供的几种容灾方案，包括基于主备集群的容灾、基于多副本的单集群容灾和基于备份与恢复的容灾。
+- [TiDB 密码管理](https://docs.pingcap.com/tidb/stable/password-management/): 了解 TiDB 的用户密码管理机制。
+- [TiDB 工具下载](https://docs.pingcap.com/tidb/stable/download-ecosystem-tools/): 本文介绍如何下载 TiDB 工具包。TiDB 工具包包含常用工具如 Dumpling、TiDB Lightning、BR 等。如果部署环境能访问互联网，可直接通过 TiUP 命令一键部署所需的 TiDB 工具。操作系统需为 Linux，架构为 amd64 或 arm64。下载步骤包括访问 TiDB 社区版页面，找到 TiDB-community-toolkit 软件包并点击立即下载。注意，点击立即下载后默认下载当前 TiDB 的最新发布版本。根据要使用的工具选择安装对应的离线包。
+- [TiDB 工具功能概览](https://docs.pingcap.com/tidb/stable/ecosystem-tool-user-guide/): TiDB 提供了丰富的工具，包括部署运维工具 TiUP 和 TiDB Operator，数据管理工具如 TiDB Data Migration（DM）、Dumpling、TiDB Lightning、Backup & Restore（BR）、TiCDC、sync-diff-inspector，以及 OLAP 分析工具 TiSpark。这些工具可用于部署、数据迁移、备份恢复、数据校验等多种操作，满足不同需求。
+- [TiDB 工具的使用场景](https://docs.pingcap.com/tidb/stable/ecosystem-tool-user-case/): 本文档介绍 TiDB 工具的常见使用场景与工具选择。
+- [TiDB 快照备份与恢复使用指南](https://docs.pingcap.com/tidb/stable/br-snapshot-guide/): 了解如何使用 br 命令行工具进行 TiDB 快照备份与恢复。
+- [TiDB 快照备份与恢复功能架构](https://docs.pingcap.com/tidb/stable/br-snapshot-architecture/): 了解 TiDB 快照备份与恢复功能的架构设计。
+- [TiDB 快照备份与恢复命令行手册](https://docs.pingcap.com/tidb/stable/br-snapshot-manual/): 介绍备份与恢复 TiDB 集群快照的命令行。
+- [TiDB 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/performance-tuning-methods/): 本文介绍了基于数据库时间的系统优化方法，以及如何利用 TiDB Performance Overview 面板进行性能分析和优化。
+- [TiDB 悲观事务模式](https://docs.pingcap.com/tidb/stable/pessimistic-transaction/): 了解 TiDB 的悲观事务模式。
+- [TiDB 执行计划概览](https://docs.pingcap.com/tidb/stable/explain-overview/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划。
+- [TiDB 支持的第三方工具](https://docs.pingcap.com/tidb/stable/dev-guide-third-party-support/): TiDB 支持的第三方工具主要包括驱动、ORM 框架和 GUI。支持等级分为 Full 和 Compatible，其中 Full 表示绝大多数功能兼容性已得到支持，Compatible 表示大部分功能可使用但未经完整验证。对于支持的 Driver 或 ORM 框架并不包括应用端事务重试和错误处理。如果在使用工具连接 TiDB 时出现问题，可在 GitHub 上提交包含详细信息的 issue 以获得进展。
+- [TiDB 数据库快速上手指南](https://docs.pingcap.com/tidb/stable/quick-start-with-tidb/): 了解如何快速上手使用 TiDB 数据库。
+- [TiDB 数据库的存储](https://docs.pingcap.com/tidb/stable/tidb-storage/): 了解 TiDB 数据库的存储层。
+- [TiDB 数据库的计算](https://docs.pingcap.com/tidb/stable/tidb-computing/): 了解 TiDB 数据库的计算层。
+- [TiDB 数据库的调度](https://docs.pingcap.com/tidb/stable/tidb-scheduling/): TiDB 数据库的调度由 PD（Placement Driver）模块负责管理和实时调度集群数据。PD 需要收集节点和 Region 的状态信息，并根据调度策略制定调度计划，包括增加 / 删除副本、迁移 Leader 角色等基本操作。调度需满足副本数量、位置分布、负载均衡、存储空间利用等需求。PD 通过心跳包收集信息，并根据策略生成调度操作序列，但具体执行由 Region Leader 决定。
+- [TiDB 整体架构](https://docs.pingcap.com/tidb/stable/tidb-architecture/): 了解 TiDB 的整体架构。
+- [TiDB 日志备份与 PITR 使用指南](https://docs.pingcap.com/tidb/stable/br-pitr-guide/): 了解 TiDB 的日志备份与 PITR 功能使用。
+- [TiDB 日志备份与 PITR 功能架构](https://docs.pingcap.com/tidb/stable/br-log-architecture/): 了解 TiDB 的日志备份与 PITR 的架构设计。
+- [TiDB 日志备份与 PITR 命令行手册](https://docs.pingcap.com/tidb/stable/br-pitr-manual/): 介绍 TiDB 日志备份与 PITR 的命令行。
+- [TiDB 最佳实践](https://docs.pingcap.com/tidb/stable/tidb-best-practices/): TiDB 最佳实践总结了使用 TiDB 的一些优化技巧，包括 Raft 一致性协议、分布式事务、数据分片、负载均衡、SQL 到 KV 的映射方案、二级索引的实现方法等。建议阅读官方文档和知乎专栏了解更多细节。部署时推荐使用 TiUP，导入数据时可对 TiKV 参数进行调优。在写入和查询时需注意事务大小限制和并发度设置。监控系统和日志查看也是了解系统状态的重要方法。适用场景包括数据量大、不希望做 Sharding、需要事务和强一致性等。
+- [TiDB 热点问题处理](https://docs.pingcap.com/tidb/stable/troubleshoot-hot-spot-issues/): TiDB 热点问题处理：介绍定位和解决读写热点问题，包括常见热点场景、确定存在热点问题的方法、使用 TiDB Dashboard 定位热点表、使用 SHARD_ROW_ID_BITS 处理热点表、使用 AUTO_RANDOM 处理自增主键热点表、小表热点的优化、打散读热点。
+- [TiDB 版本发布历史](https://docs.pingcap.com/tidb/stable/release-notes/): 介绍 TiDB 版本发布历史。
+- [TiDB 版本发布时间线](https://docs.pingcap.com/tidb/stable/release-timeline/): 了解 TiDB 的版本发布时间线。
+- [TiDB 版本规则](https://docs.pingcap.com/tidb/stable/versioning/): 了解 TiDB 版本发布的规则。
+- [TiDB 特有的函数](https://docs.pingcap.com/tidb/stable/tidb-functions/): 学习使用 TiDB 特有的函数。
+- [TiDB 环境与系统配置检查](https://docs.pingcap.com/tidb/stable/check-before-deployment/): 了解部署 TiDB 前的环境检查操作。
+- [TiDB 用户账户管理](https://docs.pingcap.com/tidb/stable/user-account-management/): TiDB 用户账户管理主要包括用户名和密码设置、添加用户、删除用户、保留用户账户、设置资源限制、设置密码、忘记密码处理和刷新权限。用户可以通过 SQL 语句或图形化界面工具进行用户管理，同时可以使用 `FLUSH PRIVILEGES` 命令立即生效修改。 TiDB 在数据库初始化时会生成一个默认账户。
+- [TiDB 监控常见问题](https://docs.pingcap.com/tidb/stable/monitor-faq/): 介绍在监控 TiDB 集群时的常见问题、原因及解决方法。
+- [TiDB 监控指标](https://docs.pingcap.com/tidb/stable/grafana-tidb-dashboard/): 了解 Grafana Dashboard 中展示的关键指标。
+- [TiDB 监控框架概述](https://docs.pingcap.com/tidb/stable/tidb-monitoring-framework/): TiDB 使用 Prometheus 作为监控和性能指标存储，Grafana 用于可视化展示，以及 TiDB Dashboard 图形化界面用于监控及诊断 TiDB 集群。Prometheus 提供多个组件，包括 Prometheus Server、Client 代码库和 Alertmanager。Grafana 展示 TiDB 集群各组件的相关监控，分组包括备份恢复、Binlog、网络探活、磁盘性能、Kafka、TiDB Lightning 等。每个分组包含多个监控项页签，以及详细的监控指标看板。观看培训视频可快速了解监控与报警系统的体系、数据流转方式、系统管理方法和常用监控指标。
+- [TiDB 磁盘 I/O 过高的处理办法](https://docs.pingcap.com/tidb/stable/troubleshoot-high-disk-io/): 了解如何定位和处理 TiDB 存储 I/O 过高的问题。
+- [TiDB 社区荣誉列表](https://docs.pingcap.com/tidb/stable/credits/): 了解 TiDB 社区贡献者列表及角色。
+- [TiDB 离线包](https://docs.pingcap.com/tidb/stable/binary-package/): 了解 TiDB 离线包及其包含的内容。
+- [TiDB 简介](https://docs.pingcap.com/tidb/stable/overview/): TiDB 是 PingCAP 公司自主设计、研发的开源分布式关系型数据库，支持在线事务处理与在线分析处理 (HTAP)。具有水平扩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等特性。适用于高可用、强一致性要求高、数据规模大等各种应用场景。具有一键水平扩缩容、金融级高可用、实时 HTAP、云原生的分布式数据库、兼容 MySQL 协议和 MySQL 生态等五大核心特性，以及金融行业、海量数据及高并发的 OLTP、实时 HTAP、数据汇聚、二次加工处理等四大核心应用场景。
+- [TiDB 证书鉴权使用指南](https://docs.pingcap.com/tidb/stable/certificate-authentication/): 了解使用 TiDB 的证书鉴权功能。
+- [TiDB 软件和硬件环境需求](https://docs.pingcap.com/tidb/stable/hardware-and-software-requirements/): TiDB 是一款开源的一站式实时 HTAP 数据库，支持部署在多种硬件环境和操作系统上。软件和硬件环境建议配置包括操作系统要求、编译和运行依赖库、Docker 镜像依赖、软件配置要求、服务器建议配置、网络要求、磁盘空间要求、客户端 Web 浏览器要求以及 TiFlash 存算分离架构的软硬件要求。
+- [TiDB 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tidb-configuration/): TiDB 配置参数包括启动参数和环境变量。启动参数包括 advertise-address、config、config-check、config-strict、cors 等。其中默认端口为 4000 和 10080。其他参数包括 log-file、metrics-addr、metrics-interval 等。注意配置文件的有效性和安全模式下的启动。
+- [TiDB 配置文件描述](https://docs.pingcap.com/tidb/stable/tidb-configuration-file/): 介绍未包含在命令行参数中的 TiDB 配置文件选项。
+- [TiDB 锁冲突问题处理](https://docs.pingcap.com/tidb/stable/troubleshoot-lock-conflicts/): 了解 TiDB 锁冲突问题以及处理方式。
+- [TiDB 集群报警规则](https://docs.pingcap.com/tidb/stable/alert-rules/): TiDB 集群中各组件的报警规则详解。
+- [TiDB 集群故障诊断](https://docs.pingcap.com/tidb/stable/troubleshoot-tidb-cluster/): TiDB 集群故障诊断包括收集出错信息、组件状态、日志信息、机器配置和 dmesg 中的问题。解决数据库连接问题需要确认服务是否启动，查看 tidb-server 日志并清空数据重新部署服务。解决 tidb-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 tikv-server 启动报错需检查参数、端口占用和 pd-server 连接。解决 pd-server 启动报错需检查参数和端口占用。进程异常退出需检查是否在前台启动，使用 nohup+& 方式运行或写在脚本中。TiKV 进程异常重启需检查 OOM 信息和 panic log。连接被拒绝需确保网络参数正确。解决文件打开过多问题需确保 ulimit -n 足够大。数据库访问超时需检查拓扑结构、硬件配置、其他服务、操作、CPU 线程、网络 /IO 监控数据。
+- [TiDB 集群监控 API](https://docs.pingcap.com/tidb/stable/tidb-monitoring-api/): TiDB 提供状态接口和 Metrics 接口来监控集群状态。状态接口可获取 TiDB Server 的运行状态和存储信息，PD 的状态接口可查看整个 TiKV 集群的详细信息。Metrics 接口用于监控整个集群的状态和性能。部署 Prometheus 和 Grafana 后，配置 Grafana 即可使用 Metrics 接口。
+- [TiDB 集群管理常见问题](https://docs.pingcap.com/tidb/stable/manage-cluster-faq/): 介绍 TiDB 集群管理的常见问题、原因及解决方法。
+- [TiDB 集群问题导图](https://docs.pingcap.com/tidb/stable/tidb-troubleshooting-map/): 了解如何处理 TiDB 集群常见问题。
+- [TiDB 高并发写入场景最佳实践](https://docs.pingcap.com/tidb/stable/high-concurrency-best-practices/): 了解 TiDB 在高并发写入场景下的最佳实践。
+- [TIDB_CHECK_CONSTRAINTS](https://docs.pingcap.com/tidb/stable/information-schema-tidb-check-constraints/): 了解 INFORMATION_SCHEMA 表 `TIDB_CHECK_CONSTRAINTS`。
+- [TIDB_HOT_REGIONS](https://docs.pingcap.com/tidb/stable/information-schema-tidb-hot-regions/): 了解 information_schema 表 `TIDB_HOT_REGIONS`。
+- [TIDB_HOT_REGIONS_HISTORY](https://docs.pingcap.com/tidb/stable/information-schema-tidb-hot-regions-history/): 了解 information_schema 表 `TIDB_HOT_REGIONS_HISTORY`。
+- [TIDB_INDEX_USAGE](https://docs.pingcap.com/tidb/stable/information-schema-tidb-index-usage/): 了解 INFORMATION_SCHEMA 表 `TIDB_INDEX_USAGE`。
+- [TIDB_INDEXES](https://docs.pingcap.com/tidb/stable/information-schema-tidb-indexes/): 了解 information_schema 表 `TIDB_INDEXES`。
+- [TIDB_SERVERS_INFO](https://docs.pingcap.com/tidb/stable/information-schema-tidb-servers-info/): 了解 INFORMATION_SCHEMA 表 `TIDB_SERVERS_INFO`。
+- [TIDB_TRX](https://docs.pingcap.com/tidb/stable/information-schema-tidb-trx/): 了解 INFORMATION_SCHEMA 表 `TIDB_TRX`。
+- [TiFlash MinTSO 调度器](https://docs.pingcap.com/tidb/stable/tiflash-mintso-scheduler/): 了解 TiFlash MinTSO 调度器的实现原理。
+- [TiFlash Pipeline Model 执行模型](https://docs.pingcap.com/tidb/stable/tiflash-pipeline-model/): 介绍 TiFlash 新的执行模型 Pipeline Model。
+- [TiFlash 兼容性说明](https://docs.pingcap.com/tidb/stable/tiflash-compatibility/): 了解与 TiFlash 不兼容的 TiDB 特性。
+- [TiFlash 升级帮助](https://docs.pingcap.com/tidb/stable/tiflash-upgrade-guide/): 了解升级 TiFlash 时的注意事项。
+- [TiFlash 命令行参数](https://docs.pingcap.com/tidb/stable/tiflash-command-line-flags/): TiFlash 的命令行启动参数包括 server --config-file、dttool migrate、dttool bench 和 dttool inspect。server --config-file 用于指定配置文件路径，dttool migrate 用于迁移 DTFile 的文件格式，dttool bench 用于提供 DTFile 的简单 IO 速度测试，dttool inspect 用于检查 DTFile 的完整性。每个命令都有对应的参数，可以根据需求进行配置。警告：TiFlash 目前只支持默认压缩等级的 LZ4 算法，自定义压缩参数并未经过大量测试。注意：为保证安全，DTTool 在迁移模式下会尝试对工作目录进行加锁。
+- [TiFlash 存算分离架构与 S3 支持](https://docs.pingcap.com/tidb/stable/tiflash-disaggregated-and-s3/): 了解 TiFlash 存算分离架构与 S3 支持。
+- [TiFlash 常见问题](https://docs.pingcap.com/tidb/stable/troubleshoot-tiflash/): 介绍 TiFlash 的常见问题、原因及解决办法。
+- [TiFlash 延迟物化](https://docs.pingcap.com/tidb/stable/tiflash-late-materialization/): 介绍通过使用 TiFlash 延迟物化的方式来加速 OLAP 场景的查询。
+- [TiFlash 性能分析和优化方法](https://docs.pingcap.com/tidb/stable/tiflash-performance-tuning-methods/): 本文介绍了 Performance Overview 面板中 TiFlash 部分，帮助你了解和监控 TiFlash 的工作负载。
+- [TiFlash 性能调优](https://docs.pingcap.com/tidb/stable/tune-tiflash-performance/): 介绍 TiFlash 性能调优的方法，包括机器资源规划和 TiDB 参数调优。
+- [TiFlash 报警规则](https://docs.pingcap.com/tidb/stable/tiflash-alert-rules/): TiFlash 报警规则介绍了 TiFlash 集群的报警规则。包括了TiFlash_schema_error、TiFlash_schema_apply_duration、TiFlash_raft_read_index_duration 和 TiFlash_raft_wait_index_duration 四种报警规则，以及它们的规则描述和处理方法。报警规则主要用于监控TiFlash集群的运行状态，及时发现问题并联系 TiFlash 开发人员进行处理。
+- [TiFlash 支持的计算下推](https://docs.pingcap.com/tidb/stable/tiflash-supported-pushdown-calculations/): 了解 TiFlash 支持的计算下推。
+- [TiFlash 数据校验](https://docs.pingcap.com/tidb/stable/tiflash-data-validation/): 了解 TiFlash 的数据校验机制以及相关的工具。
+- [TiFlash 数据落盘](https://docs.pingcap.com/tidb/stable/tiflash-spill-disk/): 介绍 TiFlash 数据落盘功能。
+- [TiFlash 查询结果物化](https://docs.pingcap.com/tidb/stable/tiflash-results-materialization/): 介绍如何在同一个事务中保存 TiFlash 的查询结果。
+- [TiFlash 简介](https://docs.pingcap.com/tidb/stable/tiflash-overview/): TiFlash 是 TiDB HTAP 形态的关键组件，提供了良好的隔离性和强一致性。它使用列存扩展和 Raft Learner 协议异步复制，通过 Raft 校对索引配合 MVCC 实现一致性隔离级别。TiFlash 架构解决了 HTAP 场景的隔离性和列存同步问题。它提供列式存储和借助 ClickHouse 高效实现的协处理器层。TiFlash 可以兼容 TiDB 和 TiSpark，推荐与 TiKV 不同节点部署以实现 Workload 隔离。具有异步复制、一致性、智能选择和计算加速等核心特性。部署完成后需要手动指定需要同步的表。
+- [TiFlash 部署拓扑](https://docs.pingcap.com/tidb/stable/tiflash-deployment-topology/): 了解在部署最小拓扑集群的基础上，部署 TiFlash 的拓扑结构。
+- [TiFlash 配置参数](https://docs.pingcap.com/tidb/stable/tiflash-configuration/): TiFlash 配置参数包括 PD 调度参数和 TiFlash 配置参数。PD 调度参数可通过 pd-ctl 调整，包括 replica-schedule-limit 和 store-balance-rate。TiFlash 配置参数包括 tiflash.toml 和 tiflash-learner.toml，用于配置 TiFlash TCP/HTTP 服务的监听和存储路径。另外，通过拓扑 label 进行副本调度和多盘部署也是可行的。
+- [TiFlash 集群监控](https://docs.pingcap.com/tidb/stable/monitor-tiflash/): TiFlash 集群监控包括 TiFlash-Summary、TiFlash-Proxy-Summary 和 TiFlash-Proxy-Details。监控指标包括存储、内存、CPU 使用率、请求处理、错误数量、线程数、任务调度、DDL、写入、读取、Raft 等信息。注意低版本监控信息不完善，建议使用 v4.0.5 或更高版本的 TiDB 集群。
+- [TiFlash 集群运维](https://docs.pingcap.com/tidb/stable/maintain-tiflash/): TiFlash 集群运维包括查看版本、重要日志和系统表。查看版本有两种方法：通过命令或在日志中查看。重要日志包括数据同步和处理请求的信息。系统表包括数据库名、表名、副本数、位置标签、可用性和同步进度。
+- [TIFLASH_REPLICA](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-replica/): 了解 INFORMATION_SCHEMA 表 `TIFLASH_REPLICA`。
+- [TIFLASH_SEGMENTS](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-segments/): 了解 information_schema 表 `TIFLASH_SEGMENTS`。
+- [TIFLASH_TABLES](https://docs.pingcap.com/tidb/stable/information-schema-tiflash-tables/): 了解 information_schema 表 `TIFLASH_TABLES`。
+- [TiKV Control 使用说明](https://docs.pingcap.com/tidb/stable/tikv-control/): TiKV Control（tikv-ctl）是 TiKV 的命令行工具，用于管理 TiKV 集群。它的安装目录在 `~/.tiup/components/ctl/{VERSION}/` 目录下。通过 TiUP 使用 TiKV Control，可以调用 `tikv-ctl` 工具。通用参数包括远程模式和本地模式，以及两个简单的命令 `--to-hex` 和 `--to-escaped`。其他子命令包括查看 Raft 状态机的信息、查看 Region 的大小、扫描查看给定范围的 MVCC、查看给定 key 的 MVCC、扫描 raw key、打印某个 key 的值、打印 Region 的 properties 信息、手动 compact 单个 TiKV 的数据、手动 compact 整个 TiKV 集群的数据、设置一个 Region 副本为 tombstone 状态、向 TiKV 发出 consistency-check 请求、Dump snapshot 元文件、打印 Raft 状态机出错的 Region、动态修改 TiKV 的配置、强制 Region 从多副本失败状态恢复服务、恢复损坏的 MVCC 数据、Ldb 命令、打印加密元数据、打印损坏的 SST 文件信息、获取一个 Region 的 RegionReadProgress 状态。
+- [TiKV MVCC 内存引擎](https://docs.pingcap.com/tidb/stable/tikv-in-memory-engine/): 了解内存引擎的适用场景和工作原理，使用内存引擎加速多版本记录查询。
+- [TiKV 内存参数性能调优](https://docs.pingcap.com/tidb/stable/tune-tikv-memory-performance/): TiKV 内存参数性能调优，根据机器配置情况调整参数以达到最佳性能。TiKV 使用 RocksDB 作为持久化存储，配置项包括 block-cache 大小和 write-buffer 大小。除此之外，系统内存还会被用于 page cache 和处理大查询时的数据结构生成。推荐将 TiKV 部署在 CPU 核数不低于 8 或内存不低于 32GiB 的机器上，对写入吞吐要求高时使用吞吐能力较好的磁盘，对读写延迟要求高时使用 IOPS 较高的 SSD 盘。
+- [TiKV 监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-tikv-dashboard/): TiKV 监控指标详解：TiUP 部署 TiDB 集群时，一键部署监控系统 (Prometheus & Grafana)，监控架构详见 TiDB 监控框架概述。Grafana Dashboard 分为 PD、TiDB、TiKV、Node_exporter、Overview、Performance_overview 等。对于日常运维，通过观察 TiKV-Details 面板上的指标，可以了解 TiKV 当前的状态。根据性能地图，可以检查集群的状态是否符合预期。TiKV-Details 默认的监控信息包括 Cluster、Errors、Server、gRPC、Thread CPU、PD、Raft IO、Raft process、Raft message、Raft propose、Raft admin、Local reader、Unified Read Pool、Storage、Flow Control、Scheduler 等。
+- [TiKV 简介](https://docs.pingcap.com/tidb/stable/tikv-overview/): TiKV 是一个分布式事务型的键值数据库，通过 Raft 协议保证了多副本数据一致性和高可用。整体架构采用 multi-raft-group 的副本机制，保证数据和读写负载均匀分散在各个 TiKV 上。TiKV 支持分布式事务，通过两阶段提交保证了 ACID 约束。同时，通过协处理器可以为 TiDB 分担一部分计算。
+- [TiKV 线程池性能调优](https://docs.pingcap.com/tidb/stable/tune-tikv-thread-performance/): 了解 TiKV 线程池性能调优。
+- [TiKV 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tikv-configuration/): TiKV 配置参数支持文件大小和时间的可读性好的单位转换。命令行参数包括监听地址、对外访问地址、服务状态监听端口、对外访问服务状态地址、配置文件、存储数据的容量、配置信息输出格式、数据存储路径、日志级别、日志文件、PD 地址列表。需要注意的是，PD 地址列表需要使用逗号分隔多个地址。
+- [TiKV 配置文件描述](https://docs.pingcap.com/tidb/stable/tikv-configuration-file/): 了解 TiKV 的配置文件参数。
+- [TIKV_REGION_PEERS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-region-peers/): 了解 INFORMATION_SCHEMA 表 `TIKV_REGION_PEERS`。
+- [TIKV_REGION_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-region-status/): 了解 information_schema 表 `TIKV_REGION_STATUS`。
+- [TIKV_STORE_STATUS](https://docs.pingcap.com/tidb/stable/information-schema-tikv-store-status/): 了解 INFORMATION_SCHEMA 表 `TIKV_STORE_STATUS`。
+- [TiProxy API](https://docs.pingcap.com/tidb/stable/tiproxy-api/): 了解如何使用 TiProxy API 获取 TiProxy 的配置、健康状况和监控数据等信息。
+- [TiProxy 命令行参数](https://docs.pingcap.com/tidb/stable/tiproxy-command-line-flags/): 了解 TiProxy 的命令行参数。
+- [TiProxy 常见问题](https://docs.pingcap.com/tidb/stable/troubleshoot-tiproxy/): 介绍 TiProxy 的常见问题、原因及解决办法。
+- [TiProxy 性能测试报告](https://docs.pingcap.com/tidb/stable/tiproxy-performance-test/): TiProxy 的性能测试报告、与 HAProxy 的性能对比。
+- [TiProxy 流量回放](https://docs.pingcap.com/tidb/stable/tiproxy-traffic-replay/): 介绍 TiProxy 的流量回放的使用场景和使用步骤。
+- [TiProxy 监控指标](https://docs.pingcap.com/tidb/stable/tiproxy-grafana/): 了解 TiProxy 的监控指标。
+- [TiProxy 简介](https://docs.pingcap.com/tidb/stable/tiproxy-overview/): 介绍 TiProxy 的主要功能、安装与使用方法。
+- [TiProxy 负载均衡策略](https://docs.pingcap.com/tidb/stable/tiproxy-load-balance/): 介绍 TiProxy 的负载均衡策略及其适用场景。
+- [TiProxy 部署拓扑](https://docs.pingcap.com/tidb/stable/tiproxy-deployment-topology/): 了解在部署最小拓扑集群的基础上，部署 TiProxy 的拓扑结构。
+- [TiProxy 配置文件](https://docs.pingcap.com/tidb/stable/tiproxy-configuration/): 了解与 TiProxy 部署和使用相关的配置参数。
+- [TiSpark 用户指南](https://docs.pingcap.com/tidb/stable/tispark-overview/): 使用 TiSpark 一站式解决用户的 HTAP 需求。
+- [TiSpark 部署拓扑](https://docs.pingcap.com/tidb/stable/tispark-deployment-topology/): 介绍 TiUP 部署包含 TiSpark 组件的 TiDB 集群的拓扑结构。
+- [Titan 介绍](https://docs.pingcap.com/tidb/stable/titan-overview/): Titan 是基于 RocksDB 的高性能单机 key-value 存储引擎插件。它支持将 value 从 LSM-tree 中分离出来单独存储，以降低写放大。Titan 适合前台写入量较大的场景，但不适合范围查询或对范围查询性能敏感的情况。开启 Titan 需要考虑 value 大小、范围查询敏感性和磁盘空间。从 v7.6.0 开始，TiDB 对 Titan 性能进行了优化，并将其作为默认的存储引擎。Titan 的 GC 方式有传统 GC 和 Level Merge，而 `min-blob-size` 的大小会影响性能。
+- [Titan 配置](https://docs.pingcap.com/tidb/stable/titan-configuration/): Titan 配置介绍了如何开启、关闭 Titan、数据迁移原理、相关参数以及 Level Merge 功能。从 TiDB v7.6.0 开始，默认启用 Titan，支持宽表写入场景和 JSON。开启 Titan 方法包括使用 TiUP 部署集群、直接编辑 TiKV 配置文件、编辑 TiDB Operator 配置文件。数据迁移是逐步进行的，可以通过全量 Compaction 提高迁移速度。常用配置参数包括 `min-blob-size`、`blob-file-compression`、`blob-cache-size` 等。关闭 Titan 可通过设置 `blob-run-mode` 参数。Level Merge 是实验功能，可提升范围查询性能并降低 Titan GC 对前台写入性能的影响。
+- [tiup clean](https://docs.pingcap.com/tidb/stable/tiup-command-clean/): tiup clean 命令用于清除组件运行过程中产生的数据。可以使用 --all 选项清除所有运行记录。
+- [TiUP Cluster](https://docs.pingcap.com/tidb/stable/tiup-component-cluster/): TiUP Cluster 是使用 Golang 编写的集群管理组件，可进行部署、启动、关闭、销毁、弹性扩缩容、升级 TiDB 集群、管理参数。支持的命令有 import、template、check、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、rename、clean、destroy、audit、replay、enable、disable、meta backup、meta restore、help。
+- [tiup cluster audit](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-audit/): tiup cluster audit 命令用于查看集群执行的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息。输出包括指定的执行日志或包含 ID、时间和命令的表格。
+- [tiup cluster audit cleanup](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-audit-cleanup/): tiup cluster audit cleanup 命令用于清理 tiup cluster 产生的执行日志。--retain-days 选项用于设置执行日志保留天数，默认值为 60 天。-h, --help 选项用于输出帮助信息。执行命令后会输出 "clean audit log successfully"。
+- [tiup cluster check](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-check/): TiUP Cluster 提供了 `check` 子命令，用于检查集群的硬件和软件环境是否满足正常运行条件。检查包括操作系统版本、CPU 支持、系统时间、内核参数、磁盘挂载参数等。用户可以通过指定选项来启用 CPU 核心数、内存大小和磁盘性能测试的检查。检查结果将以表格形式输出，包括目标节点、检查项、检查结果和结果描述。
+- [tiup cluster clean](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-clean/): tiup cluster clean 命令用于在测试环境中重置集群到刚部署的状态。它会停止集群并删除数据。警告：生产环境禁止使用。语法：tiup cluster clean <cluster-name>。选项包括 --all（清理数据和日志）、--data（开启数据清理）、--log（开启日志清理）、--ignore-node（指定不清理的节点）、--ignore-role（指定不清理的角色）、-h, --help（输出帮助信息）。输出为 tiup-cluster 的执行日志。
+- [tiup cluster deploy](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-deploy/): tiup cluster deploy 命令用于部署全新集群。语法为 tiup cluster deploy <cluster-name> <version> <topology.yaml> [flags]。选项包括 -u, -i, -p, --ignore-config-check, --no-labels, --skip-create-user, -h。输出为部署日志。
+- [tiup cluster destroy](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-destroy/): tiup cluster destroy 命令用于销毁集群，包括停止集群、删除服务的日志目录、部署目录和数据目录。选项包括 --force（忽略错误）、--retain-node-data（指定保留数据的节点）、--retain-role-data（指定保留数据的角色）、-h（输出帮助信息）。执行日志将作为输出。
+- [tiup cluster disable](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-disable/): tiup cluster disable 命令用于关闭集群服务在机器重启后的自启动。使用该命令可以指定要关闭自启的集群、节点和角色。如果不指定节点和角色，则默认关闭所有节点和角色的自启动。输出为 tiup-cluster 的执行日志。
+- [tiup cluster display](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-display/): tiup cluster display 命令用于查看集群中每个组件的运行状态。可以通过指定选项来展示特定信息，如节点的 CPU 和内存使用情况，节点的 uptime 信息等。输出包括集群名称、版本、SSH 客户端类型、Dashboard 地址以及节点的 ID、角色、主机 IP、端口号、操作系统和机器架构、服务状态、数据目录和部署目录。节点服务状态包括在线、离线、已缩容下线、下线中和未知。详细状态含义可参考相关文档。
+- [tiup cluster edit-config](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-edit-config/): tiup cluster edit-config 命令用于调整部署集群后的配置。执行命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意不能增删机器，需执行 tiup cluster reload 命令来重新加载配置。语法为 tiup cluster edit-config <cluster-name>，选项包括 -h, --help。执行命令后正常情况下无输出，若修改了不能修改的字段则会报错并提示用户重新编辑。
+- [tiup cluster enable](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-enable/): tiup cluster enable 命令用于设置集群服务在机器重启后的自启动。命令会执行 systemctl enable <service> 来开启服务的自启。可以指定节点和角色来开启自启，同时可以输出帮助信息。执行日志将由 tiup-cluster 记录。
+- [tiup cluster help](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-help/): tiup-cluster 是一个命令行工具，提供丰富的帮助信息。用户可以通过 `help` 命令或 `--help` 参数获取帮助信息。`tiup cluster help <command>` 等同于 `tiup cluster <command> --help`。语法为 `tiup cluster help [command] [flags]`。使用 `-h` 或 `--help` 输出帮助信息，默认关闭。输出为 `[command]` 或 tiup-cluster 的帮助信息。
+- [tiup cluster import](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-import/): TiUP Cluster 提供了 `import` 命令，用于将 TiDB Ansible 部署的集群过渡到使用 tiup-cluster 组件管理。导入过程的日志信息将会输出。暂不支持导入启用了 TLS 加密功能、纯 KV 集群、启用了 Kafka 的集群、启用了 Spark 的集群、启用了 TiDB Lightning/Importer 的集群、仍使用老版本 `push` 的方式收集监控指标、单独为机器的 `node_exporter` / `blackbox_exporter` 设置了非默认端口的集群。如果集群中有部分节点未部署监控，应当先补充对应节点的信息，并将补充的监控组件部署完整。
+- [tiup cluster list](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-list/): tiup-cluster 支持使用同一个中控机部署多套集群。命令 `tiup cluster list` 可以查看当前登录的用户使用该中控机部署了哪些集群。输出包含 Name、User、Version、Path、PrivateKey 字段的表格。注意：部署的集群数据默认放在 `~/.tiup/storage/cluster/clusters/` 目录下，当前登录用户无法查看其他用户部署的集群。
+- [tiup cluster meta backup](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-meta-backup/): TiUP meta 文件丢失会导致无法管理集群。使用“tiup cluster meta backup”命令定期备份文件。命令语法为“tiup cluster meta backup <cluster-name>”。选项包括指定备份文件存储目录和帮助信息。输出为 tiup-cluster 的执行日志。
+- [tiup cluster meta restore](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-meta-restore/): TiUP cluster meta restore 命令用于从备份文件中恢复 TiUP meta 文件。语法为 tiup cluster meta restore <cluster-name> <backup-file>。选项包括 -h, --help，用于输出帮助信息。恢复操作会覆盖当前的 meta 文件，建议仅在 meta 文件丢失的情况下进行恢复。执行日志将作为输出。
+- [tiup cluster patch](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-patch/): tiup cluster patch 命令用于在集群运行过程中动态替换某个服务的二进制文件。它会上传替换的二进制包到目标机器，并通过 API 下线节点，停止目标服务，解压替换二进制包，最后启动目标服务。在使用命令前需要准备二进制包，包括确定组件名、版本、操作系统和平台，下载组件包，创建临时打包目录，解压原二进制包，复制要替换的文件到临时目录，最后打包所有文件。命令还包括一些选项，如 --overwrite、--transfer-timeout、-N、-R、--offline 等。
+- [tiup cluster prune](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-prune/): tiup cluster prune 命令用于在缩容集群时清理数据。对于某些组件，需要等数据调度完成后，用户手动执行该命令。选项包括 -h 或 --help，用于输出帮助信息。清理过程会生成日志。
+- [tiup cluster reload](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-reload/): tiup cluster reload 命令用于在修改集群配置后重新加载配置，使其生效。命令会将配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。可选参数包括 --force（忽略错误强制 reload）、--transfer-timeout（设置最长等待时间）、--ignore-config-check（跳过配置检查）、-N, --node（指定要重启的节点）、-R, --role（指定要重启的角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。执行日志会输出到 tiup-cluster。
+- [tiup cluster rename](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-rename/): tiup cluster rename 命令用于更改部署集群后的集群名。如果要更改集群名，可以使用 tiup cluster rename <old-cluster-name> <new-cluster-name> 命令。注意：如果配置了 grafana_servers 的 dashboard_dir 字段，需要更新本地 dashboards 目录中的 *.json 文件的 datasource 字段的值，并执行 tiup cluster reload -R grafana 命令。执行日志将输出到 tiup-cluster。
+- [tiup cluster replay](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-replay/): tiup cluster replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用 `tiup cluster audit` 查看历史命令及其 audit-id。执行命令：tiup cluster replay <audit-id>。选项：-h, --help。输出为对应命令的输出。
+- [tiup cluster restart](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-restart/): tiup cluster restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup cluster restart <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
+- [tiup cluster scale-in](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-scale-in/): tiup cluster scale-in 命令用于集群缩容，包括下线 TiKV 和 TiFlash 组件，以及其他组件。特殊处理包括通过 API 执行移除操作，并清理相关数据文件。命令语法为 tiup cluster scale-in <cluster-name>，必须指定要缩容的节点。其他选项包括 --force 用于强制移除宕机节点，--transfer-timeout 设置最长等待时间，-h 输出帮助信息。输出为缩容日志。
+- [tiup cluster scale-out](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-scale-out/): tiup cluster scale-out 命令用于集群扩容，内部逻辑与部署类似。PD 节点的扩容通过 join 方式加入集群，并更新相关服务配置；其他服务直接启动加入集群。命令语法为 tiup cluster scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user, -i, --identity_file, -p, --password, --no-labels, --skip-create-user, -h, --help。输出为扩容日志。
+- [tiup cluster start](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-start/): tiup cluster start 命令用于启动指定集群的所有或部分服务。语法为 tiup cluster start <cluster-name> [flags]。选项包括 --init（以安全方式启动集群）、-N, --node（指定要启动的节点）、-R, --role（指定要启动的角色）、-h, --help。输出为启动日志。
+- [tiup cluster stop](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-stop/): tiup cluster stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup cluster stop <cluster-name>。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
+- [tiup cluster template](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-template/): TiUP 内置了拓扑文件的模版，用户可以通过修改该模版来生成最终的拓扑文件。使用 tiup cluster template 命令可以输出 TiUP 内置的模版内容。该命令有多个选项，包括输出详细的拓扑模版、输出本地集群的简单拓扑模版以及输出多数据中心的拓扑模版。根据指定选项输出拓扑模版，可重定向到拓扑文件中用于部署。
+- [tiup cluster upgrade](https://docs.pingcap.com/tidb/stable/tiup-component-cluster-upgrade/): tiup cluster upgrade 命令用于将指定集群升级到特定版本。命令语法为 tiup cluster upgrade <cluster-name> <version> [flags]。可使用 --force 选项忽略升级过程的错误，强制替换二进制文件并启动集群。还可通过设置 --transfer-timeout 设置最长等待时间，超时后会跳过等待直接升级服务。其他选项包括 --ignore-config-check、--ignore-version-check、--offline 等。升级服务的日志将会输出。
+- [tiup completion](https://docs.pingcap.com/tidb/stable/tiup-command-completion/): TiUP 提供了 `tiup completion` 命令，用于生成命令行自动补全的配置文件。目前支持 `bash` 和 `zsh` 两种 shell 的命令补全。安装方式包括在 macOS 上执行 `brew install bash-completion` 或 `brew install bash-completion@2`，在 Linux 上执行 `yum install bash-completion` 或 `apt install bash-completion`。使用方式包括在 `.bash_profile` 中执行 `source` 命令，并在 zsh 中执行 `tiup completion zsh > "${fpath[1]}/_tiup"`。
+- [TiUP DM](https://docs.pingcap.com/tidb/stable/tiup-component-dm/): TiUP DM 是用于对 DM 集群进行日常运维工作的管理工具，包括部署、启动、关闭、销毁、弹性扩缩容、升级、参数管理等操作。命令包括 import、template、deploy、list、display、start、stop、restart、scale-in、scale-out、upgrade、prune、edit-config、reload、patch、destroy、audit、replay、enable、disable、help。
+- [tiup dm audit](https://docs.pingcap.com/tidb/stable/tiup-component-dm-audit/): tiup dm audit 命令用于查看所有集群上的历史命令和执行日志。若不填写 audit-id，则按时间倒序输出操作记录表格，包括 audit-id、命令执行时间和命令。若填写 audit-id，则查看指定的执行日志。选项 -h, --help 用于输出帮助信息，默认关闭。输出包括指定的 audit-id 对应的执行日志或包含 ID、时间和命令字段的表格。
+- [tiup dm deploy](https://docs.pingcap.com/tidb/stable/tiup-component-dm-deploy/): tiup dm deploy 命令用于部署全新的集群。语法为 tiup dm deploy <cluster-name> <version> <topology.yaml> [flags]，其中 cluster-name 表示新集群的名字，version 为要部署的 DM 集群版本号，topology.yaml 为事先编写好的拓扑文件。选项包括 -u, -i, -p, -h，分别用于指定连接目标机器的用户名、密钥文件、密码登录和输出帮助信息。输出为部署日志。
+- [tiup dm destroy](https://docs.pingcap.com/tidb/stable/tiup-component-dm-destroy/): tiup dm destroy 命令用于销毁集群，包括停止集群、删除日志目录、部署目录和数据目录。语法为 tiup dm destroy <cluster-name>。选项 -h, --help 用于输出帮助信息。输出为 tiup-dm 的执行日志。
+- [tiup dm disable](https://docs.pingcap.com/tidb/stable/tiup-component-dm-disable/): tiup dm disable 命令用于关闭集群服务重启后的自启动。语法为 tiup dm disable <cluster-name>，其中 <cluster-name> 为要关闭自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要关闭自启的节点和角色。若不指定选项，默认关闭所有节点和角色的自启。执行该命令将输出 tiup-dm 的执行日志。
+- [tiup dm display](https://docs.pingcap.com/tidb/stable/tiup-component-dm-display/): tiup-dm 提供了 `tiup dm display` 命令来高效查看集群中每个组件的运行状态。命令语法为 `tiup dm display <cluster-name>`，可指定要查询的节点和角色。输出包括集群名称、版本、SSH 客户端类型，以及节点 ID、角色、IP、端口号、操作系统、状态、数据目录和部署目录等信息。
+- [tiup dm edit-config](https://docs.pingcap.com/tidb/stable/tiup-component-dm-edit-config/): tiup dm edit-config 命令用于调整部署集群服务的配置。使用命令后会启动一个编辑器，允许用户修改指定集群的拓扑文件。注意：修改配置时不能增删机器，需执行 tiup dm reload 命令来重新加载配置。语法：tiup dm edit-config <cluster-name>。选项：-h, --help 输出帮助信息。输出：正常情况无输出，若修改了不能修改的字段，则保存文件时报错并提示用户重新编辑。
+- [tiup dm enable](https://docs.pingcap.com/tidb/stable/tiup-component-dm-enable/): tiup dm enable 命令用于设置集群服务在机器重启后的自启动。命令语法为 tiup dm enable <cluster-name>，其中 cluster-name 为要启用自启的集群。选项包括 -N, --node 和 -R, --role，分别用于指定要开启自启的节点和角色。若不指定选项，默认开启所有节点和角色的自启。执行日志将作为输出。
+- [tiup dm help](https://docs.pingcap.com/tidb/stable/tiup-component-dm-help/): tiup-dm 提供丰富的命令行界面帮助信息，可通过 `help` 命令或 `--help` 参数获取。`tiup dm help <command>` 等同于 `tiup dm <command> --help`。语法：`tiup dm help [command] [flags]`。`[command]` 用于指定要查看的命令帮助信息，若不指定，则查看 tiup-dm 自身的帮助信息。使用 `-h, --help` 输出帮助信息，数据类型为 `BOOLEAN`，默认关闭。输出为 `[command]` 或 tiup-dm 的帮助信息。
+- [tiup dm import](https://docs.pingcap.com/tidb/stable/tiup-component-dm-import/): TiUP DM 提供了 `import` 命令，用于将 DM v1.0 集群导入到全新的 v2.0 集群。在导入前，请先停止原集群，并确认升级 TiUP DM 组件到最新版本。导入过程中会生成日志信息，不支持导入 v1.0 集群中的 DM Portal 组件。对于需要升级到 v2.0 的数据迁移任务，请不要执行 `stop-task`。具体语法和选项可以使用 `tiup dm import [flags]` 命令查看。
+- [tiup dm list](https://docs.pingcap.com/tidb/stable/tiup-component-dm-list/): tiup-dm 支持使用同一个中控机部署多套集群。命令 `tiup dm list` 可以查看当前登录的用户使用该中控机部署了哪些集群。部署的集群数据默认放在 `~/.tiup/storage/dm/clusters/` 目录下。在同一台中控机上，当前登录用户无法查看其他用户部署的集群。该命令输出含有集群名字、部署用户、集群版本、集群部署数据在中控机上的路径、连接集群的私钥所在路径的表格。
+- [tiup dm prune](https://docs.pingcap.com/tidb/stable/tiup-component-dm-prune/): tiup dm prune 命令用于在缩容集群后清理 etcd 中的少量元信息。通常情况下不会有问题，但如果需要清理，可以手动执行该命令。语法为 tiup dm prune <cluster-name>，选项包括 -h, --help，输出为清理过程的日志。
+- [tiup dm reload](https://docs.pingcap.com/tidb/stable/tiup-component-dm-reload/): tiup dm reload 命令用于在修改集群配置后重新加载配置。该命令将中控机的配置发布到远端机器，并按顺序重启服务，重启过程中集群可用。语法为 tiup dm reload <cluster-name>。选项包括 -N, --node（重启节点）、-R, --role（重启角色）、--skip-restart（仅刷新配置不重启节点）、-h, --help（输出帮助信息）。输出为 tiup-dm 的执行日志。
+- [tiup dm replay](https://docs.pingcap.com/tidb/stable/tiup-component-dm-replay/): tiup dm replay 命令用于重试集群操作中失败的命令，并跳过已成功的步骤。使用命令时需指定要重试的命令对应的 audit-id，可通过 tiup dm audit 查看历史命令及其 audit-id。命令输出为对应命令的输出。
+- [tiup dm restart](https://docs.pingcap.com/tidb/stable/tiup-component-dm-restart/): tiup dm restart 命令用于重启指定集群的所有或部分服务。重启过程中会有一段时间服务不可用。语法为 tiup dm restart <cluster-name> [flags]，其中 <cluster-name> 为要操作的集群名字。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。输出为重启服务的日志。
+- [tiup dm scale-in](https://docs.pingcap.com/tidb/stable/tiup-component-dm-scale-in/): tiup dm scale-in 命令用于集群缩容，即下线服务并移除指定节点和相关文件。语法为 tiup dm scale-in <cluster-name>，其中 <cluster-name> 为集群名。选项包括 -N, --node（必须非空，选择要缩容的节点），--force（强制移除宕机节点），-h, --help（输出帮助信息）。输出为缩容日志。
+- [tiup dm scale-out](https://docs.pingcap.com/tidb/stable/tiup-component-dm-scale-out/): tiup dm scale-out 命令用于集群扩容，内部逻辑与部署类似。首先建立新节点的 SSH 连接，在目标节点上创建必要的目录，然后执行部署并启动服务。命令语法为 tiup dm scale-out <cluster-name> <topology.yaml>。选项包括 -u, --user（string，默认为当前执行命令的用户），-i, --identity_file（string，默认 ~/.ssh/id_rsa），-p, --password，-h, --help。输出为扩容日志。
+- [tiup dm start](https://docs.pingcap.com/tidb/stable/tiup-component-dm-start/): tiup dm start 命令用于启动指定集群的所有或部分服务。命令语法为 tiup dm start <cluster-name>。选项包括 -N, --node（指定要启动的节点），-R, --role（指定要启动的角色），-h, --help（输出帮助信息）。输出为启动日志。
+- [tiup dm stop](https://docs.pingcap.com/tidb/stable/tiup-component-dm-stop/): tiup dm stop 命令用于停止指定集群的所有服务或部分服务。核心服务停止后集群将无法提供服务。语法为 tiup dm stop <cluster-name> [flags]。选项包括 -N, --node（strings，默认为 []，表示所有节点），-R, --role（strings，默认为 []，表示所有角色），-h, --help。停止服务的日志将会输出。
+- [tiup dm template](https://docs.pingcap.com/tidb/stable/tiup-component-dm-template/): tiup dm template 命令用于输出 TiUP 内置的集群拓扑模版内容。可以通过修改模版来生成最终的拓扑文件。可选的 --full 选项输出详细的拓扑模版，带上可配置的参数。输出拓扑模版到标准输出，可重定向到拓扑文件中用于部署。
+- [tiup dm upgrade](https://docs.pingcap.com/tidb/stable/tiup-component-dm-upgrade/): tiup dm upgrade 命令用于将指定集群升级到特定版本。语法为 tiup dm upgrade <cluster-name> <version> [flags]。cluster-name 为要操作的集群名字，version 为要升级到的目标版本。选项 --offline 声明当前集群处于离线状态，-h, --help 输出帮助信息。升级服务的日志可查看。
+- [tiup env](https://docs.pingcap.com/tidb/stable/tiup-command-env/): TiUP 提供灵活的定制化接口，使用环境变量实现。命令 `tiup env` 用于查询 TiUP 支持的用户自定义环境变量及其值。若未指定环境变量，则输出"{key}"="{value}"列表。若指定了环境变量，则按顺序输出"{value}"列表。若值为空，则代表未设置环境变量的值，TiUP 会使用默认值。
+- [TiUP FAQ](https://docs.pingcap.com/tidb/stable/tiup-faq/): TiUP 支持自定义镜像源，可以使用环境变量 TIUP_MIRRORS 指定镜像源地址。开发者可以通过 tiup-publish 组件将自己编写的组件发布到 TiUP 的官方镜像仓库。TiUP Playground 用于快速搭建开发环境，而 TiUP Cluster 用于部署生产环境集群。拓扑文件样例包括两地三中心、最小部署和完整拓扑文件。同一主机可以部署多个实例，但需要配置不同的端口和目录信息。集群部署期间可能出现 ssh 连接错误，可尝试加大 ssh 默认连接数并重启 sshd 服务解决。
+- [tiup help](https://docs.pingcap.com/tidb/stable/tiup-command-help/): TiUP 命令行界面提供丰富的帮助信息，用户可通过 `help` 命令或 `--help` 参数查看。`tiup help <command>` 等同于 `tiup <command> --help`。语法为 `tiup help [command]`，若不指定命令，则查看 TiUP 自身的帮助信息。选项为无，输出为 `[command]` 或 TiUP 的帮助信息。
+- [tiup install](https://docs.pingcap.com/tidb/stable/tiup-command-install/): tiup install 命令用于从镜像仓库下载指定版本的组件包，并在本地解压。当需要运行不存在于镜像仓库中的组件时，会尝试下载并自动运行，若不存在会报错。语法为 tiup install <component1>[version] [component2...N] [flags]。输出包括组件的下载信息，若组件不存在则报错"The component "%s" not found"，若版本不存在则报错"version %s not supported by component %s"。
+- [tiup list](https://docs.pingcap.com/tidb/stable/tiup-command-list/): tiup list 命令用于查询镜像中可用的组件列表。可选的组件名称。若指定，则列出该组件的所有版本；若不指定，则列出所有组件列表。--all 显示所有组件。默认只显示非隐藏组件。--installed 只显示已经安装的组件或版本。--verbose 在组件列表中显示已安装的版本列表。若未指定组件名，输出组件名、组件管理员、组件描述构成的组件信息列表。若指定组件名，输出版本、是否已安装、发布时间、支持的平台构成的版本信息列表。
+- [tiup mirror](https://docs.pingcap.com/tidb/stable/tiup-command-mirror/): TiUP 中的镜像是一个重要概念，支持本地镜像和远程镜像。命令 `tiup mirror` 用于管理镜像，包括创建、发布、密钥管理等功能。语法为 `tiup mirror <command> [flags]`，支持的子命令包括 genkey、sign、init、set、grant、publish、modify、rotate、clone、merge。详细信息请参考 TiUP 命令清单。
+- [tiup mirror clone](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-clone/): tiup mirror clone 命令用于克隆已存在的镜像或部分组件生成新镜像。新旧镜像的组件相同，但使用的签名密钥不同。命令语法为 tiup mirror clone <target-dir> [global version] [flags]。选项包括 -f, --full, -a, --arch, -o, --os, --prefix, --{component}。
+- [tiup mirror genkey](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-genkey/): TiUP 镜像命令 genkey 用于生成私钥。管理员有 root.json、index.json、snapshot.json 和 timestamp.json 的修改权限。组件管理员有相关组件的修改权限。普通用户可以下载并使用组件。私钥名默认为 private，可以显示对应的公钥。可以将公钥信息储存为文件。输出包括私钥已存在或已写入，以及公钥内容。
+- [tiup mirror grant](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-grant/): tiup mirror grant 命令用于向当前镜像中添加组件管理员。组件管理员可以发布新组件或修改之前发布的组件。添加管理员时，需将公钥发送给镜像管理员。命令仅支持本地镜像使用。语法：tiup mirror grant <id>。选项：-k, --key（指定管理员密钥）、-n, --name（指定管理员名字）。输出：执行成功无输出，管理员 ID 重复报错，密钥被其他管理员使用报错。
+- [tiup mirror init](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-init/): tiup mirror init 命令用于初始化一个空的镜像。初始化的镜像不包含任何组件和组件管理员，仅生成一些文件。语法为 tiup mirror init <path> [flags]，其中 <path> 为本地目录路径，可以为相对路径。选项包括 -k, --key-dir（string，默认 {path}/keys）。输出包括若成功则无输出，若 <path> 不为空则输出错误信息，若 <path> 不是目录则输出错误信息。
+- [tiup mirror merge](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-merge/): tiup mirror merge 命令用于将一个或多个镜像合并到当前镜像。执行此命令需要目标镜像的管理员 ID 在当前镜像中存在，并且用户的 ${TIUP_HOME}/keys 目录中有对应的私钥。语法：tiup mirror merge <mirror-dir-1> [mirror-dir-N]。选项：无。输出：成功时无输出，否则会提示缺失管理员或私钥。
+- [tiup mirror modify](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-modify/): tiup mirror modify 命令用于修改已发布的组件。只有合法的组件管理员才能修改组件，且只能修改自己发布的组件。命令语法为 tiup mirror modify <component>[version]。选项包括 -k, --key, --yank, --hide。成功时无输出，无权限时会有相应错误提示。
+- [tiup mirror publish](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-publish/): tiup mirror publish 命令用于发布新组件或已有组件的新版本。只有有权限的组件管理员才可以发布组件。命令语法为 tiup mirror publish <comp-name> <version> <tarball> <entry> [flags]。其中各参数含义为组件名、版本号、tarball 包路径、组件可执行文件位置。命令还包含选项 -k, --key, --arch, --os, --desc, --hide。成功时无输出，无权限时会有相应错误提示。
+- [tiup mirror rotate](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-rotate/): TiUP 的镜像中有一个重要文件 root.json，记录了系统需要使用的公钥和信任链基础。包含管理员签名、用于验证的公钥和过期时间。更新 root.json 需要管理员重新签名，使用命令 `tiup mirror rotate` 自动化更新流程。需要确保 TiUP 客户端升级到 v1.5.0 或以上版本。命令启动编辑器修改内容，等待管理员签名。选项包括临时服务器监听地址。输出为各个镜像管理员当前的签名状态。
+- [tiup mirror set](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-set/): tiup mirror set 命令用于切换当前镜像，支持本地文件系统和远程网络两种镜像。命令语法为 tiup mirror set <mirror-addr> [flags]，其中 <mirror-addr> 为镜像地址，可以是网络地址或本地文件路径。选项 -r, --root 用于指定根证书。输出为无。
+- [tiup mirror sign](https://docs.pingcap.com/tidb/stable/tiup-command-mirror-sign/): tiup mirror sign 命令用于对镜像中定义的元信息文件进行签名。语法为 tiup mirror sign <manifest-file>。选项包括 -k, --key 和 --timeout。输出包括成功、文件已被指定的 key 签名过和文件不是合法的 manifest。
+- [tiup status](https://docs.pingcap.com/tidb/stable/tiup-command-status/): tiup status 命令用于查看组件的运行信息，包括组件名称、进程 ID、运行状态、启动时间、数据目录、二进制文件路径和启动参数。组件可能处于在线、离线、无法访问、已缩容下线、下线中或未知状态。这些状态来自于 PD 的调度信息。
+- [tiup telemetry](https://docs.pingcap.com/tidb/stable/tiup-command-telemetry/): TiUP 遥测功能在 v1.11.3 及以上版本默认关闭，以下版本默认开启。开启后会分享使用情况信息给 PingCAP，包括遥测标示符、命令执行情况、部署情况等。不会分享集群准确名字、拓扑结构、配置文件。使用命令 `tiup telemetry` 控制遥测，支持 status、reset、enable、disable 命令。
+- [tiup uninstall](https://docs.pingcap.com/tidb/stable/tiup-command-uninstall/): tiup uninstall 命令用于卸载已安装的组件。语法为 tiup uninstall <component1> <version> [component2...N] [flags]。选项包括 --all 用于卸载指定组件的全部已安装版本，--self 用于卸载 TiUP 自身。正常退出时会显示"Uninstalled component "%s" successfully!"，若未指定 <version> 也未指定 --all 则会报错"Use "tiup uninstall tidbx --all" if you want to remove all versions."。
+- [tiup update](https://docs.pingcap.com/tidb/stable/tiup-command-update/): tiup update 命令用于升级已安装的组件或自身。语法为 tiup update [组件名] [版本]，可指定多个组件或版本。选项包括 --all（升级所有组件）、--force（强制升级已安装版本）、--nightly（升级到 nightly 版本）、--self（升级 TiUP 自身）。
+- [TiUP 命令概览](https://docs.pingcap.com/tidb/stable/tiup-reference/): TiUP 是 TiDB 生态的包管理器，管理着诸如 TiDB、PD、TiKV 等组件。它支持执行命令和运行组件，可以通过 `--help` 获取命令信息。选项包括打印二进制文件路径、指定组件路径、指定组件 tag、打印版本和帮助信息。TiUP 包含众多命令和子命令，以及组件清单。
+- [TiUP 常见运维操作](https://docs.pingcap.com/tidb/stable/maintain-tidb-using-tiup/): TiUP 是用于管理 TiDB 集群的工具，可以进行查看集群列表、启动、关闭、修改配置参数、查看状态等常见运维操作。操作简单方便，适合用于 TiDB 集群的管理。
+- [TiUP 故障排查](https://docs.pingcap.com/tidb/stable/tiup-troubleshooting-guide/): TiUP 故障排查包括命令故障排查和集群组件故障排查。命令故障包括强制刷新组件列表和版本信息，网络中断导致的下载问题，以及 checksum 错误。集群组件故障包括 SSH 私钥问题，升级中断和缺失组件文件的解决方法。可通过 Github Issues 或 AskTUG 求助。
+- [TiUP 文档地图](https://docs.pingcap.com/tidb/stable/tiup-documentation-guide/): TiUP 文档地图包括使用文档和资源两部分。使用文档包括 TiUP 概览、TiUP 术语、TiUP 组件管理、TiUP FAQ、TiUP 故障排查和 TiUP 参考手册。资源包括 TiUP 版本发布说明、AskTUG TiUP 主题和 TiUP Issues。
+- [TiUP 术语及核心概念](https://docs.pingcap.com/tidb/stable/tiup-terminology-and-concepts/): TiUP 是一个用于下载、更新、卸载组件的程序，通过各种组件来扩展其功能。组件是可以运行的程序或脚本，通过 tiup <component> 命令来运行。TiUP 组件可以从镜像仓库下载，用户可以通过设置 TIUP_MIRRORS 环境变量来自定义镜像仓库。
+- [TiUP 简介](https://docs.pingcap.com/tidb/stable/tiup-overview/): TiUP 是 TiDB 生态中的包管理工具，简化了软件的安装和升级维护工作。安装 TiUP 十分简洁，只需执行一行命令即可完成。TiUP 的愿景是降低 TiDB 生态中所有工具的使用门槛，通过命令和组件来实现包管理和操作。
+- [TiUP 镜像参考指南](https://docs.pingcap.com/tidb/stable/tiup-mirror-reference/): TiUP 镜像是存放 TiUP 组件和元信息的仓库。镜像存在两种形式：本地镜像和远程镜像。镜像可通过命令创建和更新。镜像目录结构包括根证书、索引、组件、快照和时间戳。客户端通过逻辑保证下载文件安全。
+- [TopN 和 Limit 下推](https://docs.pingcap.com/tidb/stable/topn-limit-push-down/): TiDB 中的 LIMIT 子句对应 Limit 算子节点，ORDER BY 子句对应 Sort 算子节点。相邻的 Limit 和 Sort 算子组合成 TopN 算子节点，表示按排序规则提取记录的前 N 项。TopN 下推将尽可能下推到数据源附近，减少数据传输或计算的开销。可参考 [优化规则及表达式下推的黑名单](/blocklist-control-plan.md) 中的关闭方法。TopN 可下推到存储层 Coprocessor，减少计算开销。TopN 无法下推过 Join，排序规则仅依赖于外表列时可下推。TopN 也可转换成 Limit，简化排序操作。
+- [TRACE](https://docs.pingcap.com/tidb/stable/sql-statement-trace/): TiDB 数据库中 TRACE 的使用概况。
+- [TRUNCATE](https://docs.pingcap.com/tidb/stable/sql-statement-truncate/): TiDB 数据库中 TRUNCATE 的使用概况。
+- [TSO 配置参数](https://docs.pingcap.com/tidb/stable/command-line-flags-for-tso-configuration/): TSO 配置参数可以通过命令行参数或环境变量配置。
+- [TSO 配置文件描述](https://docs.pingcap.com/tidb/stable/tso-configuration-file/): TSO 配置文件包含了多个配置项，如节点名称、数据路径、节点 URL 等。
+- [UNLOCK STATS](https://docs.pingcap.com/tidb/stable/sql-statement-unlock-stats/): TiDB 数据库中 UNLOCK STATS 的使用概况。
+- [UPDATE](https://docs.pingcap.com/tidb/stable/sql-statement-update/): TiDB 数据库中 UPDATE 的使用概况。
+- [Upgrade A Tidb Cluster](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster): External documentation: https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster
+- [USE](https://docs.pingcap.com/tidb/stable/sql-statement-use/): TiDB 数据库中 USE 的使用概况。
+- [USER_ATTRIBUTES](https://docs.pingcap.com/tidb/stable/information-schema-user-attributes/): 了解 INFORMATION_SCHEMA 表 `USER_ATTRIBUTES`。
+- [USER_PRIVILEGES](https://docs.pingcap.com/tidb/stable/information-schema-user-privileges/): 了解 INFORMATION_SCHEMA 表 `USER_PRIVILEGES`。
+- [UUID 最佳实践](https://docs.pingcap.com/tidb/stable/uuid/): 了解在 TiDB 中使用 UUID 的最佳实践和策略。
+- [VARIABLES_INFO](https://docs.pingcap.com/tidb/stable/information-schema-variables-info/): 了解 information_schema 表 `VARIABLES_INFO`。
+- [VIEWS](https://docs.pingcap.com/tidb/stable/information-schema-views/): 了解 INFORMATION_SCHEMA 表 `VIEWS`。
+- [What's New in TiDB 5.0](https://docs.pingcap.com/tidb/stable/release-5.0.0/): TiDB 5.0 版本新增了许多功能和优化，包括 MPP 架构、聚簇索引、异步提交事务、Raft Joint Consensus 算法等。此外，还优化了系统变量、配置文件参数、性能、稳定性和数据迁移功能。TiUP 工具也进行了多项优化，包括部署操作逻辑、升级稳定性、升级时长和运维功能。遥测方面新增了集群使用指标的收集。
+- [WITH](https://docs.pingcap.com/tidb/stable/sql-statement-with/): TiDB 数据库中 WITH (公共表表达式) 的使用概况。
+- [Zh](https://docs.pingcap.com/zh): External documentation: https://docs.pingcap.com/zh
+- [三节点混合部署最佳实践](https://docs.pingcap.com/tidb/stable/three-nodes-hybrid-deployment/): 了解三节点混合部署最佳实践。
+- [上游使用 pt-osc/gh-ost 工具的持续同步场景](https://docs.pingcap.com/tidb/stable/migrate-with-pt-ghost/): 介绍在使用 DM 持续增量数据同步，上游使用 pt-osc/gh-ost 工具进行在线 DDL 变更时 DM 的处理方式和注意事项。
+- [下推到 TiKV 的表达式列表](https://docs.pingcap.com/tidb/stable/expressions-pushed-down/): TiDB 中下推到 TiKV 的表达式列表及相关设置。
+- [下推计算结果缓存](https://docs.pingcap.com/tidb/stable/coprocessor-cache/): TiDB 4.0 支持下推计算结果缓存，配置位于 `tikv-client.copr-cache`，缓存仅存储在 TiDB 内存中，不共享缓存，对 Region 写入会导致缓存失效。缓存命中率可通过 `EXPLAIN ANALYZE` 或 Grafana 监控面板查看。
+- [下游存在更多列的迁移场景](https://docs.pingcap.com/tidb/stable/migrate-with-more-columns-downstream/): 介绍下游存在更多列的迁移场景。
+- [不同库名或表名的数据校验](https://docs.pingcap.com/tidb/stable/route-diff/): TiDB DM 等同步工具可以使用 route-rules 设置数据同步到下游指定表中。sync-diff-inspector 通过设置 rules 提供了校验不同库名、表名的表的功能。可以通过 rules 设置映射关系来简化配置，校验大量的不同库名或者表名的表。表路由的初始化和示例包括规则中存在 target-schema/target-table 表名为 schema.table 的行为，规则中只存在 target-schema 的行为，以及规则中不存在 target-schema.target-table 的行为。
+- [与 Apache Kafka 和 Apache Flink 进行数据集成](https://docs.pingcap.com/tidb/stable/replicate-data-to-kafka/): 了解如何使用 TiCDC 从 TiDB 同步数据至 Apache Kafka 和 Apache Flink。
+- [与 Confluent Cloud 和 Snowflake 进行数据集成](https://docs.pingcap.com/tidb/stable/integrate-confluent-using-ticdc/): 了解如何使用 TiCDC 从 TiDB 同步数据至 Confluent Cloud 以及 Snowflake、ksqlDB、SQL Server。
+- [与 MySQL 兼容性对比](https://docs.pingcap.com/tidb/stable/mysql-compatibility/): 本文对 TiDB 和 MySQL 二者之间从语法和功能特性上做出详细的对比。
+- [与 MySQL 安全特性差异](https://docs.pingcap.com/tidb/stable/security-compatibility-with-mysql/): TiDB 支持与 MySQL 5.7 类似的安全特性，同时也支持 MySQL 8.0 的部分安全特性。然而，在实现上存在一些差异，包括不支持列级别权限设置和部分权限属性。此外，TiDB 的密码过期策略和密码复杂度策略与 MySQL 存在一些差异。另外，TiDB 支持多种身份验证方式，包括 TLS 证书和 JWT。
+- [临时表](https://docs.pingcap.com/tidb/stable/dev-guide-use-temporary-tables/): 介绍 TiDB 临时表创建、删除、限制。
+- [临时表](https://docs.pingcap.com/tidb/stable/temporary-tables/): 了解 TiDB 中的临时表功能，使用临时表存储业务中间数据，减少表管理开销，并提升性能。
+- [为 DM 的连接开启加密传输](https://docs.pingcap.com/tidb/stable/dm-enable-tls/): 了解如何为 DM 的连接开启加密传输。
+- [为 TiDB 客户端服务端间通信开启加密传输](https://docs.pingcap.com/tidb/stable/enable-tls-between-clients-and-servers/): TiDB 服务端与客户端间默认采用非加密连接，容易造成信息泄露。建议使用加密连接确保安全性。要开启 TLS 加密传输，需要在服务端配置开启 TLS 支持，并在客户端应用程序中配置使用 TLS 加密连接。可以通过配置系统变量或在创建 / 修改用户时指定要求加密连接。可通过命令检查当前连接是否是加密连接。TLS 版本为 TLSv1.2 和 TLSv1.3，支持的加密算法包括 AES 和 CHACHA20_POLY1305。
+- [为 TiDB 组件间通信开启加密传输](https://docs.pingcap.com/tidb/stable/enable-tls-between-components/): 了解如何为 TiDB 集群内各组件间开启加密传输。
+- [为 TiDB 落盘文件开启加密](https://docs.pingcap.com/tidb/stable/enable-disk-spill-encrypt/): 了解如何为 TiDB 落盘文件开启加密。
+- [主从集群一致性读和数据校验](https://docs.pingcap.com/tidb/stable/ticdc-upstream-downstream-check/): TiCDC 提供了 Syncpoint 功能，通过利用 TiDB 的 snapshot 特性，在同步过程中维护了一个上下游具有一致性 snapshot 的 `ts-map`。启用 Syncpoint 功能后，可以进行一致性快照读和数据一致性校验。要开启 Syncpoint 功能，只需在创建同步任务时把 TiCDC 的配置项 `enable-sync-point` 设置为 `true`。通过配置 `snapshot` 可以对 TiDB 主从集群的数据进行校验。
+- [乐观事务和悲观事务](https://docs.pingcap.com/tidb/stable/dev-guide-optimistic-and-pessimistic-transaction/): 介绍 TiDB 中的乐观事务和悲观事务，乐观事务的重试等。
+- [乐观事务模型下写写冲突问题排查](https://docs.pingcap.com/tidb/stable/troubleshoot-write-conflicts/): 介绍 TiDB 中乐观锁下写写冲突出现的原因以及解决方案。
+- [乐观模式下分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge-optimistic/): 介绍 DM 提供的乐观模式下分库分表的合并迁移功能。
+- [事务概览](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-overview/): 简单介绍 TiDB 中的事务。
+- [事务错误处理](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-troubleshoot/): 介绍 TiDB 中的事务错误处理办法。
+- [事务限制](https://docs.pingcap.com/tidb/stable/dev-guide-transaction-restraints/): 介绍 TiDB 中的事务限制。
+- [从 Amazon Aurora 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-aurora-to-tidb/): 介绍如何使用快照从 Amazon Aurora 迁移数据到 TiDB。
+- [从 CSV 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-csv-files-to-tidb/): 介绍如何从 CSV 等文件迁移数据到 TiDB。
+- [从 MariaDB 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-mariadb/): 介绍如何将数据从 MariaDB 文件迁移数据到 TiDB。
+- [从 Parquet 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-parquet-files-to-tidb/): 介绍如何使用 TiDB Lightning 从 Parquet 文件迁移数据到 TiDB。
+- [从 SQL 文件迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-sql-files-to-tidb/): 介绍如何使用 TiDB Lightning 从 MySQL SQL 文件迁移数据到 TiDB。
+- [从 TiDB 集群迁移数据至兼容 MySQL 的数据库](https://docs.pingcap.com/tidb/stable/migrate-from-tidb-to-mysql/): 了解如何将数据从 TiDB 集群迁移至与 MySQL 兼容的数据库。
+- [从 TiDB 集群迁移数据至另一 TiDB 集群](https://docs.pingcap.com/tidb/stable/migrate-from-tidb-to-tidb/): 了解如何将数据从一个 TiDB 集群迁移至另一 TiDB 集群。
+- [从 Vitess 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-from-vitess/): 介绍从 Vitess 迁移数据到 TiDB 所使用的工具。
+- [从大数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-large-mysql-to-tidb/): 介绍如何从大数据量 MySQL 迁移数据到 TiDB。
+- [从大数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-large-mysql-shards-to-tidb/): 使用 Dumpling 和 TiDB Lightning 合并导入分表数据到 TiDB，以及如何使用 DM 持续增量复制数据。本文介绍的方法适用于导入数据总量大于 1 TiB 的场景。
+- [从小数据量 MySQL 迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-small-mysql-to-tidb/): 介绍如何从小数据量 MySQL 迁移数据到 TiDB。
+- [从小数据量分库分表 MySQL 合并迁移数据到 TiDB](https://docs.pingcap.com/tidb/stable/migrate-small-mysql-shards-to-tidb/): 介绍如何从 TB 级以下分库分表 MySQL 迁移数据到 TiDB。
+- [从窗口函数中推导 TopN 或 Limit](https://docs.pingcap.com/tidb/stable/derive-topn-from-window/): 介绍从窗口函数中推导 TopN 或 Limit 的优化规则，以及如何开启该规则。
+- [代价模型](https://docs.pingcap.com/tidb/stable/cost-model/): 介绍 TiDB 进行物理优化时所使用的代价模型的原理。
+- [优化向量搜索性能](https://docs.pingcap.com/tidb/stable/vector-search-improve-performance/): 了解优化 TiDB 向量搜索性能的最佳实践。
+- [优化规则与表达式下推的黑名单](https://docs.pingcap.com/tidb/stable/blocklist-control-plan/): 了解优化规则与表达式下推的黑名单。
+- [位函数和操作符](https://docs.pingcap.com/tidb/stable/bit-functions-and-operators/): TiDB 支持 MySQL 8.0 中的所有位函数和操作符。
+- [使用 AS OF TIMESTAMP 语法读取历史数据](https://docs.pingcap.com/tidb/stable/as-of-timestamp/): 了解如何使用 AS OF TIMESTAMP 语法读取历史数据。
+- [使用 Django 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-django/): 了解如何使用 Django 连接到 TiDB。本文提供了使用 Django 与 TiDB 交互的 Python 示例代码片段。
+- [使用 DM binary 部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-binary/): 本文介绍了如何使用 DM binary 快速部署 DM 集群。首先需要下载 DM 安装包，然后在五台服务器上部署两个 DM-worker 实例和三个 DM-master 实例。对于 DM-master 的部署，可以使用命令行参数或配置文件两种方式。而对于 DM-worker 的部署，也可以使用命令行参数或配置文件两种方式。部署完成后，需要确保各组件间端口可正常连通。
+- [使用 DM 迁移数据](https://docs.pingcap.com/tidb/stable/migrate-data-using-dm/): 本文介绍如何使用 DM 工具迁移数据。首先部署 DM 集群，然后检查集群信息和创建数据源。配置任务后，启动任务并查询任务状态。最后，停止任务并监控任务与查看日志。
+- [使用 dmctl 运维 TiDB Data Migration 集群](https://docs.pingcap.com/tidb/stable/dmctl-introduction/): 了解如何使用 dmctl 运维 DM 集群。
+- [使用 Dumpling 和 TiDB Lightning 备份与恢复](https://docs.pingcap.com/tidb/stable/backup-and-restore-using-dumpling-lightning/): 了解如何使用 Dumpling 和 TiDB Lightning 备份与恢复集群数据。
+- [使用 Dumpling 导出数据](https://docs.pingcap.com/tidb/stable/dumpling-overview/): 使用 Dumpling 从 TiDB 导出数据。
+- [使用 EXPLAIN 解读执行计划](https://docs.pingcap.com/tidb/stable/explain-walkthrough/): 通过示例了解如何使用 EXPLAIN 分析执行计划。
+- [使用 FastScan 功能](https://docs.pingcap.com/tidb/stable/use-fastscan/): 介绍通过使用 FastScan 来加速 OLAP 场景的查询的方法。
+- [使用 Go-MySQL-Driver 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-golang-sql-driver/): 了解如何使用 Go-MySQL-Driver 连接到 TiDB。本文提供了使用 Go-MySQL-Driver 与 TiDB 交互的 Golang 示例代码片段。
+- [使用 GORM 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-golang-gorm/): 了解如何使用 GORM 连接到 TiDB。本文提供了使用 GORM 与 TiDB 交互的 Golang 示例代码片段。
+- [使用 Grafana 监控 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/grafana-monitor-best-practices/): 了解高效利用 Grafana 监控 TiDB 的七个技巧。
+- [使用 Hibernate 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-hibernate/): 了解如何使用 Hibernate 连接到 TiDB。本文提供了使用 Hibernate 与 TiDB 交互的 Java 示例代码片段。
+- [使用 JDBC 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-jdbc/): 了解如何使用 JDBC 连接到 TiDB。本文提供了使用 JDBC 与 TiDB 交互的 Java 示例代码片段。
+- [使用 MPP 模式](https://docs.pingcap.com/tidb/stable/use-tiflash-mpp-mode/): 了解如何使用 MPP 模式。
+- [使用 MyBatis 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-mybatis/): 了解如何使用 MyBatis 连接到 TiDB。本文提供了使用 MyBatis 与 TiDB 交互的 Java 示例代码片段。
+- [使用 MySQL Connector/Python 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-mysql-connector/): 了解如何使用 MySQL Connector/Python 连接到 TiDB。本文提供了使用 MySQL Connector/Python 与 TiDB 交互的 Python 示例代码片段。
+- [使用 MySQL Workbench 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-gui-mysql-workbench/): 了解如何使用 MySQL Workbench 连接到 TiDB。
+- [使用 mysql.js 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-mysqljs/): 本文描述了 TiDB 和 mysql.js 的连接步骤，并给出了简单示例代码片段。
+- [使用 mysql2 连接 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-ruby-mysql2/): 本文描述了 TiDB 和 mysql2 的连接步骤，并给出了使用 mysql2 gem 连接 TiDB 的简单示例代码片段。
+- [使用 mysqlclient 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-mysqlclient/): 了解如何使用 mysqlclient 连接到 TiDB。本文提供了使用 mysqlclient 与 TiDB 交互的 Python 示例代码片段。
+- [使用 Navicat 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-gui-navicat/): 了解如何使用 Navicat 连接到 TiDB。
+- [使用 node-mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-mysql2/): 本文描述了 TiDB 和 node-mysql2 的连接步骤，并给出了简单示例代码片段。
+- [使用 OpenAPI 运维 TiDB Data Migration 集群](https://docs.pingcap.com/tidb/stable/dm-open-api/): 了解如何使用 OpenAPI 接口来管理 DM 集群状态和数据同步。
+- [使用 peewee 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-peewee/): 了解如何使用 peewee 连接到 TiDB。本文提供了使用 peewee 与 TiDB 交互的 Python 示例代码片段。
+- [使用 PingCAP Clinic Diag 采集 SQL 查询计划信息](https://docs.pingcap.com/tidb/stable/clinic-collect-sql-query-plan/): 了解如何使用 PingCAP Clinic Diag 采集 TiUP 部署集群的 SQL 查询计划信息。
+- [使用 PingCAP Clinic 生成诊断报告](https://docs.pingcap.com/tidb/stable/clinic-report/): 介绍 PingCAP Clinic 诊断报告的使用场景、方法以及如何解读报告。
+- [使用 PingCAP Clinic 诊断集群](https://docs.pingcap.com/tidb/stable/clinic-user-guide-for-tiup/): 详细介绍在使用 TiUP 部署的 TiDB 集群或 DM 集群上如何通过 PingCAP Clinic 诊断服务远程定位集群问题和本地快速检查集群状态。
+- [使用 PLAN REPLAYER 保存和恢复集群现场信息](https://docs.pingcap.com/tidb/stable/sql-plan-replayer/): 了解如何使用 PLAN REPLAY 命令保存和恢复集群现场信息。
+- [使用 Prisma 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-prisma/): 本文描述了 TiDB 和 Prisma 的连接步骤，并给出了简单示例代码片段。
+- [使用 PyMySQL 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-pymysql/): 了解如何使用 PyMySQL 连接到 TiDB。本文提供了使用 PyMySQL 与 TiDB 交互的 Python 示例代码片段。
+- [使用 Python 开始向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-get-started-using-python/): 了解如何使用 Python 和 TiDB 向量搜索快速开发可执行语义搜索的人工智能应用程序。
+- [使用 Rails 框架和 ActiveRecord ORM 连接 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-ruby-rails/): 本文描述了 TiDB 和 Rails 框架的连接步骤，并给出了使用 Rails 框架和 ActiveRecord ORM 连接 TiDB 的简单示例代码片段。
+- [使用 Sequelize 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-sequelize/): 本文描述了 TiDB 和 Sequelize 的连接步骤，并给出了简单示例代码片段。
+- [使用 Spring Boot 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-java-spring-boot/): 了解如何使用 Spring Boot 连接到 TiDB。本文提供了使用 Spring Boot 与 TiDB 交互的 Java 示例代码片段。
+- [使用 SQL 开始向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-get-started-using-sql/): 了解如何在 TiDB 中使用 SQL 语句快速开始向量搜索，从而为你的生成式 AI 应用提供支持。
+- [使用 SQLAlchemy 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-python-sqlalchemy/): 了解如何使用 SQLAlchemy 连接到 TiDB。本文提供了使用 SQLAlchemy 与 TiDB 交互的 Python 示例代码片段。
+- [使用 TiDB Cloud Serverless 构建 TiDB 集群](https://docs.pingcap.com/tidb/stable/dev-guide-build-cluster-in-cloud/): 使用 TiDB Cloud Serverless 构建 TiDB 集群，并连接 TiDB Cloud Serverless 集群。
+- [使用 TiDB Dashboard 诊断报告定位问题](https://docs.pingcap.com/tidb/stable/dashboard-diagnostics-usage/): 本文介绍了使用 TiDB Dashboard 诊断报告定位问题的方法。通过对比两个时间段的监控项差异来帮助 DBA 定位问题。示例中展示了大查询/写入导致 QPS 抖动或延迟上升的诊断方法，以及如何用对比报告定位问题。对比报告可以帮助 DBA 更快速地定位问题，例如通过查看监控项的差异大小排序来发现异常。通过对比报告定位问题，可以更准确地诊断可能的慢查询和影响查询执行的负载。
+- [使用 TiDB Data Migration 处理出错的 DDL 语句](https://docs.pingcap.com/tidb/stable/handle-failed-ddl-statements/): 了解在使用 TiDB Data Migration 迁移数据时，如何处理出错的 DDL 语句。
+- [使用 TiDB 的增删改查 SQL](https://docs.pingcap.com/tidb/stable/dev-guide-tidb-crud-sql/): 简单介绍 TiDB 的增删改查 SQL。
+- [使用 TiDB 读取 TiFlash](https://docs.pingcap.com/tidb/stable/use-tidb-to-read-tiflash/): 了解如何使用 TiDB 读取 TiFlash 副本。
+- [使用 TiSpark 读取 TiFlash](https://docs.pingcap.com/tidb/stable/use-tispark-to-read-tiflash/): 了解如何使用 TiSpark 读取 TiFlash。
+- [使用 TiUP bench 组件压测 TiDB](https://docs.pingcap.com/tidb/stable/tiup-bench/): TiUP bench 组件集成了多种压测 workloads，包括 TPC-C、TPC-H、CH-benCHmark、YCSB 和自定义 SQL 文件。每种压测都有对应的命令和参数，可以通过 TiUP 运行。TPC-C 测试包括准备数据、运行测试、检查一致性和清理数据等步骤。TPC-H 测试也有类似的步骤，包括准备数据、运行测试和清理数据。YCSB 测试可以分别针对 TiDB 和 TiKV 节点进行，包括准备数据和运行测试。此外，还可以通过 RawSQL 文件进行测试，包括准备数据和执行查询。
+- [使用 TiUP no-sudo 模式部署运维 TiDB 线上集群](https://docs.pingcap.com/tidb/stable/tiup-cluster-no-sudo-mode/): 了解如何使用 TiUP no-sudo 模式部署运维 TiDB 线上集群。
+- [使用 TiUP 升级 TiDB](https://docs.pingcap.com/tidb/stable/upgrade-tidb-using-tiup/): TiUP 可用于 TiDB 升级。升级过程中需注意不支持 TiFlash 组件从 5.3 之前的老版本在线升级至 5.3 及之后的版本，只能采用停机升级。在升级过程中，不要执行 DDL 语句，避免出现行为未定义的问题。升级前需查看集群中是否有正在进行的 DDL Job，并等待其完成或取消后再进行升级。升级完成后，可使用 TiUP 安装对应版本的 `ctl` 组件来更新相关工具版本。
+- [使用 TiUP 命令管理组件](https://docs.pingcap.com/tidb/stable/tiup-component-management/): TiUP 是一个用于管理组件的命令行工具。它提供了一系列命令来查询组件列表、安装、升级、运行、查看状态、清理实例和卸载组件。此外，还可以使用实验性的 `link` 和 `unlink` 命令来将组件的二进制符号链接到可执行文件目录。
+- [使用 TiUP 扩容缩容 PD 微服务节点](https://docs.pingcap.com/tidb/stable/scale-microservices-using-tiup/): 介绍如何使用 TiUP 扩容缩容集群中的 PD 微服务节点，以及如何切换 PD 工作模式。
+- [使用 TiUP 扩容缩容 TiDB 集群](https://docs.pingcap.com/tidb/stable/scale-tidb-using-tiup/): TiUP 可以在不中断线上服务的情况下扩容和缩容 TiDB 集群。使用 `tiup cluster list` 查看当前集群名称列表。扩容 TiDB/PD/TiKV 节点需要编写扩容拓扑配置，并执行扩容命令。扩容后，使用 `tiup cluster display <cluster-name>` 检查集群状态。缩容 TiDB/PD/TiKV 节点需要查看节点 ID 信息，执行缩容操作，然后检查集群状态。缩容 TiFlash/TiCDC 节点也需要执行相似的操作。
+- [使用 TiUP 离线镜像部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-tiup-offline/): 学习如何使用 TiUP DM 组件来离线部署 TiDB Data Migration 工具。
+- [使用 TiUP 运维 DM 集群](https://docs.pingcap.com/tidb/stable/maintain-dm-using-tiup/): 学习如何使用 TiUP 运维 DM 集群。
+- [使用 TiUP 部署 DM 集群](https://docs.pingcap.com/tidb/stable/deploy-a-dm-cluster-using-tiup/): 学习如何使用 TiUP DM 组件来部署 TiDB Data Migration 工具。
+- [使用 TiUP 部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/production-deployment-using-tiup/): 了解如何使用 TiUP 部署 TiDB 集群。
+- [使用 TiUP 部署运维 TiDB 线上集群](https://docs.pingcap.com/tidb/stable/tiup-cluster/): 使用 TiUP 的 cluster 组件可以快速部署生产集群，并提供强大的生产集群管理功能，包括升级、缩容、扩容、操作、审计等。部署集群的命令为 tiup cluster deploy，部署完成后可以通过 tiup cluster list 查看集群列表。启动集群的命令为 tiup cluster start，查看集群状态的命令为 tiup cluster display。可以使用 tiup cluster scale-in 进行集群缩容，tiup cluster scale-out 进行集群扩容。另外，还可以使用 tiup cluster upgrade 进行滚动升级，使用 tiup cluster edit-config 进行配置更新。最后，可以使用 tiup cluster exec 在集群节点机器上执行命令。
+- [使用 TTL (Time to Live) 定期删除过期数据](https://docs.pingcap.com/tidb/stable/time-to-live/): Time to Live (TTL) 提供了行级别的生命周期控制策略。本篇文档介绍如何通过 TTL (Time to Live) 来管理表数据的生命周期。
+- [使用 TypeORM 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nodejs-typeorm/): 本文描述了 TiDB 和 TypeORM 的连接步骤，并给出了简单示例代码片段。
+- [使用 WebUI 管理 DM 迁移任务](https://docs.pingcap.com/tidb/stable/dm-webui-guide/): 学习如何使用 WebUI 来方便的管理数据迁移任务。
+- [使用物理导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-physical-import-mode-usage/): 了解如何使用 TiDB Lightning 的物理导入模式。
+- [使用资源管控 (Resource Control) 实现资源组限制和流控](https://docs.pingcap.com/tidb/stable/tidb-resource-control-ru-groups/): 介绍如何通过资源管控能力来实现对应用资源消耗的控制和有效调度。
+- [使用资源管控 (Resource Control) 管理后台任务](https://docs.pingcap.com/tidb/stable/tidb-resource-control-background-tasks/): 介绍如何通过资源管控 (Resource Control) 控制后台任务。
+- [使用逻辑导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-logical-import-mode-usage/): 了解在 TiDB Lightning 的逻辑导入模式下，如何编写数据导入任务的配置文件，如何进行性能调优等。
+- [信息函数](https://docs.pingcap.com/tidb/stable/information-functions/): TiDB 支持 MySQL 8.0 中提供的大部分信息函数。
+- [修改 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-modify/): 了解修改 JSON 值的 JSON 函数。
+- [停止 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-stop-task/): 了解 TiDB Data Migration 如何停止数据迁移任务。
+- [元数据锁](https://docs.pingcap.com/tidb/stable/metadata-lock/): 介绍 TiDB 中元数据锁的概念、原理、实现和影响。
+- [公共表表达式 (CTE)](https://docs.pingcap.com/tidb/stable/dev-guide-use-common-table-expression/): 介绍 TiDB 公共表表达式能力，用以简化 SQL。
+- [关联子查询去关联](https://docs.pingcap.com/tidb/stable/correlated-subquery-optimization/): 了解如何给关联子查询解除关联。
+- [关键字](https://docs.pingcap.com/tidb/stable/keywords/): 本文介绍 TiDB 的关键字。
+- [其他函数](https://docs.pingcap.com/tidb/stable/miscellaneous-functions/): TiDB 支持使用 MySQL 8.0 中提供的大部分其他函数。
+- [函数和操作符概述](https://docs.pingcap.com/tidb/stable/functions-and-operators-overview/): TiDB 中的函数和操作符使用方法与 MySQL 基本一致。在 SQL 语句中，表达式可用于诸如 SELECT 语句的 ORDER BY 或 HAVING 子句，SELECT/DELETE/UPDATE 语句的 WHERE 子句，或 SET 语句之类的地方。可使用字面值，列名，NULL，内置函数，操作符等来书写表达式。其中有些表达式下推到 TiKV 上执行，详见下推到 TiKV 的表达式列表。
+- [分享 TiDB Dashboard 会话](https://docs.pingcap.com/tidb/stable/dashboard-session-share/): 了解如何将当前的 TiDB Dashboard 会话分享给其他用户访问。
+- [分区表](https://docs.pingcap.com/tidb/stable/partitioned-table/): 了解如何使用 TiDB 的分区表。
+- [分区裁剪](https://docs.pingcap.com/tidb/stable/partition-pruning/): 了解 TiDB 分区裁剪的使用场景。
+- [分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge/): DM 提供了分库分表的合并迁移功能，可将上游 MySQL/MariaDB 实例中的表迁移到下游 TiDB 的同一个表中。支持悲观协调和乐观协调两种模式。悲观模式保证数据不出错，但可能会阻塞迁移；乐观模式处理 DDL 时不会阻塞数据迁移，但可能导致数据不一致。
+- [分库分表场景下的数据校验](https://docs.pingcap.com/tidb/stable/shard-diff/): sync-diff-inspector 支持对分库分表场景进行数据校验。使用 Datasource config 进行配置，设置对应 rules，配置上游表与下游表的映射关系。当上游分表较多且符合一定规则时，可以使用 table-rules 进行配置。注意事项：如果上游数据库有 test.table-0 也会被下游数据库匹配到。
+- [分析慢查询](https://docs.pingcap.com/tidb/stable/analyze-slow-queries/): 学习如何定位和分析慢查询。
+- [分表合并数据迁移最佳实践](https://docs.pingcap.com/tidb/stable/shard-merge-best-practices/): 使用 DM 对分库分表进行合并迁移时的最佳实践。
+- [分页查询](https://docs.pingcap.com/tidb/stable/dev-guide-paginate-results/): 介绍 TiDB 的分页查询功能。
+- [切换 DM-worker 与上游 MySQL 实例的连接](https://docs.pingcap.com/tidb/stable/usage-scenario-master-slave-switch/): 了解如何切换 DM-worker 与上游 MySQL 实例的连接。
+- [列裁剪](https://docs.pingcap.com/tidb/stable/column-pruning/): 列裁剪是优化器在优化过程中删除不需要的列的基本思想。这样可以减少 I/O 资源占用并为后续优化带来便利。TiDB 会在逻辑优化阶段进行列裁剪，减少资源浪费。该扫描过程称作“列裁剪”，对应逻辑优化规则中的 columnPruner。如果要关闭这个规则，可以参照优化规则及表达式下推的黑名单中的关闭方法。
+- [创建 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-create/): 了解创建 JSON 值的 JSON 函数。
+- [创建 TiDB Data Migration 数据源](https://docs.pingcap.com/tidb/stable/quick-start-create-source/): 了解如何为 DM 创建数据源。
+- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-create-task/): 了解 TiDB Data Migration 如何创建数据迁移任务。
+- [创建 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/quick-start-create-task/): 了解在部署 DM 集群后，如何快速创建数据迁移任务。
+- [创建二级索引](https://docs.pingcap.com/tidb/stable/dev-guide-create-secondary-indexes/): 创建二级索引的方法、规范及例子。
+- [创建数据库](https://docs.pingcap.com/tidb/stable/dev-guide-create-database/): 创建数据库的方法、规范及例子。
+- [创建表](https://docs.pingcap.com/tidb/stable/dev-guide-create-table/): 创建表的方法、规范及例子。
+- [删除数据](https://docs.pingcap.com/tidb/stable/dev-guide-delete-data/): 删除数据、批量删除数据的方法、最佳实践及例子。
+- [加密和压缩函数](https://docs.pingcap.com/tidb/stable/encryption-and-compression-functions/): TiDB 支持 MySQL 8.0 中提供的大部分加密和压缩函数。
+- [升级与升级后常见问题](https://docs.pingcap.com/tidb/stable/upgrade-faq/): TiDB 升级与升级后的常见问题与解决办法。
+- [升级集群监控组件](https://docs.pingcap.com/tidb/stable/upgrade-monitoring-services/): 介绍如何升级 TiDB 集群监控组件 Prometheus、Grafana 和 Alertmanager。
+- [单区域双 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/two-data-centers-in-one-city-deployment/): 了解单个区域两个可用区自适应同步模式部署方式。
+- [单区域多 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/multi-data-centers-in-one-city-deployment/): 本文档介绍单个区域多个可用区部署 TiDB 的方案。
+- [单表查询](https://docs.pingcap.com/tidb/stable/dev-guide-get-data-from-single-table/): 介绍 TiDB 中的单表查询功能。
+- [双区域多 AZ 部署 TiDB](https://docs.pingcap.com/tidb/stable/three-data-centers-in-two-cities-deployment/): 介绍在两个区域多个可用区部署 TiDB 的方式。
+- [只读存储节点最佳实践](https://docs.pingcap.com/tidb/stable/readonly-nodes/): 介绍如何通过使用只读存储节点，达到物理隔离部分流量的目的。
+- [同步数据到 Kafka](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-kafka/): 了解如何使用 TiCDC 将数据同步到 Kafka。
+- [同步数据到 MySQL 兼容数据库](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-mysql/): 了解如何使用 TiCDC 将数据同步到 TiDB 或 MySQL
+- [同步数据到 Pulsar](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-pulsar/): 了解如何使用 TiCDC 将数据同步到 Pulsar。
+- [同步数据到存储服务](https://docs.pingcap.com/tidb/stable/ticdc-sink-to-cloud-storage/): 了解如何使用 TiCDC 将数据同步到存储服务，以及数据变更记录的存储路径。
+- [向量函数和操作符](https://docs.pingcap.com/tidb/stable/vector-search-functions-and-operators/): 本文介绍 TiDB 的向量相关函数和操作。
+- [向量搜索概述](https://docs.pingcap.com/tidb/stable/vector-search-overview/): 介绍 TiDB 向量搜索功能。TiDB 向量搜索可以对文档、图像、音频和视频等多种数据类型进行语义搜索。
+- [向量搜索索引](https://docs.pingcap.com/tidb/stable/vector-search-index/): 了解如何在 TiDB 中构建并使用向量搜索索引加速 K 近邻 (K-Nearest Neighbors, KNN) 查询。
+- [向量搜索限制](https://docs.pingcap.com/tidb/stable/vector-search-limitations/): 了解 TiDB 向量搜索功能的限制。
+- [向量搜索集成概览](https://docs.pingcap.com/tidb/stable/vector-search-integration-overview/): 介绍 TiDB 向量搜索支持的 AI 框架、嵌入模型和 ORM 库。
+- [向量数据类型](https://docs.pingcap.com/tidb/stable/vector-search-data-types/): 本文介绍 TiDB 的向量数据类型。
+- [唯一序列号生成方案](https://docs.pingcap.com/tidb/stable/dev-guide-unique-serial-number-generation/): 唯一序列号生成方案，为自行生成唯一 ID 的开发者提供帮助。
+- [在 AWS Lambda 函数中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-aws-lambda/): 本文介绍如何在 AWS Lambda 函数中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
+- [在 Django ORM 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-django-orm/): 了解如何在 Django ORM 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
+- [在 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/tidb-in-kubernetes/): 你可以使用 TiDB Operator 在 Kubernetes 上部署 TiDB。TiDB Operator 是 Kubernetes 上的 TiDB 集群自动运维系统，提供部署、升级、扩缩容、备份恢复、配置变更的 TiDB 全生命周期管理。借助 TiDB Operator，TiDB 可以无缝运行在公有云或自托管的 Kubernetes 集群上。TiDB Operator 的文档目前独立于 TiDB 文档。要查看如何在 Kubernetes 上部署 TiDB 的详细步骤，请参阅对应版本的 TiDB Operator 文档。
+- [在 LangChain 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-langchain/): 展示如何在 LangChain 中使用 TiDB 向量搜索
+- [在 LlamaIndex 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-llamaindex/): 了解如何在 LlamaIndex 中使用 TiDB 向量搜索。
+- [在 Next.js 中使用 mysql2 连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-sample-application-nextjs/): 本文介绍了如何在 Next.js 中使用 TiDB 和 mysql2 构建一个 CRUD 应用程序，并给出了简单示例代码片段。
+- [在 peewee 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-peewee/): 了解如何在 peewee 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
+- [在 SQLAlchemy 中使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-sqlalchemy/): 了解如何在 SQLAlchemy 中通过 TiDB 向量搜索功能存储向量并执行语义搜索。
+- [在三数据中心下就近读取数据](https://docs.pingcap.com/tidb/stable/three-dc-local-read/): 了解通过 Stale Read 功能在三数据中心下就近读取数据，减少跨数据中心请求。
+- [在公有云上部署 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/best-practices-on-public-cloud/): 了解在公有云上部署 TiDB 的最佳实践。
+- [在线修改集群配置](https://docs.pingcap.com/tidb/stable/dynamic-config/): 介绍在线修改集群配置的功能。
+- [在线应用 Hotfix 到 DM 集群](https://docs.pingcap.com/tidb/stable/tiup-component-dm-patch/): 了解如何应用 hotfix 补丁包到 DM 集群。
+- [基于 Avro 的 TiCDC 行数据 Checksum 校验](https://docs.pingcap.com/tidb/stable/ticdc-avro-checksum-verification/): 介绍 TiCDC 行数据 Checksum 校验的具体实现。
+- [基于 DM 同步场景下的数据校验](https://docs.pingcap.com/tidb/stable/dm-diff/): 了解如何使用 TiDB DM 拉取指定配置进行数据校验。
+- [基于主备集群的容灾方案](https://docs.pingcap.com/tidb/stable/dr-secondary-cluster/): 了解如何使用 TiCDC 构建主备集群进行容灾。
+- [基于备份与恢复的容灾方案](https://docs.pingcap.com/tidb/stable/dr-backup-restore/): 了解如何基于 TiDB 的备份与恢复功能实现容灾。
+- [基于多副本的单集群容灾方案](https://docs.pingcap.com/tidb/stable/dr-multi-replica/): 了解 TiDB 提供的基于多副本的单集群容灾方案。
+- [基于角色的访问控制](https://docs.pingcap.com/tidb/stable/role-based-access-control/): TiDB 的基于角色的访问控制 (RBAC) 系统类似于 MySQL 8.0 的 RBAC 系统。用户可以创建、删除和授予角色权限，也可以将角色授予其他用户。角色需要在用户启用后才能生效。用户可以通过 `SHOW GRANTS` 查看角色权限，也可以设置默认启用角色。角色授权具有原子性，失败会回滚。除了角色授权外，还有用户管理和权限管理相关操作。
+- [备份与恢复 RawKV 数据](https://docs.pingcap.com/tidb/stable/rawkv-backup-and-restore/): 了解如何使用 tikv-br 命令行工具备份和恢复 RawKV 数据。
+- [备份与恢复常见问题](https://docs.pingcap.com/tidb/stable/backup-and-restore-faq/): 了解备份恢复相关的常见问题以及解决方法。
+- [备份存储](https://docs.pingcap.com/tidb/stable/backup-and-restore-storages/): 了解 BR 支持的备份存储服务的 URI 格式、鉴权方案和使用方式。
+- [备份恢复监控告警](https://docs.pingcap.com/tidb/stable/br-monitoring-and-alert/): 了解备份恢复的监控告警。
+- [备份自动调节](https://docs.pingcap.com/tidb/stable/br-auto-tune/): 了解 TiDB 的自动调节备份功能，在集群资源占用率较高的情况下，BR 会自动限制备份使用的资源以求减少对集群的影响。
+- [外部存储服务的 URI 格式](https://docs.pingcap.com/tidb/stable/external-storage-uri/): 介绍了外部存储服务 Amazon S3、GCS、和 Azure Blob Storage 的 URI 格式。
+- [外键约束](https://docs.pingcap.com/tidb/stable/foreign-key/): TiDB 数据库中外键约束的使用概况。
+- [多表连接查询](https://docs.pingcap.com/tidb/stable/dev-guide-join-tables/): 介绍 TiDB 中的多表连接查询功能。
+- [如何对 TiDB 进行 CH-benCHmark 测试](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-ch/): 本文介绍如何对 TiDB 进行 CH-benCHmark 测试。
+- [如何对 TiDB 进行 TPC-C 测试](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-tpcc/): 本文介绍了如何对 TiDB 进行 TPC-C 测试。TPC-C 是一个对 OLTP 系统进行测试的规范，使用商品销售模型对系统进行测试，包含五类事务：NewOrder、Payment、OrderStatus、Delivery、StockLevel。测试使用 tpmC 值衡量系统最大有效吞吐量，以 NewOrder Transaction 为准。使用 go-tpc 进行测试实现，通过 TiUP 命令下载测试程序。测试包括数据导入、运行测试和清理测试数据。
+- [如何用 Sysbench 测试 TiDB](https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-sysbench/): 使用 Sysbench 1.0 或更新版本测试 TiDB 性能。调整 TiDB 和 TiKV 的日志级别以提高性能。配置 RocksDB 的 block cache 以充分利用内存。调整 Sysbench 配置文件并导入数据。进行数据预热和统计信息收集。执行 Point select、Update index 和 Read-only 测试命令。解决可能出现的性能问题。
+- [如何过滤 binlog 事件](https://docs.pingcap.com/tidb/stable/filter-binlog-event/): 介绍如何过滤 binlog 事件。
+- [如何通过 SQL 表达式过滤 DML](https://docs.pingcap.com/tidb/stable/filter-dml-event/): 介绍如何通过 SQL 表达式过滤 DML 事件
+- [子查询](https://docs.pingcap.com/tidb/stable/dev-guide-use-subqueries/): 介绍 TiDB 子查询功能。
+- [子查询相关的优化](https://docs.pingcap.com/tidb/stable/subquery-optimization/): 了解子查询相关的优化。
+- [字符串函数](https://docs.pingcap.com/tidb/stable/string-functions/): TiDB 支持 MySQL 8.0 中提供的大部分字符串函数以及 Oracle 21 中提供的部分函数。
+- [字符串类型](https://docs.pingcap.com/tidb/stable/data-type-string/): TiDB 支持 MySQL 所有字符串类型，包括 CHAR、VARCHAR、BINARY、VARBINARY、BLOB、TEXT、ENUM 和 SET。CHAR 是定长字符串，长度固定为创建表时声明的长度。VARCHAR 是变长字符串，空间占用大小不得超过 65535 字节。TEXT 是文本串，最大列长为 65535 字节。TINYTEXT 最大列长度为 255。MEDIUMTEXT 最大列长度为 16777215。LONGTEXT 最大列长度为 4294967295。BINARY 存储二进制字符串。VARBINARY 存储二进制字符串。BLOB 是二进制大文件，最大列长度为 65535 字节。TINYBLOB 最大列长度为 255。MEDIUMBLOB 最大列长度为 16777215。LONGBLOB 最大列长度为 4294967295。ENUM 是枚举类型，值必须从固定集合中选取。SET 是集合类型，包含零个或多个值的字符串。
+- [字符集和排序规则](https://docs.pingcap.com/tidb/stable/character-set-and-collation/): TiDB 支持的字符集包括 ascii、binary、gbk、latin1、utf8 和 utf8mb4。排序规则包括 ascii_bin、binary、gbk_bin、gbk_chinese_ci、latin1_bin、utf8_bin、utf8_general_ci、utf8_unicode_ci、utf8mb4_0900_ai_ci、utf8mb4_0900_bin、utf8mb4_bin、utf8mb4_general_ci 和 utf8mb4_unicode_ci。TiDB 强烈建议使用 utf8mb4 字符集，因为它支持更多字符。在 TiDB 中，默认的排序规则受到客户端的连接排序规则设置的影响。如果客户端使用 utf8mb4_0900_ai_ci 作为连接排序规则，TiDB 将遵循客户端的配置。TiDB 还支持新的排序规则框架，用于在语义上支持不同的排序规则。
+- [字面值](https://docs.pingcap.com/tidb/stable/literal-values/): 本文介绍了 TiDB SQL 语句的字面值。
+- [定位消耗系统资源多的查询](https://docs.pingcap.com/tidb/stable/identify-expensive-queries/): TiDB 会将执行时间超过 tidb_expensive_query_time_threshold 限制（默认值为 60s），或使用内存超过 tidb_mem_quota_query 限制（默认值为 1 GB）的语句输出到 tidb-server 日志文件中，用于定位消耗系统资源多的查询语句。expensive query 日志和慢查询日志的区别在于，expensive query 日志可以将正在执行的语句的相关信息打印出来。当一条语句在执行过程中达到资源使用阈值时，TiDB 会即时将这条语句的相关信息写入日志。
+- [对象命名规范](https://docs.pingcap.com/tidb/stable/dev-guide-object-naming-guidelines/): 介绍 TiDB 中的对象命名规范。
+- [将 Grafana 监控数据导出成快照](https://docs.pingcap.com/tidb/stable/exporting-grafana-snapshots/): 了解如何将 Grafana 监控数据导出为快照以及如何将快照文件可视化。
+- [已知的第三方工具兼容问题](https://docs.pingcap.com/tidb/stable/dev-guide-third-party-tools-compatibility/): 介绍在测试中发现的 TiDB 与第三方工具的兼容性问题。
+- [常规统计信息](https://docs.pingcap.com/tidb/stable/statistics/): 介绍 TiDB 中常规统计信息的收集和使用。
+- [平滑升级 TiDB](https://docs.pingcap.com/tidb/stable/smooth-upgrade-tidb/): 本文介绍支持无需手动取消 DDL 的平滑升级集群功能。
+- [序列函数](https://docs.pingcap.com/tidb/stable/sequence-functions/): 了解 TiDB 中的序列函数。
+- [延迟的拆解分析](https://docs.pingcap.com/tidb/stable/latency-breakdown/): 详细介绍 TiDB 运行各阶段中时间消耗带来的延迟，以及如何在真实场景中分析延迟。
+- [开发 Java 应用使用 TiDB 的最佳实践](https://docs.pingcap.com/tidb/stable/java-app-best-practices/): 本文介绍了开发 Java 应用程序使用 TiDB 的常见问题与解决办法。TiDB 是高度兼容 MySQL 协议的数据库，基于 MySQL 开发的 Java 应用的最佳实践也多适用于 TiDB。
+- [开发者手册概览](https://docs.pingcap.com/tidb/stable/dev-guide-overview/): 整体叙述了开发者手册，罗列了开发者手册的大致脉络。
+- [性能优化概述](https://docs.pingcap.com/tidb/stable/performance-tuning-overview/): 本文介绍性能优化的基本概念，比如用户响应时间、吞吐和数据库时间，以及性能优化的通用流程。
+- [性能调优最佳实践](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql-best-practices/): 介绍使用 TiDB 的性能调优最佳实践。
+- [恢复 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-resume-task/): 了解 TiDB Data Migration 如何恢复数据迁移任务。
+- [悲观模式下分库分表合并迁移](https://docs.pingcap.com/tidb/stable/feature-shard-merge-pessimistic/): 介绍 DM 提供的悲观模式（默认模式）下分库分表的合并迁移功能。
+- [慢查询日志](https://docs.pingcap.com/tidb/stable/identify-slow-queries/): TiDB 会将执行时间超过 300 毫秒的语句输出到慢查询日志中，用于帮助用户定位慢查询语句。可以通过修改系统变量来启用或禁用慢查询日志。日志示例包括执行时间、用户信息、执行计划等字段。用户可通过查询 SLOW_QUERY 表来查询慢查询日志中的内容。还可以使用 pt-query-digest 工具分析 TiDB 慢日志。ADMIN SHOW SLOW 命令可以显示最近的慢查询记录或最慢的查询记录。
+- [手动处理 Sharding DDL Lock](https://docs.pingcap.com/tidb/stable/manually-handling-sharding-ddl-locks/): DM 使用 sharding DDL lock 来确保分库分表的 DDL 操作可以正确执行。在异常情况下，需要手动处理异常的 DDL lock。使用 shard-ddl-lock 命令查看 DDL lock 信息，使用 shard-ddl-lock unlock 命令请求 DM-master 解除指定的 DDL lock。支持处理部分 MySQL source 被移除和 unlock 过程中部分 DM-worker 异常停止或网络中断的情况。
+- [执行计划管理 (SPM)](https://docs.pingcap.com/tidb/stable/sql-plan-management/): 介绍 TiDB 的执行计划管理 (SQL Plan Management) 功能。
+- [扩展统计信息](https://docs.pingcap.com/tidb/stable/extended-statistics/): 了解如何使用扩展统计信息指导优化器。
+- [批量建表](https://docs.pingcap.com/tidb/stable/br-batch-create-table/): 了解如何使用批量建表功能。在恢复备份数据时，可以通过批量建表功能加快数据的恢复速度。
+- [控制执行计划](https://docs.pingcap.com/tidb/stable/control-execution-plan/): 本章节介绍了控制执行计划的方法，包括使用提示指导执行计划、执行计划管理、优化规则及表达式下推的黑名单。此外，还介绍了一些系统变量对执行计划的影响，以及引入的特殊变量 `tidb_opt_fix_control`，用于更细粒度地控制优化器的行为。
+- [控制流程函数](https://docs.pingcap.com/tidb/stable/control-flow-functions/): TiDB 支持 MySQL 8.0 中的控制流程函数，包括 CASE、IF()、IFNULL() 和 NULLIF()。这些函数可以用于构建 if/else 语句和处理 NULL 值。
+- [提升 TiDB 建表性能](https://docs.pingcap.com/tidb/stable/accelerated-table-creation/): 介绍 TiDB 加速建表中的概念、原理、实现和影响。
+- [提高 TiDB Dashboard 安全性](https://docs.pingcap.com/tidb/stable/dashboard-ops-security/): TiDB Dashboard 需要提高安全性。建议为 `root` 用户设置强密码或禁用 `root` 账户，并为 TiDB Dashboard 创建最小权限用户。使用防火墙阻止不可信访问，配置反向代理仅代理 TiDB Dashboard，并为反向代理开启 TLS。其他建议的安全措施包括为组件间通信和客户端服务端间通信开启加密传输。
+- [插入数据](https://docs.pingcap.com/tidb/stable/dev-guide-insert-data/): 插入数据、批量导入数据的方法、最佳实践及例子。
+- [搜索 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-search/): 了解搜索 JSON 值的 JSON 函数。
+- [搭建双集群主从复制](https://docs.pingcap.com/tidb/stable/replicate-between-primary-and-secondary-clusters/): 了解如何配置一个 TiDB 集群以及该集群的 TiDB 或 MySQL 从集群，并将增量数据实时从主集群同步到从集群，
+- [搭建私有镜像](https://docs.pingcap.com/tidb/stable/tiup-mirror/): TiUP 提供了构建私有镜像的方案，使用 mirror 指令来实现，可用于离线部署。执行 `tiup mirror clone` 命令，可构建本地地镜像。克隆完成后，可以通过 SCP、NFS、HTTP 或 HTTPS 共享仓库。使用 `TIUP_MIRRORS` 环境变量来使用镜像。重新运行 `tiup mirror clone` 命令会创建新的 manifest，并下载可用的最新版本的组件。可以创建自定义仓库，并使用自己构建的 TiDB 组件。
+- [操作符](https://docs.pingcap.com/tidb/stable/operators/): 操作符是用于在 MySQL 中执行各种操作的关键元素。它们包括逻辑操作符（如 AND、OR、NOT、XOR）、赋值操作符（如 =、:=）、比较操作符（如 =、<、>、LIKE、BETWEEN）、以及其他操作符（如 +、-、*、/）。操作符具有不同的优先级，可以用于执行各种复杂的操作。需要注意的是，MySQL 不支持 ILIKE 操作符。
+- [操作系统性能参数调优](https://docs.pingcap.com/tidb/stable/tune-operating-system/): 了解如何进行 CentOS 7 系统的性能调优。
+- [支持资源](https://docs.pingcap.com/tidb/stable/support/): 在使用 TiDB 时遇到问题，如何获取支持。
+- [数值函数与操作符](https://docs.pingcap.com/tidb/stable/numeric-functions-and-operators/): TiDB 支持 MySQL 8.0 中的所有数值函数和操作符。
+- [数值类型](https://docs.pingcap.com/tidb/stable/data-type-numeric/): TiDB 支持 MySQL 的所有数值类型，包括整数类型、浮点类型和定点类型。整数类型包括 BIT、BOOLEAN、TINYINT、SMALLINT、MEDIUMINT、INTEGER 和 BIGINT，存储空间和取值范围各不相同。浮点类型包括 FLOAT 和 DOUBLE，存储空间分别为 4 和 8 字节。定点类型包括 DECIMAL 和 NUMERIC，可设置小数位数和小数点后位数。建议使用 DECIMAL 类型存储精确值。
+- [数据批量处理](https://docs.pingcap.com/tidb/stable/batch-processing/): 介绍了 TiDB 为数据批量处理场景提供的功能，包括 Pipelined DML、非事务性 DML、IMPORT INTO 语句以及已被废弃的 batch-dml。
+- [数据类型概述](https://docs.pingcap.com/tidb/stable/data-type-overview/): TiDB 支持除了空间类型（SPATIAL）之外的所有 MySQL 数据类型，包括数值型类型、字符串类型、时间和日期类型、JSON 类型。数据类型定义一般为 T(M[, D])，其中 T 表示具体的类型，M 在整数类型中表示最大显示长度，在浮点数或者定点数中表示精度，在字符类型中表示最大长度，D 表示浮点数、定点数的小数位长度，fsp 在时间和日期类型里的 TIME、DATETIME 以及 TIMESTAMP 中表示秒的精度，其取值范围是 0 到 6，值为 0 表示没有小数部分，如果省略，则默认精度为 0。
+- [数据类型的默认值](https://docs.pingcap.com/tidb/stable/data-type-default-values/): 数据类型的默认值描述了列的默认值设置规则。默认值必须是常量，对于时间类型可以使用特定函数。从 v8.0.0 开始，BLOB、TEXT 和 JSON 可以设置表达式默认值。如果列没有设置 DEFAULT，TiDB 会根据规则添加隐式默认值。对于 NOT NULL 列，根据 SQL_MODE 进行不同行为。表达式默认值是实验特性，不建议在生产环境中使用。MySQL 8.0.13 开始支持在 DEFAULT 子句中指定表达式为默认值。TiDB 支持为 BLOB、TEXT 和 JSON 数据类型分配默认值，但仅支持通过表达式来设置。
+- [数据索引一致性错误](https://docs.pingcap.com/tidb/stable/troubleshoot-data-inconsistency-errors/): TiDB 在执行事务或执行 ADMIN CHECK 命令时会检查数据索引的一致性。如果发现不一致，会报错并记录相关错误日志。报错处理可通过改写 SQL 或关闭错误检查来绕过。对于特定错误代码，可通过设置 @@tidb_enable_mutation_checker=0 或 @@tidb_txn_assertion_level=OFF 来跳过检查。需注意关闭开关会关闭所有 SQL 语句的对应检查。
+- [数据迁移工具概览](https://docs.pingcap.com/tidb/stable/migration-tools/): 介绍 TiDB 的数据迁移工具。
+- [数据迁移概述](https://docs.pingcap.com/tidb/stable/migration-overview/): 了解各种数据迁移场景和对应的数据迁移方案。
+- [数据集成概述](https://docs.pingcap.com/tidb/stable/integration-overview/): 了解使用 TiCDC 进行数据集成的具体场景。
+- [断点备份](https://docs.pingcap.com/tidb/stable/br-checkpoint-backup/): 了解断点备份功能，包括它的使用场景、实现原理以及使用方法。
+- [断点恢复](https://docs.pingcap.com/tidb/stable/br-checkpoint-restore/): 了解断点恢复功能，包括它的使用场景、实现原理以及使用方法。
+- [日常巡检](https://docs.pingcap.com/tidb/stable/daily-check/): 介绍 TiDB 集群需要常关注的性能指标。
+- [日志脱敏](https://docs.pingcap.com/tidb/stable/log-redaction/): 了解 TiDB 各组件中的日志脱敏。
+- [日期和时间函数](https://docs.pingcap.com/tidb/stable/date-and-time-functions/): TiDB 支持 MySQL 8.0 中的所有日期和时间函数。
+- [日期和时间类型](https://docs.pingcap.com/tidb/stable/data-type-date-and-time/): TiDB 支持 MySQL 的所有日期和时间类型，包括 DATE、TIME、DATETIME、TIMESTAMP 和 YEAR。每种类型都有有效值范围，值为 0 表示无效值。TIMESTAMP 和 DATETIME 类型能自动生成新的时间值。关于日期和时间值类型，需要注意日期部分必须是“年 - 月 - 日”的格式，如果日期的年份部分是 2 位数，TiDB 会根据具体规则进行转换。不同类型的零值如下表所示：DATE:0000-00-00, TIME:00:00:00, DATETIME:0000-00-00 00:00:00, TIMESTAMP:0000-00-00 00:00:00, YEAR:0000。如果 SQL 模式允许使用无效的 DATE、DATETIME、TIMESTAMP 值，无效值会自动转换为相应的零值。
+- [时区支持](https://docs.pingcap.com/tidb/stable/configure-time-zone/): TiDB 的时区设置由 `time_zone` 系统变量控制，可以在会话级别或全局级别进行设置。`TIMESTAMP` 数据类型的的显示值受时区设置影响，但 `DATETIME`、`DATE` 或 `TIME` 数据类型不受影响。在数据迁移时，需要特别注意主库和从库的时区设置是否一致。
+- [暂停 TiDB Data Migration 数据迁移任务](https://docs.pingcap.com/tidb/stable/dm-pause-task/): 了解 TiDB Data Migration 如何暂停数据迁移任务。
+- [更新数据](https://docs.pingcap.com/tidb/stable/dev-guide-update-data/): 更新数据、批量更新数据的方法、最佳实践及例子。
+- [最小拓扑架构](https://docs.pingcap.com/tidb/stable/minimal-deployment-topology/): 介绍 TiDB 集群的最小拓扑。
+- [服务器状态变量](https://docs.pingcap.com/tidb/stable/status-variables/): 使用状态变量查看系统和会话状态。
+- [本地快速部署 TiDB 集群](https://docs.pingcap.com/tidb/stable/tiup-playground/): TiDB 集群是分布式系统，由多个组件构成。想要快速体验 TiDB，可以使用 TiUP 中的 playground 组件快速搭建本地测试环境。通过命令行参数可以设置各组件的数量和配置，也可以启动多个组件实例。使用 `tiup client` 可以快速连接到本地启动的 TiDB 集群。还可以查看已启动集群的信息，扩容或缩容集群。
+- [术语表](https://docs.pingcap.com/tidb/stable/glossary/): 了解 TiDB 相关术语。
+- [权限管理](https://docs.pingcap.com/tidb/stable/privilege-management/): TiDB 支持 MySQL 5.7 和 MySQL 8.0 的权限管理系统。权限相关操作包括授予权限、收回权限、查看用户权限和动态权限。权限系统的实现包括授权表和连接验证。权限生效时机是在 TiDB 启动时加载到内存，并且可以手动刷新。
+- [构建 TiFlash 副本](https://docs.pingcap.com/tidb/stable/create-tiflash-replicas/): 了解如何构建 TiFlash 副本。
+- [概览](https://docs.pingcap.com/tidb/stable/dev-guide-optimize-sql-overview/): 介绍 TiDB 的 SQL 性能调优概览。
+- [概述](https://docs.pingcap.com/tidb/stable/dev-guide-schema-design-overview/): TiDB 数据库模式设计的概述。
+- [注释语法](https://docs.pingcap.com/tidb/stable/comment-syntax/): 本文介绍 TiDB 支持的注释语法。
+- [海量 Region 集群调优最佳实践](https://docs.pingcap.com/tidb/stable/massive-regions-best-practices/): 了解海量 Region 导致性能问题的原因和优化方法。
+- [混合部署拓扑](https://docs.pingcap.com/tidb/stable/hybrid-deployment-topology/): 介绍混合部署 TiDB 集群的拓扑结构。
+- [物理优化](https://docs.pingcap.com/tidb/stable/sql-physical-optimization/): 物理优化是基于代价的优化，为逻辑执行计划制定物理执行计划。优化器根据数据统计信息选择时间复杂度、资源消耗和物理属性最小的物理执行计划。TiDB 执行计划文档介绍了索引选择、统计信息、错误索引解决方案、Distinct 优化和代价模型。
+- [物理导入模式](https://docs.pingcap.com/tidb/stable/tidb-lightning-physical-import-mode/): 了解 TiDB Lightning 的物理导入模式。
+- [理解 TiKV 中的 Stale Read 和 safe-ts](https://docs.pingcap.com/tidb/stable/troubleshoot-stale-read/): TiKV 中的 Stale Read 依赖于 safe-ts，保证读取历史数据版本的安全性。safe-ts 由每个 Region 中的 peer 维护，resolved-ts 则由 Region leader 维护。诊断 Stale Read 问题可通过 Grafana、tikv-ctl 和日志。常见原因包括事务提交时间过长、事务存在时间过长以及 CheckLeader 信息推送延迟。处理慢事务提交可通过识别锁所属的事务和检查应用程序逻辑。处理长事务可通过识别事务、检查应用程序逻辑和处理慢查询。解决 CheckLeader 问题可通过检查网络和监控面板指标。
+- [生成列](https://docs.pingcap.com/tidb/stable/generated-columns/): 生成列是由列定义中的表达式计算得到的值。它包括存储生成列和虚拟生成列，存储生成列会将计算得到的值存储起来，而虚拟生成列不会存储其值。生成列可以用于从 JSON 数据类型中解出数据，并为该数据建立索引。在 INSERT 和 UPDATE 语句中，会检查生成列计算得到的值是否满足生成列的定义。生成列的局限性包括不能增加存储生成列，不能转换存储生成列为普通列，不能修改存储生成列的生成列表达式，以及不支持所有的 JSON 函数。
+- [生成自签名证书](https://docs.pingcap.com/tidb/stable/generate-self-signed-certificates/): 本文介绍了使用 openssl 生成自签名证书的示例。用户可以根据需要生成符合要求的证书和密钥。首先安装 OpenSSL，然后生成 CA 证书和各个组件的证书，最后为客户端签发证书。证书的作用是为各个组件和客户端验证身份。
+- [用 EXPLAIN 查看 JOIN 查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-joins/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看 MPP 模式查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-mpp/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看分区查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-partitions/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看子查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-subqueries/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看带视图的 SQL 执行计划](https://docs.pingcap.com/tidb/stable/explain-views/): 了解 TiDB 中视图相关语句的执行计划。
+- [用 EXPLAIN 查看索引合并的 SQL 执行计划](https://docs.pingcap.com/tidb/stable/explain-index-merge/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看索引查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-indexes/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用 EXPLAIN 查看聚合查询的执行计划](https://docs.pingcap.com/tidb/stable/explain-aggregation/): 了解 TiDB 中 EXPLAIN 语句返回的执行计划信息。
+- [用户自定义变量](https://docs.pingcap.com/tidb/stable/user-defined-variables/): 本文介绍 TiDB 的用户自定义变量。
+- [窗口函数](https://docs.pingcap.com/tidb/stable/window-functions/): TiDB 中的窗口函数与 MySQL 8.0 基本一致。可以将 `tidb_enable_window_function` 设置为 `0` 来解决升级后无法解析语法的问题。TiDB 支持除 `GROUP_CONCAT()` 和 `APPROX_PERCENTILE()` 以外的所有 `GROUP BY` 聚合函数。其他支持的窗口函数包括 `CUME_DIST()`、`DENSE_RANK()`、`FIRST_VALUE()`、`LAG()`、`LAST_VALUE()`、`LEAD()`、`NTH_VALUE()`、`NTILE()`、`PERCENT_RANK()`、`RANK()` 和 `ROW_NUMBER()`。这些函数可以下推到 TiFlash。
+- [管理 Changefeed](https://docs.pingcap.com/tidb/stable/ticdc-manage-changefeed/): 了解 Changefeed 相关的各种管理手段。
+- [管理 TiDB Data Migration 上游数据源](https://docs.pingcap.com/tidb/stable/dm-manage-source/): 了解如何管理上游 MySQL 实例。
+- [管理 TiDB Data Migration 迁移表的表结构](https://docs.pingcap.com/tidb/stable/dm-manage-schema/): 了解如何管理待迁移表在 DM 内部的表结构。
+- [管理资源消耗超出预期的查询 (Runaway Queries)](https://docs.pingcap.com/tidb/stable/tidb-resource-control-runaway-queries/): 介绍如何通过资源管控能力来实现对资源消耗超出预期的语句 (Runaway Queries) 进行控制和降级。
+- [精度数学](https://docs.pingcap.com/tidb/stable/precision-math/): TiDB 中的精确数值运算与 MySQL 基本一致。精确数值运算包括整型和 DECIMAL 类型，以及精确值数字字面量。DECIMAL 数据类型是定点数类型，其运算是精确计算。在表达式计算中，TiDB 会尽可能不做任何修改的使用每个输入的数值。数值修约时，`round()` 函数将使用四舍五入的规则。向 DECIMAL 或整数类型列插入数据时，round 的规则将采用 round half away from zero 的方式。
+- [系统变量](https://docs.pingcap.com/tidb/stable/system-variables/): 使用 TiDB 系统变量来优化性能或修改运行行为。
+- [系统变量索引](https://docs.pingcap.com/tidb/stable/system-variable-reference/): 查看 TiDB 所有的系统变量，以及引用这些变量的文档。
+- [索引推荐 (Index Advisor)](https://docs.pingcap.com/tidb/stable/index-advisor/): 了解如何使用 TiDB 索引推荐 (Index Advisor) 功能优化查询性能。
+- [索引的最佳实践](https://docs.pingcap.com/tidb/stable/dev-guide-index-best-practice/): 介绍 TiDB 中索引的最佳实践。
+- [索引的选择](https://docs.pingcap.com/tidb/stable/choose-index/): 介绍 TiDB 如何选择索引去读入数据，以及相关的一些控制索引选择的方式。
+- [约束](https://docs.pingcap.com/tidb/stable/constraints/): TiDB 支持的约束与 MySQL 基本相同，包括非空约束和 CHECK 约束。非空约束规则与 MySQL 相同，而 CHECK 约束需要在 tidb_enable_check_constraint 设置为 ON 后才能开启。可以通过 CREATE TABLE 或 ALTER TABLE 语句添加 CHECK 约束。唯一约束和主键约束也与 MySQL 相似，但 TiDB 目前仅支持对 NONCLUSTERED 的主键进行添加和删除操作。外键约束从 v6.6.0 开始支持，可以使用 CREATE TABLE 和 ALTER TABLE 命令来添加和删除外键。
+- [结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索](https://docs.pingcap.com/tidb/stable/vector-search-integrate-with-jinaai-embedding/): 了解如何结合 Jina AI 嵌入模型 API 使用 TiDB 向量搜索，以存储向量嵌入信息并执行语义搜索。
+- [结果集不稳定](https://docs.pingcap.com/tidb/stable/dev-guide-unstable-result-set/): 结果集不稳定错误的处理办法。
+- [缓存表](https://docs.pingcap.com/tidb/stable/cached-tables/): 了解 TiDB 中的缓存表功能，用于很少被修改的热点小表，提升读性能。
+- [聚合 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-aggregate/): 了解聚合 JSON 值的 JSON 函数。
+- [聚簇索引](https://docs.pingcap.com/tidb/stable/clustered-indexes/): 本文档介绍了聚簇索引的概念、使用场景、使用方法、限制和兼容性。
+- [自定义监控组件的配置](https://docs.pingcap.com/tidb/stable/customized-montior-in-tiup-environment/): 了解如何自定义 TiUP 管理的监控组件的配置。
+- [表属性](https://docs.pingcap.com/tidb/stable/table-attributes/): 介绍 TiDB 的 `ATTRIBUTES` 使用方法。
+- [表库过滤](https://docs.pingcap.com/tidb/stable/table-filter/): 在 TiDB 数据迁移工具中使用表库过滤功能。
+- [表达式求值的类型转换](https://docs.pingcap.com/tidb/stable/type-conversion-in-expression-evaluation/): TiDB 中的表达式求值类型转换与 MySQL 基本一致。详情请参见 MySQL 表达式求值类型转换文档。
+- [表达式语法](https://docs.pingcap.com/tidb/stable/expression-syntax/): 本文列出 TiDB 的表达式语法。
+- [视图](https://docs.pingcap.com/tidb/stable/dev-guide-use-views/): 介绍 TiDB 中的视图功能。
+- [视图](https://docs.pingcap.com/tidb/stable/views/): TiDB 支持视图，视图是虚拟表，结构由创建时的 SELECT 语句定义。使用视图可保证数据安全，简化复杂查询。查询视图类似查询表，TiDB 执行查询时会展开视图。可通过 SHOW CREATE TABLE 或 SHOW CREATE VIEW 查看视图创建语句及相关信息。也可查询 INFORMATION_SCHEMA.VIEWS 表或访问 HTTP API 获取视图元信息。视图有局限性，不支持物化视图，且为只读视图，不支持写入操作。已创建的视图仅支持 DROP 操作。
+- [访问 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-access/): TiDB Dashboard 可通过浏览器访问，支持多 PD 实例访问。浏览器兼容性包括 Chrome、Firefox 和 Edge。登录界面可使用 root 用户或自定义 SQL 用户登录。支持简体中文和英文语言切换。可在用户页面登出当前用户。
+- [读写延迟增加](https://docs.pingcap.com/tidb/stable/troubleshoot-cpu-issues/): 介绍读写延时增加、抖动时的排查思路，可能的原因和解决方法。
+- [谓词下推](https://docs.pingcap.com/tidb/stable/predicate-push-down/): TiDB 逻辑优化规则中的谓词下推旨在尽早完成数据过滤，减少数据传输或计算的开销。谓词下推适用于将过滤表达式计算下推到数据源，如示例 1、2、3。但对于存储层不支持的谓词、外连接中的谓词和包含用户变量的谓词则不能下推。
+- [资源管控 (Resource Control) 监控指标详解](https://docs.pingcap.com/tidb/stable/grafana-resource-control-dashboard/): 了解资源管控 (Resource Control) 的 Grafana Dashboard 中所展示的关键指标。
+- [跨数据中心部署拓扑](https://docs.pingcap.com/tidb/stable/geo-distributed-deployment-topology/): 介绍跨数据中心部署 TiDB 集群的拓扑结构。
+- [迁移使用 GH-ost/PT-osc 的源数据库](https://docs.pingcap.com/tidb/stable/feature-online-ddl/): 使用 GH-ost/PT-osc 进行在线 DDL 工具执行 DDL 时，会产生锁表操作，阻塞数据库读写。为降低影响，可选择在线 DDL 工具 gh-ost 和 pt-osc。在 DM 迁移 MySQL 到 TiDB 时，可开启 `online-ddl` 配置，实现 DM 工具与 gh-ost 或 pt-osc 的协同。 DM 与 online DDL 工具协作细节包括 gh-ost 和 pt-osc 的实现过程，以及自定义规则配置。
+- [迁移升级 TiDB 集群](https://docs.pingcap.com/tidb/stable/tidb-upgrade-migration-guide/): 本文介绍如何使用 BR 全量备份恢复与 TiCDC 增量数据同步实现 TiDB 集群的迁移升级。
+- [迁移常见问题](https://docs.pingcap.com/tidb/stable/migration-tidb-faq/): 介绍 TiDB 迁移中的常见问题。
+- [返回 JSON 值的 JSON 函数](https://docs.pingcap.com/tidb/stable/json-functions-return/): 了解返回 JSON 值的 JSON 函数。
+- [连接到 TiDB](https://docs.pingcap.com/tidb/stable/dev-guide-connect-to-tidb/): 介绍连接到 TiDB 的方法。
+- [连接池与连接参数](https://docs.pingcap.com/tidb/stable/dev-guide-connection-parameters/): 针对开发者的 TiDB 连接池与连接参数的说明。
+- [选择驱动或 ORM 框架](https://docs.pingcap.com/tidb/stable/dev-guide-choose-driver-or-orm/): 选择驱动或 ORM 框架连接 TiDB。
+- [通过 SQL 表达式过滤 DML](https://docs.pingcap.com/tidb/stable/feature-expression-filter/): 增量数据迁移时可通过 SQL 表达式过滤 binlog event，例如不向下游迁移 `DELETE` 事件。从 v2.0.5 起，DM 支持使用 `binlog value filter` 过滤迁移数据。在 `ROW` 格式的 binlog 中，可以基于列的值配置 SQL 表达式。如果表达式结果为 `TRUE`，DM 就不会向下游迁移该条行变更。具体操作步骤和实现细节，请参考如何通过 SQL 表达式过滤 DML。
+- [通过 TiUP 部署 DM 集群的拓扑文件配置](https://docs.pingcap.com/tidb/stable/tiup-dm-topology-reference/): TiUP 部署 DM 集群的拓扑文件配置包括全局配置、组件配置、master 服务器配置、worker 服务器配置、监控服务器配置、Grafana 服务器配置和 Alertmanager 服务器配置。每个配置包含不同字段，如部署目录、数据目录、日志目录等。部署完成后部分字段不能再修改。
+- [通过 TiUP 部署 TiDB 集群的拓扑文件配置](https://docs.pingcap.com/tidb/stable/tiup-cluster-topology-reference/): 介绍通过 TiUP 部署或扩容 TiDB 集群时提供的拓扑文件配置和示例。
+- [通过反向代理使用 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-ops-reverse-proxy/): TiDB Dashboard 可通过反向代理安全提供给外部网络。首先获取实际地址，然后配置反向代理，最后修改路径前缀。详细步骤可参考官方文档。
+- [通过拓扑 label 进行副本调度](https://docs.pingcap.com/tidb/stable/schedule-replicas-by-topology-labels/): TiDB v5.3.0 引入了通过拓扑 label 进行副本调度的功能。为了提升集群的高可用性和数据容灾能力，推荐让 TiKV 节点在物理层面上尽可能分散。通过设置 TiKV 和 TiFlash 的 labels，可以标识它们的地理位置。同时，需要配置 PD 的 location-labels 和 isolation-level 来使 PD 理解 TiKV 节点拓扑并加强拓扑隔离要求。PD 在副本调度时会保证同一份数据的不同副本尽可能分散，以提高集群容灾能力。
+- [通过系统变量 `tidb_external_ts` 读取历史数据](https://docs.pingcap.com/tidb/stable/tidb-external-ts/): 了解如何通过系统变量 `tidb_external_ts` 读取历史数据。
+- [通过系统变量 `tidb_read_staleness` 读取历史数据](https://docs.pingcap.com/tidb/stable/tidb-read-staleness/): 了解如何通过系统变量 `tidb_read_staleness` 读取历史数据。
+- [通过系统变量 tidb_snapshot 读取历史数据](https://docs.pingcap.com/tidb/stable/read-historical-data/): 本文介绍了通过系统变量 `tidb_snapshot` 读取历史数据的操作流程和历史数据的保留策略。TiDB 实现了通过标准 SQL 接口读取历史数据功能，无需特殊的 client 或者 driver。当数据被更新、删除后，依然可以通过 SQL 接口将更新 / 删除前的数据读取出来。历史数据保留策略使用 MVCC 管理版本，超过一定时间的历史数据会被彻底删除，以减小空间占用以及避免历史版本过多引入的性能开销。
+- [逻辑优化](https://docs.pingcap.com/tidb/stable/sql-logical-optimization/): 本章节介绍了 TiDB 查询计划的关键逻辑改写，包括子查询优化、列裁剪、关联子查询去关联、Max/Min 消除、谓词下推、分区裁剪、TopN 和 Limit 下推以及 Join 重排序。这些改写帮助 TiDB 生成最终的查询计划，提高查询效率。
+- [逻辑导入模式简介](https://docs.pingcap.com/tidb/stable/tidb-lightning-logical-import-mode/): 了解 TiDB Lightning 的逻辑导入模式 (Logical Import Mode)。
+- [遥测](https://docs.pingcap.com/tidb/stable/telemetry/): 介绍遥测的场景，如何禁用功能和查看遥测状态。
+- [避免隐式类型转换](https://docs.pingcap.com/tidb/stable/dev-guide-implicit-type-conversion/): 介绍 TiDB 中隐式类型转换可能会带来的后果和避免方法。
+- [部署 TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-ops-deploy/): TiDB Dashboard 是内置于 TiDB 4.0 或更高版本的 PD 组件中的界面，无需额外部署。对于 TiDB v6.5.0 及 TiDB Operator v1.4.0 之后的版本，在 Kubernetes 上支持将 TiDB Dashboard 作为独立的 Pod 部署。部署标准 TiDB 集群的文档可参考快速试用 TiDB 集群、生产环境部署和 Kubernetes 环境部署。当集群中部署了多个 PD 实例时，仅有一个 PD 实例会提供 TiDB Dashboard 服务。可通过 TiUP 查看实际运行 TiDB Dashboard 服务的 PD 实例，并切换其他 PD 实例提供 TiDB Dashboard 服务。也可以禁用和重新启用 TiDB Dashboard。
+- [部署 TiDB Lightning](https://docs.pingcap.com/tidb/stable/deploy-tidb-lightning/): 了解如何部署 TiDB Lightning，包括在线部署和离线部署。
+- [配置 TiDB Dashboard 使用 SSO 登录](https://docs.pingcap.com/tidb/stable/dashboard-session-sso/): 了解如何配置 TiDB Dashboard 启用 SSO 登录。
+- [锁函数](https://docs.pingcap.com/tidb/stable/locking-functions/): 了解 TiDB 中的用户级锁函数。
+- [错误码与故障诊断](https://docs.pingcap.com/tidb/stable/error-codes/): TiDB 错误码包括 MySQL 兼容的错误码和 TiDB 特有的错误码。如果遇到错误码，请参考官方文档或社区获取支持。常见错误码包括内存使用超限、写入冲突、表数据损坏、事务过大、写入冲突等。另外，TiDB 还提供了故障诊断文档供参考。
+- [错误索引的解决方案](https://docs.pingcap.com/tidb/stable/wrong-index-solution/): 了解如何处理错误索引问题。
+- [集合运算](https://docs.pingcap.com/tidb/stable/set-operators/): 了解 TiDB 支持的集合运算。
+- [集群监控部署](https://docs.pingcap.com/tidb/stable/deploy-monitoring-services/): 本文适用于手动部署 TiDB 监控报警系统的用户。假设 TiDB 的拓扑结构如下：Node1 主机 IP 为 192.168.199.113，服务包括 PD1、TiDB、node_export、Prometheus、Grafana；Node2 主机 IP 为 192.168.199.114，服务包括 PD2、node_export；Node3 主机 IP 为 192.168.199.115，服务包括 PD3、node_export；Node4 主机 IP 为 192.168.199.116，服务包括 TiKV1、node_export；Node5 主机 IP 为 192.168.199.117，服务包括 TiKV2、node_export；Node6 主机 IP 为 192.168.199.118，服务包括 TiKV3、node_export。具体部署步骤包括下载二进制包、启动 node_exporter 服务、启动 Prometheus 服务、启动 Grafana 服务、配置 Grafana 数据源和导入 Grafana 面板。可查看 TiDB Server、PD Server 和 TiKV Server 的监控信息。
+- [静态加密](https://docs.pingcap.com/tidb/stable/encryption-at-rest/): 了解如何启用静态加密功能保护敏感数据。
+- [非 Prepare 语句执行计划缓存](https://docs.pingcap.com/tidb/stable/sql-non-prepared-plan-cache/): 介绍 TiDB 中非 Prepare 语句执行计划缓存的原理、使用方法及示例。
+- [非事务 DML 语句](https://docs.pingcap.com/tidb/stable/non-transactional-dml/): 以事务的原子性和隔离性为代价，将 DML 语句拆成多个语句依次执行，用以提升批量数据处理场景的稳定性和易用性。
+- [预处理语句](https://docs.pingcap.com/tidb/stable/dev-guide-prepared-statement/): 介绍 TiDB 的预处理语句功能。
+- [验证 JSON 文档的函数](https://docs.pingcap.com/tidb/stable/json-functions-validate/): 了解验证 JSON 文档的函数。
+- [验证集群运行状态](https://docs.pingcap.com/tidb/stable/post-installation-check/): 介绍如何验证集群运行状态。
+- [高可用常见问题](https://docs.pingcap.com/tidb/stable/high-availability-faq/): 介绍高可用相关的常见问题。
+- [高可靠常见问题](https://docs.pingcap.com/tidb/stable/high-reliability-faq/): 介绍高可靠相关的常见问题。
+
+## TiDB on Kubernetes 文档（使用 TiDB Operator 部署）
+
+- [TiDB on Kubernetes 文档](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/): 使用 PingCAP 提供的 TiDB Operator，你可以在公有云或自托管的 Kubernetes 集群上自动运维 TiDB 集群，实现 TiDB 在 Kubernetes 上的无缝运行。
+- [API 文档](https://github.com/pingcap/tidb-operator/blob/v1.6.1/docs/api-references/docs.md)
+- [Kubernetes 上的 TiDB Binlog Drainer 配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-tidb-binlog-drainer/): 了解 Kubernetes 上的 TiDB Binlog Drainer 配置参数。
+- [Kubernetes 上的 TiDB 工具指南](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-toolkit/): 详细介绍 Kubernetes 上的 TiDB 相关的工具及其使用方法。
+- [Kubernetes 上的 TiDB 常见部署错误](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-failures/): 介绍 Kubernetes 上 TiDB 部署的常见错误以及处理办法。
+- [Kubernetes 上的 TiDB 集群常见异常](https://docs.pingcap.com/tidb-in-kubernetes/stable/exceptions/): 介绍 TiDB 集群运行过程中常见异常以及处理办法。
+- [Kubernetes 上的 TiDB 集群常见网络问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/network-issues/): 介绍 Kubernetes 上 TiDB 集群的常见网络问题以及诊断解决方案。
+- [Kubernetes 上的 TiDB 集群常见问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/faq/): 介绍 Kubernetes 上的 TiDB 集群常见问题以及解决方案。
+- [Kubernetes 上的 TiDB 集群故障自动转移](https://docs.pingcap.com/tidb-in-kubernetes/stable/use-auto-failover/): 介绍 Kubernetes 上的 TiDB 集群故障自动转移的功能。
+- [Kubernetes 上的 TiDB 集群环境需求](https://docs.pingcap.com/tidb-in-kubernetes/stable/prerequisites/): 介绍在 Kubernetes 上部署 TiDB 集群的软硬件环境需求。
+- [Kubernetes 上的 TiDB 集群管理常用使用技巧](https://docs.pingcap.com/tidb-in-kubernetes/stable/tips/): 介绍 Kubernetes 上 TiDB 集群管理常用使用技巧。
+- [Kubernetes 上的持久化存储类型配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-storage-class/): 介绍 Kubernetes 上的数据持久化存储类型配置。
+- [Kubernetes 上的集群初始化配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/initialize-a-cluster/): 介绍如何初始化配置 Kubernetes 上的 TiDB 集群。
+- [Kubernetes 的监控与告警](https://docs.pingcap.com/tidb-in-kubernetes/stable/monitor-kubernetes/): 介绍如何监控 Kubernetes。
+- [PingCAP Clinic 数据采集说明](https://docs.pingcap.com/tidb-in-kubernetes/stable/clinic-data-collection/): 详细说明 PingCAP Clinic 诊断服务在使用 Operator 部署的 TiDB 集群中能够采集的诊断数据类型、输出文件及采集参数。
+- [TiDB on Kubernetes Sysbench 性能测试](https://docs.pingcap.com/tidb-in-kubernetes/stable/benchmark-sysbench/): TiDB Operator GA 发布后，我们在 GKE 平台进行了全面的性能测试。测试结果显示，在 Host 网络模式下，TiDB 性能略优于 Pod 网络模式（约 7%）。此外，使用 Ubuntu 系统的 Host 网络模式下，TiDB 性能也略优于 COS 系统（约 9%）。在集群外访问时，使用 Load Balancer 会略损失性能（约 5%）。多可用区下节点之间的延迟增加，会对 TiDB 性能产生一定影响（30% ~ 6%）。计算型机型相对普通型机器带来了很大 QPS 提升（50% ~ 60%）。
+- [TiDB Operator 0.1.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.1.0/): TiDB Operator 0.1.0 was released on August 22, 2018. Notable changes include the ability to bootstrap multiple TiDB clusters, support for monitoring deployment and Helm charts, basic Network PV/Local PV support, safe scaling of the TiDB cluster, orderly cluster upgrades, and stopping the TiDB process without terminating the Pod. Additionally, cluster meta info can be synchronized to POD/PV/PVC labels, and basic unit tests & E2E tests are available. Tutorials for GKE and local DinD are also provided.
+- [TiDB Operator 0.2.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.2.0/): TiDB Operator 0.2.0 was released on September 11, 2018. Notable changes include experimental support for auto-failover, unification of Tiller and TiDB Operator managed resources labels, managing TiDB service via Tiller, adding toleration for TiDB cluster components, and refactoring upgrade functions as interface. Additionally, a script for easy setup of DinD environment was added, and code was linted and formatted in CI.
+- [TiDB Operator 0.2.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.2.1/): TiDB Operator 0.2.1 was released on September 20, 2018. This version includes bug fixes for retry on conflict logic, TiDB timezone configuration, failover, and repeated updating of pod and pd/tidb StatefulSet.
+- [TiDB Operator 0.3.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.3.0/): TiDB Operator 0.3.0 was released on October 12, 2018. Notable changes include the addition of full backup support, TiDB Binlog support, graceful upgrade feature, and the ability to persist monitor data.
+- [TiDB Operator 0.3.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.3.1/): TiDB Operator 0.3.1 was released on October 31, 2018. The release includes minor changes such as parameterizing the serviceAccount, bumping TiDB to v2.0.7, and allowing user-specified config files. Bug fixes include addressing issues with parallel upgrades, wrong parameters, and recovery after a failed upgrade.
+- [TiDB Operator 0.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-0.4.0/): TiDB Operator 0.4.0 was released on November 9, 2018. Notable changes include extending Kubernetes scheduler for TiDB data awareness, restoring backup data from GCS bucket, and setting password for TiDB when first deployed. Minor changes and bug fixes include updating roadmap, adding unit tests, E2E tests, adding TiDB failover limit, synchronizing PV reclaim policy early, using helm release name as instance label, and fixing local PV setup script.
+- [TiDB Operator 1.0 Beta.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.0/): TiDB Operator 1.0 Beta.0 was released on November 26, 2018. Notable changes include the introduction of basic chaos testing, improved unit test coverage, default log-level values for PD/TiKV/TiDB, and various bug fixes and enhancements. The release also includes a user guide and migration to Go 1.11 module.
+- [TiDB Operator 1.0 Beta.1 P1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p1/): TiDB Operator 1.0 Beta.1 P1 was released on January 7, 2019. The bug fixes include resolving scheduler policy issues for Kubernetes v1.10, v1.11, and v1.12. The documentation updates include a proposal to add multiple statefulsets support to TiDB Operator and an updated roadmap.
+- [TiDB Operator 1.0 Beta.1 P2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1-p2/): TiDB Operator 1.0 Beta.1 P2 was released on February 21, 2019. Notable changes include a new algorithm for scheduler HA predicate, addition of TiDB discovery service, serial scheduling, change in tolerations type to an array, direct start when there is a join file, addition of code coverage icon, omission of just the empty leaves in `values.yml`, backup to ceph object storage in charts, and addition of `ClusterIDLabelKey` label to TidbCluster.
+- [TiDB Operator 1.0 Beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.1/): TiDB Operator 1.0 Beta.1 was released on December 27, 2018. The release includes bug fixes such as pd_control bug, orphan pod cleaner, scheduler configuration fix, Grafana configuration fix, and more. Minor improvements include adding Kubernetes 1.12 local DinD scripts, bumping default TiDB to v2.1.0, releasing tidb-operator/tidb-cluster charts, and adding connection timeout for TiDB password setter job. Other improvements involve separating ad-hoc backup and restore to another chart, adding compiler version info to tidb-operator binary, allowing specifying TiDB service LoadBalancer IP, and exposing TiKV cpu/memory related configuration to values.yaml.
+- [TiDB Operator 1.0 Beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.2/): TiDB Operator 1.0 Beta.2 has been released on May 10, 2019. The new version includes enhanced stability, improved ease of use, bug fixes, and other improvements. Some of the key changes include refactored e2e test, one-command deployment for AWS and Aliyun, and support for slow log of TiDB. Numerous bug fixes and detailed changes have also been made to improve the overall performance and user experience.
+- [TiDB Operator 1.0 Beta.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-beta.3/): TiDB Operator 1.0 Beta.3 was released on June 6, 2019. The new version includes the removal of `nodeSelectorRequired` from values.yaml and the addition of stability cases, new features, documentation improvements, and bug fixes. Some notable new features include ConfigMap rollout management, stable scheduling for pods, and support for adding additional pod annotations. The default TiDB version has been upgraded to v3.0.0-rc.1, and various bug fixes and changes have been implemented.
+- [TiDB Operator 1.0 GA Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0-ga/): TiDB Operator 1.0.0 has been released on July 30, 2019. The new version requires action to be taken for configuration changes in `values.yaml`. Stability test cases have been added, along with improvements such as GKE SSD setup simplification and AWS Terraform script modularization. Bug fixes include sysbench installation and TiKV metrics monitoring. Detailed bug fixes and changes include upgrading TiDB monitor, specifying TiKV status address, and enabling nlb cross zone load balancing by default. Multiple TiDB clusters management is now supported in Alibaba Cloud. The default TiDB version has been upgraded to v3.0.1. The release also includes various other bug fixes and improvements.
+- [TiDB Operator 1.0 RC.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.0-rc.1/): TiDB Operator 1.0 RC.1 was released on July 12, 2019. The new version includes stability test cases, improvements such as increasing TiKV GC life time, and bug fixes like fixing unbound variables in the backup script and scheduled backup bugs. It also supports force upgrade when PD cluster is unavailable and adds Amazon S3 support for backup/restore features. Multiple clusters management in EKS and local SSD provision for COS on GKE are also included. The release notes contain detailed bug fixes and changes, including various pull requests for bug fixes and improvements.
+- [TiDB Operator 1.0.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.1/): TiDB Operator version 1.0.1 was released on September 17, 2019. The release includes important bug fixes and improvements. Users of version 1.0.0 or prior must upgrade to avoid potential service outage. The backup tool image has been updated to fix a serious bug. Other improvements include modularizing GCP Terraform, adding support for various configurations, and reducing e2e run time. Bug fixes address issues such as TiKV scale-in failure, orphan pods cleaner bugs, and incorrect condition judgment. The release also includes detailed bug fixes and changes.
+- [TiDB Operator 1.0.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.2/): TiDB Operator version 1.0.2 was released on November 1, 2019. The new version includes improvements such as suspending the ReplaceUnhealthy process for AWS TiKV auto-scaling-group, adding a new VM manager 'qm' in stability test, and setting default externalTrafficPolicy to 'Local' for TiDB service in AWS/GCP/Aliyun. Bug fixes include issues with tkctl version, create_tidb_cluster_release variable in AWS Terraform script, and compatibility issues with Kubernetes 1.16 and above versions. Other fixes and changes are also included in this release.
+- [TiDB Operator 1.0.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.3/): TiDB Operator version 1.0.3 was released on November 13, 2019. The new version requires an upgrade to TiDB v3.0.5 and adds timezone support for all charts. Existing TiDB clusters with customized timezones will trigger a rolling update. Improvements include timezone support and configuring resource requests and limits for all containers of the TiDB cluster. Bug fixes include upgrading default TiDB version to v3.0.5 and adding timezone support for all containers of the TiDB cluster.
+- [TiDB Operator 1.0.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.4/): TiDB Operator version 1.0.4 was released on November 23, 2019. The new version introduces HostNetwork support for better performance, podSecurityContext support, and new Helm charts for TiDB Lightning and TiDB Binlog. It also includes bug fixes and changes. Users of the v1.1.0.alpha branch are advised to upgrade to v1.0.4, as it includes all fixes from the alpha branch and introduces additional improvements.
+- [TiDB Operator 1.0.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.5/): TiDB Operator version 1.0.5 was released on December 11, 2019. The new features include fixing backup failure issue, recommending deployment of TiDB and Pump on the same node, fixing RBAC permission, and resolving e2e nil point dereference. No action is required for upgrading from v1.0.4.
+- [TiDB Operator 1.0.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.6/): TiDB Operator 1.0.6 was released on December 27, 2019. Users need to migrate configs from the old `values.yaml` to the new one to avoid monitor pod failures. The new release includes improvements in monitor, TiDB Scheduler, compatibility, TiKV Importer, E2E, and CI. Notable changes include enabling alert rule persistence, adding node & pod info in TiDB Grafana, refining scheduler error messages, fixing compatibility issues in Kubernetes v1.17, and adjusting the release CI script.
+- [TiDB Operator 1.0.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.0.7/): TiDB Operator 1.0.7 was released on June 16, 2020. Notable changes include fixing alert rules lost after rolling upgrade, upgrading local volume provisioner to 2.3.4, fixing operator failover config invalid, removing unnecessary duplicated docs, updating doc links and image in readme, emitting events when PD failover, fixing some broken urls, and removing some not very useful update events.
+- [TiDB Operator 1.1 Beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-beta.1/): 支持配置时区，备份到 S3，基础默认设置，增强型 StatefulSet 扩缩容，自定义资源初始化 TiDB 集群，优化配置结构，支持临时存储，发布 Terraform Aliyun ACK 版本，优化报错信息，支持 TLS 加密连接，支持动态扩展云存储 PV，支持自动生成证书，支持暂停备份计划，升级 TiDB 版本。
+- [TiDB Operator 1.1 Beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-beta.2/): 默认存储类和备份存储类已废弃，现在使用 Kubernetes 默认存储类。用户可设置备份和恢复的亲和性和容忍度。解决了 AdvancedStatefulSet 和 Admission Webhook 一起使用的问题。支持基于 CPU 平均负载的集群自动扩容。支持用户自定义证书。修复了一些问题并优化了日志。
+- [TiDB Operator 1.1 GA Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1-ga/): TiDB Operator 1.1 GA 发布日期 2020 年 5 月 28 日。将 TiDB Pod 的 readiness 探针从 HTTPGet 更改为 TCPSocket 4000 端口。这将触发 tidb-server 组件滚动升级。你可以在升级 TiDB Operator 之前将 spec.paused 设置为 true 以避免滚动升级，并在准备升级 tidb-server 时将其重新设置为 false。
+- [TiDB Operator 1.1 RC.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.1/): 此版本包括对 tidb-server 的配置选项的更新，备份和恢复规范的修改，以及对 TiDB 组件的一些修复和改进。还支持通过 Terraform 在 AWS 和 ACK 上部署 TiDB 集群，并添加了一些新的功能和文档。
+- [TiDB Operator 1.1 RC.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.2/): TiDB Operator 1.1 RC.2 was released on April 15, 2020. Action required includes changing TiDB pod readiness probe and setting spec.paused to true before upgrading. Notable changes include adding status field for TidbAutoScaler CR, emitting more events for TidbCluster and TidbClusterAutoScaler, and adding TLS support for TiKV metrics API. Other changes involve adding a switch to skip PD Dashboard TLS configuration, supporting TiFlash in TidbCluster CR, and fixing errors related to alertmanager in TidbMonitor.
+- [TiDB Operator 1.1 RC.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.3/): TiDB Operator 1.1 RC.3 was released on April 30, 2020. Notable changes include support for TiFlash metrics in TidbMonitor, fixing bugs related to failover pods and statefulsets, and adding new features like configuring Ingress in TidbMonitor and supporting failover for TiFlash. Other changes include updates to terraform scripts and adding new fields in TiKVConfig.
+- [TiDB Operator 1.1 RC.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.0-rc.4/): TiDB Operator 1.1 RC.4 发布于 2020 年 5 月 15 日。每个组件可以使用单独的 TiDB 客户端证书。用户应该将 `Backup` 和 `Restore` CR 中的旧的 TLS 配置迁移到新的配置。
+- [TiDB Operator 1.1.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.1/): TiDB Operator 1.1.1 版本发布，重大变化包括添加 `additionalContainers` 和 `additionalVolumes` 字段，修复了多个问题，并更新了配置版本到 v4.0.1。
+- [TiDB Operator 1.1.10 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.10/): TiDB Operator 1.1.10 版本发布，包含兼容性改动、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性改动包括 `apiVersion` 更改，滚动升级改动导致 TidbMonitor Pod 删除重建。新功能包括灰度升级、TidbMonitor 支持 `remotewrite`、配置 init containers 等。优化提升包括自定义存储、增加 label 支持多集群监控等。Bug 修复包括备份或者恢复失败、Pod 在升级过程中不会进行迁移 leader 等问题。
+- [TiDB Operator 1.1.11 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.11/): TiDB Operator 1.1.11 版本发布，新增优化 LeaderElection 和自定义 Store 标签功能。优化 TiFlash 滚动更新机制，改进获取 region leader 数量方式。支持打印 RocksDB 和 Raft 日志到 stdout。
+- [TiDB Operator 1.1.12 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.12/): TiDB Operator 1.1.12 版本发布日期为 2021 年 4 月 15 日。新功能包括支持为备份和恢复 Job 设置自定义环境变量，支持备份恢复 CR 设置 affinity 和 tolerations，以及支持 tidb-operator chart 使用新的 service account。优化提升包括 TiDBInitializer 中增加重试机制，增加多 PVC 支持，以及优化 `PodsAreChanged` 函数。Bug 修复包括修复挂载多 PVC 时容量设置错误的问题，修复创建 `.spec.tidb` 为空并开启 TLS 的 TidbCluster 导致 tidb-controller-manager panic 的问题，以及修复 `UnjoinedMembers` 中 PVC 状态异常的问题。
+- [TiDB Operator 1.1.13 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.13/): TiDB Operator 1.1.13 版本发布，优化了 TiCDC 配置 TLS 证书、BR 工具镜像 tag、扩缩容 TiDB 过程中协调 PVC、备份日志中隐藏数据库密码。修复了部署异构集群时可能 panic 的问题和 TiDB 实例缩容后在 TiDB Dashboard 中仍然存在的问题。
+- [TiDB Operator 1.1.14 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.14/): TiDB Operator 1.1.14 版本发布日期为 2021 年 10 月 21 日。此版本修复了 `tidb-backup-manager` 和 `tidb-operator` 镜像中的安全漏洞。
+- [TiDB Operator 1.1.15 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.15/): TiDB Operator 1.1.15 发布日期为 2022 年 2 月 17 日。此版本修复了 TiDB Operator 计算 TiKV Region leader 数量时可能会造成 goroutine 泄露的问题。
+- [TiDB Operator 1.1.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.2/): TiDB Operator 1.1.2 版本修复了与 PD 4.0.2 不兼容的问题。需要将 TiDB Operator 升级到 v1.1.2 后再部署 TiDB 4.0.2 及更高版本。其他变更包括抓取监控指标和更新配置为 v4.0.2，修复缩容后 PD 成员可能仍然存在的错误，同步信息到 `TidbCluster` `Status` 字段，以及支持在 TiDB 参数中配置容器生命周期 hook 和 `terminationGracePeriodSeconds`。
+- [TiDB Operator 1.1.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.3/): TiDB Operator 1.1.3 版本发布，需要采取的行动包括在 `BackupSpec` 中添加 `cleanPolicy` 字段，将 `mydumper` 替换为 `dumpling` 进行备份。其他变更包括更新 backup manager 工具、为 TiCDC 添加 TLS 支持、在 Drainer 和下游数据库服务器之间添加 TLS 支持等。
+- [TiDB Operator 1.1.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.4/): TiDB Operator 1.1.4 版本发布，重大变化包括添加 TableFilter 到 BackupSpec 和 RestoreSpec，更新 TiDB 和配套工具版本为 v4.0.4，支持自定义环境变量，增加存储请求，为备份恢复添加 TLS 支持，支持 TiFlash 中的 cert-allowed-cn 配置项，修复了启用 TLS 时的内存泄漏问题，为 TiFlash 添加 TLS 支持，配置 TZ 环境。
+- [TiDB Operator 1.1.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.5/): TiDB Operator 1.1.5 版本发布日期为 2020 年 9 月 18 日。此版本兼容性变化需要注意 TiFlash 版本低于 `v4.0.5` 的设置。新功能包括支持为 TiDB/Pump/PD 配置 `serviceAccount`，以及配置 `spec.tikv.config.log-format` 和 `spec.tikv.config.server.max-grpc-send-msg-len`。优化提升方面支持 TiDB/PD/TiKV 的 v4.0.6 配置，挂载集群客户端证书到 PD Pod，以及对于 TiFlash/PD/TiDB 的伸缩实例优先于升级。同时修复了 TidbMonitor CR 中的 Grafana container 忽略 `Env` 配置的问题。
+- [TiDB Operator 1.1.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.6/): TiDB Operator 1.1.6 版本发布日期为 2020 年 10 月 16 日。此版本包含兼容性变化、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性变化包括 `spec.pd.config` 参数的自动转换和需要手动编辑 TidbCluster CR 的配置。滚动升级改动包括 TiDB 或 TiKV 集群的滚动升级以及 TiFlash 集群的滚动升级。新功能包括支持 Backup 和 Restore CR 自定义 BR 命令行参数、配置 TiKV evict leader 超时时间等。优化提升包括透传 TiFlash/TiKV/PD/Pump 的 TOML 格式配置、定时备份到 GCS 时目录名称添加备份时间等。Bug 修复包括修复 Discovery 可能导致启动多个 PD 集群的错误。
+- [TiDB Operator 1.1.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.7/): TiDB Operator 1.1.7 版本发布日期为 2020 年 11 月 13 日。此版本中兼容性变化包括配置项 `prometheus.spec.config.commandOptions` 的行为变化。新增功能包括对 `Backup` 和 `Restore` CR 的配置项 `spec.toolImage` 的新增，以及对 `spec.pd.storageVolumes`、`spec.tidb.storageVolumes` 和 `spec.tikv.storageVolumes` 的支持。优化提升方面包括禁止缩容 TiKV 实例和新增 `BackupStatus` 和 `RestoreStatus` 中的 `phase` 状态。此外还修复了当前 `TidbCluster` 之外存在 PD member 时无法把 PD scale 到 0 的 bug。
+- [TiDB Operator 1.1.8 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.8/): TiDB Operator 1.1.8 版本新增了对备份和恢复任务的支持，用户可以利用该功能实现基于 NFS 或者任意 Kubernetes 支持的 Volume 类型的任务。此外，还优化了 TiDB 组件和客户端开启 TLS 的功能，支持为 TiDB service 指定额外的端口，以及在连接 TiDB server 时不使用 TLS。修复了一系列 Bug，包括部署 TiDB 集群问题、编码错误问题、Pods 误认为问题等。
+- [TiDB Operator 1.1.9 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.1.9/): TiDB Operator 1.1.9 版本发布日期为 2020 年 12 月 28 日。此版本优化了支持使用 `spec.toolImage` 来为 `Backup` 和 `Restore` 指定 Dumpling/TiDB Lightning 的二进制可执行文件。同时修复了 Prometheus 不能拉取 TiKV Importer 的 metrics 以及用 BR 和 GCS 进行备份与恢复时的兼容性问题。
+- [TiDB Operator 1.2.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0/): TiDB Operator 1.2.0 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级改动包括升级 TiDB Operator 会导致 TidbMonitor Pod 删除重建。新功能包括支持为 `TiDBMonitor` 的 `Prometheus` 设置更细粒度的 `retentionTime` 和通过 `priorityClassName` 设置备份 Job 优先级。优化提升包括调整升级过程中驱逐 TiKV 的 Region Leader 超时的默认值。Bug 修复包括修复解析 `TiDBMonitor` 定义中 `Prometheus.RemoteWrite` 的 URL 可能失败的问题。
+- [TiDB Operator 1.2.0-alpha.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-alpha.1/): TiDB Operator 1.2.0-alpha.1 版本发布。滚动升级改动包括 TidbMonitor Pod 重建。新增功能包括跨多个 Kubernetes 集群部署 TiDB 集群、管理 DM 2.0、PD API 弹性伸缩、灰度升级 TiDB Operator。优化提升包括 TiDB Lightning chart 支持 local backend、TLS、持久化 checkpoint，TidbMonitor 支持配置 Thanos sidecar，管理资源从 Deployment 变为 StatefulSet。其他改进包括优化队列 rate limiter 间隔，修改 TidbMonitor 自定义告警规则存储目录。
+- [TiDB Operator 1.2.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-beta.1/): TiDB Operator 1.2.0-beta.1 发布日期为 2021 年 4 月 7 日。此版本包含兼容性改动和滚动升级改动。新增功能包括为备份和恢复 Job 设置自定义环境变量，支持配置额外的 volume 和 volumeMount，以及支持设置自定义 Store 标签。优化提升方面包括增加重试机制解决 DNS 查询异常处理问题，优化 Thanos 的 example yaml，以及在 PD 的扩缩容和容灾过程中增加多 PVC 支持。Bug 修复方面包括修复挂载多 PVC 时容量设置错误的问题，修复 TidbMonitor 外部标签包含无法识别的环境变量的问题，以及修复备份或恢复 Pod 状态没有正常更新为 Failed 的问题。
+- [TiDB Operator 1.2.0-beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-beta.2/): TiDB Operator 1.2.0-beta.2 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。新功能包括 TidbMonitor 支持监控多个启用了 TLS 的 TidbCluster，以及为所有 TiDB 组件设置安全上下文和拓扑约束。优化提升包括为 TidbMonitor Pod 增加 readiness 探测器和支持不生成 Prometheus 的告警规则。 Bug 修复包括修复 TiDB 实例缩容后仍在 TiDB Dashboard 中展示的问题和解决 TidbCluster CR 同步问题。
+- [TiDB Operator 1.2.0-rc.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-rc.1/): TiDB Operator 1.2.0-rc.1 发布，滚动升级改动会导致 Pump Pod 删除重建。新增支持为 TidbCluster 中的 Pod 与 service 设置自定义的 label，以及对 Pump 的完整生命周期管理。优化提升包括隐藏数据库密码的展示、支持为 Grafana 配置额外的 volumeMount、为 TidbMonitor 增加额外的信息展示列，以及 TidbMonitor 支持将配置信息直接写入到 PD 的 etcd 中。Bug 修复包括对启用了 TLS 的 DmCluster 进行监控的问题、PD 在扩容过程中 member 数量统计不正确的问题、DM-master 可能无法成功重启的问题、`configUpdateStrategy` 从 `InPlace` 修改为 `RollingUpdate` 后可能造成的 TidbCluster 组件滚动更新的问题，以及使用 Dumpling 备份数据时可能失败的问题。
+- [TiDB Operator 1.2.0-rc.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.0-rc.2/): TiDB Operator 1.2.0-rc.2 发布，新增支持透传 TiCDC 的 TOML 格式配置、为 TiCDC 设置存储卷和挂载、自定义 Discovery、TidbMonitor 和 TidbInitializer 的标签和注释、修改 Grafana 仪表盘。优化支持未指定 BR toolImage tag 时将 TiKV 版本作为 tag、扩缩容 TiDB 过程中协调 PVC、增加 liveness 与 readiness 探测器。修复部署异构集群时可能 panic 的问题、TidbCluster spec 未更改时 TiDB service 与 TidbCluster 状态持续更新的问题。
+- [TiDB Operator 1.2.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.1/): TiDB Operator 1.2.1 版本发布日期为 2021 年 8 月 18 日。滚动升级改动，如果部署 TiCDC 时配置了 hostNetwork 为 true，升级 TiDB Operator 后会导致 TiCDC Pod 删除重建。优化提升包括支持为 TidbCluster 的所有组件配置 hostNetwork，使所有组件都可以使用宿主机网络。
+- [TiDB Operator 1.2.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.2/): TiDB Operator 1.2.2 版本发布日期为 2021 年 9 月 3 日。滚动升级改动包括升级 TiDB Operator 会导致 TiDBMonitor Pod 和 TiFlash Pod 删除重建。新功能包括 TiDBMonitor 支持动态重新加载配置。Bug 修复包括修复 TiCDC 无法从低版本升级到 v5.2.0 的问题。
+- [TiDB Operator 1.2.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.3/): TiDB Operator 1.2.3 版本发布日期为 2021 年 9 月 7 日。此版本修复了升级到 TiDB Operator v1.2.2 时导致 TiFlash Pod 滚动重启的问题。
+- [TiDB Operator 1.2.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.4/): TiDB Operator 1.2.4 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级会导致 TidbMonitor Pod 删除重建。新增 TidbMonitor 支持用户自定义 Prometheus 告警规则和动态重新加载告警规则，以及支持批量删除备份数据。优化了 TiFlash 滚动升级流程，修复了镜像中的安全漏洞和备份数据残留的问题。
+- [TiDB Operator 1.2.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.5/): TiDB Operator 1.2.5 版本发布，优化了 DM 配置、TiFlash init container 资源配置和 TiDB TLS 客户端认证参数配置。修复了组件启动脚本更新后的滚动更新问题、启用 TLS 后 TidbCluster spec 自动更新问题、TiKV Region leader 数量计算可能导致 goroutine 泄露的问题和一些高级别的安全问题。
+- [TiDB Operator 1.2.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.6/): TiDB Operator 1.2.6 发布日期 2022 年 1 月 4 日。优化更新 Restore 和 Backup 状态时的重试逻辑。
+- [TiDB Operator 1.2.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.2.7/): TiDB Operator 1.2.7 发布，新增 `spec.pd.startUpScriptVersion` 字段，支持在 PD 启动脚本中使用 `dig` 命令解析域名。优化部署或更新组件的 StatefulSet，预先检查配置的 VolumeMount 是否存在，防止集群进行失败的滚动更新。
+- [TiDB Operator 1.3.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.0/): TiDB Operator 1.3.0 版本发布，包括兼容性改动、新功能、优化提升和 Bug 修复。兼容性改动包括跨集群部署 TiDB 集群升级操作，TiFlash 升级操作需注意。新增功能包括支持内部组件访问 TiDB 时跳过服务端证书验证、设置所有组件 Pod 的 DNS 配置等。优化提升包括部署或更新组件的 StatefulSet 预先检查配置的 VolumeMount 是否存在，跨集群部署 TiDB 集群功能增强。Bug 修复包括修复 Kubernetes v1.23 及之后版本无法部署 tidb scheduler 的问题。
+- [TiDB Operator 1.3.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.0-beta.1/): TiDB Operator 1.3.0-beta.1 发布日期为 2022 年 1 月 12 日。此版本的兼容性改动包括删除 Pod `ValidatingWebhook` 和 `MutatingWebhook`，升级后不会影响 TiDB 集群管理。升级到 1.3.0-beta.1 版本后，需要按照操作来升级 TiDB Operator。此版本还支持新功能和优化提升，包括支持 TiFlash 的 init container 配置资源使用量，支持持续性能分析，以及优化 TidbMonitor 部署示例等。
+- [TiDB Operator 1.3.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.1/): TiDB Operator 1.3.1 版本发布日期为 2022 年 2 月 24 日。此版本修复了 TiFlash 丢失元数据的问题，并添加了新的 `spec.dnsPolicy` 字段以支持配置 Pod 的 DNSPolicy。另外，`tidb-lightning` Helm chart 默认后端改为使用 `local`。还修复了 TiFlash 配置中缺少 `tmp_path` 字段时无法使用 TiFlash v5.4.0 及以后版本的问题，以及 Discovery 服务错误导致 TiDB 集群 PD 组件启动失败的问题。
+- [TiDB Operator 1.3.10 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.10/): TiDB Operator 1.3.10 发布，优化提升包括升级 Golang 版本到 1.19 以修复安全漏洞。
+- [TiDB Operator 1.3.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.2/): TiDB Operator 1.3.2 版本发布，优化支持在启用 Istio 的 Kubernetes 集群上部署与运行 TiDB，支持多架构 Docker 镜像包括 ARM 系统。
+- [TiDB Operator 1.3.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.3/): TiDB Operator 1.3.3 发布，新增了 `spec.tidb.service.port` 字段，修复了集群升级过程中可能泄漏的问题，更新了 `tidb-backup-manager` 镜像的基础镜像，修复了不兼容 ARM 架构的问题，修复了当 tidb Service 没有 Endpoint 时可能会 panic 的问题，修复了 Kubernetes 集群访问失败并重试后组件 Pod 的 Labels 和 Annotations 可能丢失的问题。
+- [TiDB Operator 1.3.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.4/): TiDB Operator 1.3.4 发布，优化提升包括在各个组件的状态信息中添加了 `volumes` 字段，以展示存储卷状态。
+- [TiDB Operator 1.3.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.5/): TiDB Operator 1.3.5 发布，新增功能支持使用 Azure Blob Storage 备份与恢复 TiDB 集群数据。
+- [TiDB Operator 1.3.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.6/): TiDB Operator 1.3.6 版本发布日期为 2022 年 7 月 5 日。此版本优化了扩容 PVC 对集群性能的影响，现在扩容 PVC 时按照 Pod 一个个扩容，并且在扩容 TiKV 的 PVC 前会先驱逐该 TiKV 上的 leader。
+- [TiDB Operator 1.3.7 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.7/): TiDB Operator 1.3.7 版本发布，新增了暂停组件功能，优化了扩容完成后重建 StatefulSet 的流程，修复了本地存储升级 TiKV 和清理备份文件后残留的问题。
+- [TiDB Operator 1.3.8 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.8/): TiDB Operator 1.3.8 版本发布，新增了为 `TidbCluster` 添加特殊 Annotation 的功能，支持配置 TiDB、TiKV 和 TiFlash 的 Pod 的最小等待时间。此外，还优化了支持优雅升级版本大于或等于 6.3.0 的 TiCDC pod。
+- [TiDB Operator 1.3.9 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.3.9/): TiDB Operator 1.3.9 发布，修复了在已设置 `acrossK8s` 字段但未设置 `clusterDomain` 的情况下，PD 升级流程会卡住的问题。
+- [TiDB Operator 1.4. Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.7/): TiDB Operator 1.4.7 发布，修复了 BackupSchedule CR 字段中的 `logBackupTemplate` 字段变成可选值的问题。
+- [TiDB Operator 1.4.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0/): TiDB Operator 1.4.0 版本发布，新增支持独立管理 TiDB Dashboard，配置 TiKV 和 PD 的 Readiness Probe，以及基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复。优化支持 IPv6 网络环境，修复了基于 EBS 快照备份无法恢复到不同 namespace 的问题和日志备份停止占用 Complete 状态的 bug。
+- [TiDB Operator 1.4.0-alpha.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-alpha.1/): TiDB Operator 1.4.0-alpha.1 发布，包含兼容性改动、滚动升级改动、新功能、优化提升和错误修复。新增自动设置 TiDB 的 location labels、新字段 `spec.tikv.scalePolicy` 与 `spec.tiflash.scalePolicy`、`startScriptVersion` 字段、BR 恢复集群到备份时间点、feature gate `VolumeModifying`、修改存储参数、配置 BR 的 `--check-requirements` 参数、使用字段 `additionalContainers` 自定义 Pod 容器配置。优化了 `TidbMonitor` 使用的 Prometheus 的 remoteWrite 配置和 TiFlash `Service` 添加 metric 端口。修复了集群扩缩容时的问题和 PD spec 为空导致 TiDB Operator 崩溃的问题。
+- [TiDB Operator 1.4.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.1/): TiDB Operator 1.4.0-beta.1 发布，新增支持基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复（实验特性），修复了日志备份的 checkpoint ts 无法更新的问题。
+- [TiDB Operator 1.4.0-beta.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.2/): TiDB Operator 1.4.0-beta.2 发布日期为 2022 年 11 月 11 日。此版本修复了使用 Azure Blob Storage 时未设置前缀的问题，并升级了 AWS SDK 到 v1.44.72 以支持使用 AWS 的 Asia Pacific (Jakarta) 区域 (`ap-southeast-3`)。
+- [TiDB Operator 1.4.0-beta.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.0-beta.3/): TiDB Operator 1.4.0-beta.3 发布，新增 TiProxy 实验性支持和基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复 GA。修复了拼写错误和清理卷快照备份失败的问题，以及大规模 TiKV 节点下备份 TiDB 集群失败的问题。
+- [TiDB Operator 1.4.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.1/): TiDB Operator 1.4.1 版本发布，新增故障自动转移功能，优化了 TiDB Controller Manager 中 Kubernetes 客户端的配置，修复了未配置 PV 权限时 TiDB Controller Manager panic 的问题。
+- [TiDB Operator 1.4.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.2/): TiDB Operator 1.4.2 发布，修复了开启 `preferIPv6` 时 TiFlash 没有监听 IPv6 地址的问题。
+- [TiDB Operator 1.4.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.3/): TiDB Operator 1.4.3 发布，修复了开启 `preferIPv6` 时 TiFlash 的 metric server 未监听正确 IPv6 地址的问题，以及在 AWS 环境中打开了 feature gate `VolumeModifying` 且 `StorageClass` 缺少 EBS 相关参数时 TiDB Operator 会一直尝试修改 EBS 参数的问题。
+- [TiDB Operator 1.4.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.4/): TiDB Operator 1.4.4 发布，新增支持在已部署 TiFlash 的集群上使用卷快照备份和恢复，准确显示备份大小，支持重试快照备份，集成管理日志备份和快照备份。修复了使用非语义版本格式的 TiDB 镜像同步失败的问题，使用卷快照备份一个已缩容的集群后无法恢复数据的问题，卷快照备份可能崩溃的问题，卷快照恢复可能在最后阶段失败的问题。
+- [TiDB Operator 1.4.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.5/): TiDB Operator 1.4.5 版本发布，优化了 TidbCluster 的错误处理相关 metrics 和 worker 队列相关 metrics，增加了 DM master 组件的 `startUpScriptVersion` 字段，以及跨 Kubernetes 集群滚动重启或缩容 TiCDC 集群的能力。同时修复了定时备份中取消 GC、Backup CR 字段可选值、TiDB Operator 未配置权限时的 panic 问题，以及 TidbCluster 中设置 `AdditionalVolumeMounts` 时可能的 panic 问题。
+- [TiDB Operator 1.4.6 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.4.6/): TiDB Operator 1.4.6 发布，优化默认启用 volume resize 支持，修复备份恢复时报错问题，修复 TiCDC image tag 不符合语义化版本时无法 Graceful Drain TiCDC 的问题。
+- [TiDB Operator 1.5.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.0/): 了解 TiDB Operator 1.5.0 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator 1.5.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.0-beta.1/): TiDB Operator 1.5.0-beta.1 发布，新增支持优雅重启 PD 和 TiDB Pod，使用 Advanced StatefulSet 管理 TiCDC 和 TiProxy，新增 TiDB Spec 字段，允许用户定义策略重启失败备份任务，升级 Kubernetes 依赖库至 v1.20 版本，添加与 reconciler 和 worker queue 相关的 Metric，优化滚动升级 TiKV 节点性能，允许用户自定义 Prometheus Scraping 相关配置，TiProxy 支持共享部分 TiDB 证书，配置 `spec.preferIPv6` 为 `true` 时，Service 的 `ipFamilyPolicy` 将配置为 `PreferDualStack`，添加统计协调流程失败计数的 Metric，修复了因为 metric 接口冲突而导致 pprof 接口无法访问的问题。
+- [TiDB Operator 1.5.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.1/): TiDB Operator 1.5.1 发布，新增支持替换 PD、TiKV 和 TiDB 所使用的 volume。修复了多个 Bug，包括手动触发 TiKV eviction 时 PVC Modifier 报错的问题，替换 TiKV volume 过程中再触发 TiKV eviction 时可能造成 TiDB Operator reconcile 死锁的问题，TidbCluster 在 Upgrade 过程中可能无法回滚的问题，以及 MaxReservedTime 选项没有被 backup schedule gc 使用的问题。
+- [TiDB Operator 1.5.2 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.2/): TiDB Operator 1.5.2 版本新增了对 AWS EBS 快照的备份能力的跨多个 K8S 集群的支持。优化了重启 PD、TiKV 时的启动流程，修复了替换 volume 时可能出现的问题。
+- [TiDB Operator 1.5.3 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.3/): 了解 TiDB Operator 1.5.3 版本的新功能和 Bug 修复。
+- [TiDB Operator 1.5.4 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.4/): 了解 TiDB Operator 1.5.4 版本的优化提升和 Bug 修复。
+- [TiDB Operator 1.5.5 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.5.5/): 了解 TiDB Operator 1.5.5 版本的新功能和优化提升。
+- [TiDB Operator 1.6.0 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.0/): 了解 TiDB Operator 1.6.0 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator 1.6.0-beta.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.0-beta.1/): 了解 TiDB Operator 1.6.0-beta.1 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator 1.6.1 Release Notes](https://docs.pingcap.com/tidb-in-kubernetes/stable/release-1.6.1/): 了解 TiDB Operator 1.6.1 版本的新功能、优化提升，以及 Bug 修复。
+- [TiDB Operator RBAC 规则](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-operator-rbac/): 介绍 TiDB Operator 需要的 RBAC 规则。
+- [TiDB Operator v1.6 新特性](https://docs.pingcap.com/tidb-in-kubernetes/stable/whats-new-in-v1.6/): 了解 TiDB Operator 1.6.0 版本引入的新特性。
+- [TiDB Operator 架构](https://docs.pingcap.com/tidb-in-kubernetes/stable/architecture/): 了解 TiDB Operator 架构及其工作原理。
+- [TiDB Operator 简介](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-operator-overview/): 介绍 TiDB Operator 的整体架构及使用方式。
+- [TiDB Scheduler 扩展调度器](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-scheduler/): 了解 TiDB Scheduler 扩展调度器及其工作原理。
+- [TiDB 集群的监控与告警](https://docs.pingcap.com/tidb-in-kubernetes/stable/monitor-a-tidb-cluster/): 介绍如何监控 TiDB 集群。
+- [TidbMonitor 分片功能](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-monitor-shards/): 如何使用 TidbMonitor 分片功能
+- [TidbMonitor 开启动态配置功能](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-monitor-dynamic-configuration/): 动态更新 TidbMonitor 配置
+- [为 DM 开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-dm/): 在 Kubernetes 上如何为 DM 开启 TLS。
+- [为 MySQL 客户端开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-mysql-client/): 在 Kubernetes 上如何为 TiDB 集群的 MySQL 客户端开启 TLS。
+- [为 TiDB 组件间开启 TLS](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-between-components/): 在 Kubernetes 上如何为 TiDB 集群组件间开启 TLS。
+- [为使用云存储的 TiDB 集群更换节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/replace-nodes-for-cloud-disk/): 介绍如何为使用云存储的 TiDB 集群更换节点。
+- [为使用本地存储的 TiDB 集群更换节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/replace-nodes-for-local-disk/): 介绍如何为使用本地存储的 TiDB 集群更换节点。
+- [为已有 TiDB 集群部署 HTAP 存储引擎 TiFlash](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tiflash/): 了解如何在 Kubernetes 上为已有 TiDB 集群部署 TiDB HTAP 存储引擎 TiFlash。
+- [为已有 TiDB 集群部署异构集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-heterogeneous-tidb-cluster/): 本文档介绍如何为已有的 TiDB 集群部署一个异构集群。
+- [为已有 TiDB 集群部署负载均衡 TiProxy](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tiproxy/): 了解如何在 Kubernetes 上为已有 TiDB 集群部署负载均衡 TiProxy。
+- [从 Helm 2 迁移到 Helm 3](https://docs.pingcap.com/tidb-in-kubernetes/stable/migrate-to-helm3/): 介绍如何将由 Helm 2 管理的组件迁移到由 Helm 3 管理。
+- [以非 root 用户运行容器](https://docs.pingcap.com/tidb-in-kubernetes/stable/containers-run-as-non-root-user/): 了解如何以非 root 用户运行容器。
+- [使用 BR 备份 TiDB 集群到 GCS](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs-using-br/): 介绍如何使用 BR 备份 TiDB 集群到 Google Cloud Storage (GCS)。
+- [使用 BR 备份 TiDB 集群数据到 Azure Blob Storage](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-azblob-using-br/): 介绍如何使用 BR 备份 TiDB 集群数据到 Azure Blob Storage 上。
+- [使用 BR 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-aws-s3-using-br/): 介绍如何使用 BR 备份 TiDB 集群数据到兼容 Amazon S3 的存储。
+- [使用 BR 恢复 Azure Blob Storage 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-azblob-using-br/): 介绍如何使用 BR 恢复 Azure Blob Storage 上的备份数据。
+- [使用 BR 恢复 GCS 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-gcs-using-br/): 介绍如何使用 BR 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
+- [使用 BR 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-aws-s3-using-br/): 介绍如何使用 BR 恢复 Amazon S3 兼容存储上的备份数据。
+- [使用 Dumpling 备份 TiDB 集群数据到 GCS](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs/): 介绍如何使用 Dumpling 将 TiDB 集群数据备份到 Google Cloud Storage (GCS)。
+- [使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-s3/): 介绍如何使用 Dumpling 备份 TiDB 集群数据到兼容 S3 的存储。
+- [使用 PD Recover 恢复 PD 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/pd-recover/): 了解如何使用 PD Recover 恢复 PD 集群。
+- [使用 PingCAP Clinic 诊断 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/clinic-user-guide/): 详细介绍在使用 TiDB Operator 部署的集群上如何安装、使用 PingCAP Clinic 诊断服务进行数据采集和快速检查。
+- [使用 TiDB Lightning 恢复 GCS 上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-gcs/): 介绍如何使用 TiDB Lightning 将存储在 GCS 上的备份数据恢复到 TiDB 集群。
+- [使用 TiDB Lightning 恢复 S3 兼容存储上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-s3/): 了解如何使用 TiDB Lightning 将兼容 S3 存储上的备份数据恢复到 TiDB 集群。
+- [使用多套 TiDB Operator 单独管理不同的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-multiple-tidb-operator/): 介绍如何部署多套 TiDB Operator 分别管理不同的 TiDB 集群。
+- [修改 TiDB 集群配置](https://docs.pingcap.com/tidb-in-kubernetes/stable/modify-tidb-configuration/): 了解如何修改部署在 Kubernetes 上的 TiDB 的集群配置。
+- [升级 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/upgrade-a-tidb-cluster/): 介绍如何升级 Kubernetes 上的 TiDB 集群。
+- [升级 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/upgrade-tidb-operator/): 介绍如何升级 TiDB Operator。
+- [同步数据到开启 TLS 的下游服务](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-ticdc-sink/): 了解在 Kubernetes 上如何同步数据到开启 TLS 的下游服务。
+- [在 ARM64 机器上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-cluster-on-arm64/): 本文档介绍如何在 ARM64 机器上部署 TiDB 集群
+- [在 AWS EKS 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-aws-eks/): 介绍如何在 AWS EKS (Elastic Kubernetes Service) 上部署 TiDB 集群。
+- [在 Azure AKS 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-azure-aks/): 介绍如何在 Azure AKS (Azure Kubernetes Service) 上部署 TiDB 集群。
+- [在 Google Cloud GKE 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-gcp-gke/): 了解如何在 Google Cloud GKE 上部署 TiDB 集群。
+- [在 Kubernetes 上使用 DM](https://docs.pingcap.com/tidb-in-kubernetes/stable/use-tidb-dm/): 了解如何在 Kubernetes 上使用 TiDB DM 迁移数据。
+- [在 Kubernetes 上快速上手 TiDB](https://docs.pingcap.com/tidb-in-kubernetes/stable/get-started/): 介绍如何快速地在 Kubernetes 上使用 TiDB Operator 部署 TiDB 集群
+- [在 Kubernetes 上部署 DM](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-dm/): 了解如何在 Kubernetes 上部署 TiDB DM 集群。
+- [在 Kubernetes 上部署 TiCDC](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-ticdc/): 了解如何在 Kubernetes 上部署 TiCDC。
+- [在 Kubernetes 上部署 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-operator/): 了解如何在 Kubernetes 上部署 TiDB Operator。
+- [在标准 Kubernetes 上部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-on-general-kubernetes/): 介绍如何在标准 Kubernetes 集群上通过 TiDB Operator 部署 TiDB 集群。
+- [基于 AWS EBS 卷快照的备份](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-aws-s3-by-snapshot/): 介绍如何基于 EBS 卷快照使用 TiDB Operator 备份 TiDB 集群数据到 S3。
+- [基于 AWS EBS 卷快照的恢复](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-aws-s3-by-snapshot/): 介绍如何将存储在 S3 上的备份元数据以及 EBS 卷快照恢复到 TiDB 集群。
+- [基于 EBS 卷快照备份恢复的性能介绍](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-snapshot-perf/): 了解 EBS 卷快照备份恢复的性能基线。
+- [基于 EBS 卷快照的备份恢复功能架构](https://docs.pingcap.com/tidb-in-kubernetes/stable/volume-snapshot-backup-restore/): 了解 TiDB EBS 卷快照的备份恢复架构设计。
+- [基于 EBS 快照备份恢复的常见问题](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-faq/): 介绍卷快照备份恢复中的常见问题以及解决方案。
+- [增强型 StatefulSet 控制器](https://docs.pingcap.com/tidb-in-kubernetes/stable/advanced-statefulset/): 介绍如何开启、使用增强型 StatefulSet 控制器
+- [备份 TiDB 集群到持久卷](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-pv-using-br/): 介绍如何使用 BR 备份 TiDB 集群数据到持久卷。
+- [备份与恢复 CR 介绍](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-cr/): 介绍用于备份与恢复的 Custom Resource (CR) 资源的各字段。
+- [备份与恢复简介](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-restore-overview/): 介绍如何使用 BR、Dumpling、TiDB Lightning 工具对 Kubernetes 上的 TiDB 集群进行数据备份和数据恢复。
+- [导入集群数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-data-using-tidb-lightning/): 使用 TiDB Lightning 导入集群数据。
+- [将 TiDB 迁移至 Kubernetes](https://docs.pingcap.com/tidb-in-kubernetes/stable/migrate-tidb-to-kubernetes/): 介绍如何将部署在物理机或虚拟机中的 TiDB 迁移至 Kubernetes 集群中
+- [开启 TiDB Operator 准入控制器](https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-admission-webhook/): 介绍如何开启 TiDB Operator 准入控制器以及它的作用。
+- [恢复持久卷上的备份数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-pv-using-br/): 介绍如何将存储在持久卷上的备份数据恢复到 TiDB 集群。
+- [恢复误删的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/recover-deleted-cluster/): 介绍如何恢复误删的 TiDB 集群。
+- [手动扩缩容 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/scale-a-tidb-cluster/): 了解如何在 Kubernetes 上对 TiDB 集群手动扩缩容。
+- [挂起 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/suspend-tidb-cluster/): 了解如何通过配置挂起 Kubernetes 上的 TiDB 集群。
+- [日志收集](https://docs.pingcap.com/tidb-in-kubernetes/stable/logs-collection/): 介绍收集 TiDB 及相关组件日志的方法。
+- [暂停同步 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/pause-sync-of-tidb-cluster/): 介绍如何暂停同步 Kubernetes 上的 TiDB 集群
+- [更新和替换 TLS 证书](https://docs.pingcap.com/tidb-in-kubernetes/stable/renew-tls-certificate/): 介绍如何更新和替换 TiDB 组件间的 TLS 证书。
+- [构建多个网络互通的 AWS EKS 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/build-multi-aws-eks/): 介绍如何构建多个 AWS EKS 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
+- [构建多个网络互通的 Google Cloud GKE 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/build-multi-gcp-gke/): 介绍如何构建多个 Google Cloud GKE 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
+- [查看日志](https://docs.pingcap.com/tidb-in-kubernetes/stable/view-logs/): 介绍如何查看 TiDB 集群各组件日志以及 TiDB 慢查询日志。
+- [灰度升级 TiDB Operator](https://docs.pingcap.com/tidb-in-kubernetes/stable/canary-upgrade-tidb-operator/): 介绍如何灰度升级 TiDB Operator，避免 TiDB Operator 升级对整个 Kubernetes 集群中的所有 TiDB 集群产生不可预知的影响。
+- [管理 TiDB 集群的 Command Cheat Sheet](https://docs.pingcap.com/tidb-in-kubernetes/stable/cheat-sheet/): 介绍管理 TiDB 集群的 Command Cheat Sheet。
+- [维护 TiDB 集群所在的 Kubernetes 节点](https://docs.pingcap.com/tidb-in-kubernetes/stable/maintain-a-kubernetes-node/): 介绍如何维护 TiDB 集群所在的 Kubernetes 节点。
+- [聚合多个 TiDB 集群的监控数据](https://docs.pingcap.com/tidb-in-kubernetes/stable/aggregate-multiple-cluster-monitor-data/): 通过 Thanos 框架聚合多个 TiDB 集群的监控数据
+- [访问 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/access-tidb/): 介绍如何访问 Kubernetes 上的 TiDB 集群。
+- [访问 TiDB Dashboard](https://docs.pingcap.com/tidb-in-kubernetes/stable/access-dashboard/): 介绍如何在 Kubernetes 环境下访问 TiDB Dashboard
+- [跨多个 Kubernetes 集群监控 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-monitor-across-multiple-kubernetes/): 介绍如何对跨多个 Kubernetes 集群的 TiDB 集群进行监控，并集成到常见 Prometheus 多集群监控体系中
+- [跨多个 Kubernetes 集群部署 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-cluster-across-multiple-kubernetes/): 本文档介绍如何实现跨多个 Kubernetes 集群部署 TiDB 集群
+- [远程存储访问授权](https://docs.pingcap.com/tidb-in-kubernetes/stable/grant-permissions-to-remote-storage/): 介绍如何授权访问远程存储。
+- [部署 TiDB Binlog](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-binlog/): 了解如何在 Kubernetes 上部署 TiDB 集群的 TiDB Binlog。
+- [配置 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-a-tidb-cluster/): 了解如何在 Kubernetes 中配置 TiDB 集群。
+- [重启 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/restart-a-tidb-cluster/): 了解如何重启 Kubernetes 集群上的 TiDB 集群。
+- [销毁 Kubernetes 上的 TiDB 集群](https://docs.pingcap.com/tidb-in-kubernetes/stable/destroy-a-tidb-cluster/): 介绍如何销毁 Kubernetes 集群上的 TiDB 集群。


### PR DESCRIPTION
This PR adds an llms.txt file to provide LLM-friendly content in English. For details, see issue https://github.com/pingcap/website-docs/issues/602.

Note: The `llms.txt` file in this PR covers the documentation TiDB Self-Managed (release-8.5), TiDB Operator (release-1.6).

Related PRs for en: #603, #604, #607 