### PR TITLE
refactor: update HeaderNav component to use direct URL for AskTug

### DIFF
--- a/src/components/Layout/HeaderNav.tsx
+++ b/src/components/Layout/HeaderNav.tsx
@@ -75,7 +75,7 @@ export default function HeaderNavStack(props: {
       />
 
       {["zh"].includes(language) && (
-        <NavItem label={t("navbar.asktug")} to={generateAskTugUrl(language)} />
+        <NavItem label={t("navbar.asktug")} to="https://asktug.com/" />
       )}
 
       {["en", "ja"].includes(language) && (
@@ -315,7 +315,7 @@ export function HeaderNavStackMobile(props: { buildType?: BuildType }) {
         {["zh"].includes(language) && (
           <MenuItem onClick={handleClose} disableRipple>
             <LinkComponent
-              to={generateAskTugUrl(language)}
+              to="https://asktug.com/"
               style={{ width: "100%" }}
               onClick={() =>
                 gtmTrack(GTMEvent.ClickHeadNav, {
@@ -348,16 +348,4 @@ export function HeaderNavStackMobile(props: { buildType?: BuildType }) {
       </Menu>
     </Box>
   );
-}
-
-function generateAskTugUrl(language: string) {
-  switch (language) {
-    case "zh":
-      return "https://asktug.com/";
-    case "en":
-      return "https://ask.pingcap.com/";
-    default:
-      break;
-  }
-  return "https://asktug.com/";
 }

--- a/src/shared/resources.ts
+++ b/src/shared/resources.ts
@@ -227,10 +227,6 @@ export const EN_FOOTER_ITEMS = [
         url: "https://www.pingcap.com/blog/",
       },
       {
-        name: "Forum",
-        url: "https://ask.pingcap.com/",
-      },
-      {
         name: "Events & Webinars",
         url: "https://www.pingcap.com/event",
       },
@@ -457,10 +453,6 @@ export const JA_FOOTER_ITEMS = [
       {
         name: "Discord",
         url: "https://discord.gg/DQZ2dy3cuc?utm_source=doc",
-      },
-      {
-        name: "Forum",
-        url: "https://ask.pingcap.com/",
       },
       {
         name: "Slack",


### PR DESCRIPTION
- Replaced dynamic URL generation for the AskTug link with a static URL in both desktop and mobile navigation.
- Removed the `generateAskTugUrl` function as it is no longer needed.
- Cleaned up the code by eliminating unused references to the AskTug forum in footer items.