### PR TITLE
feat: update campaign titles and links in translations

### DIFF
--- a/locale/en/translation.json
+++ b/locale/en/translation.json
@@ -176,10 +176,10 @@
       "viewLatestLTSVersion": "View latest LTS version docs"
     },
     "campaign": {
-      "link": "https://tidbcloud.com/",
-      "titleBeforeStarter": "TiDB Cloud Serverless is now ",
-      "titleAfterStarter": "! Same experience, new name.",
-      "end": "Try it out →"
+      "title1": "TiDB Cloud Essential",
+      "title2": "is now in public preview.",
+      "end": "Try it out →",
+      "link": "https://tidbcloud.com/"
     }
   },
   "campaign": {

--- a/locale/ja/translation.json
+++ b/locale/ja/translation.json
@@ -159,14 +159,14 @@
       "viewLatestLTSVersion": "最新の LTS バージョンのドキュメントを表示する"
     },
     "campaign": {
-      "link": "https://tidbcloud.com/",
-      "titleBeforeStarter": "TiDB Cloud Serverless が ",
-      "titleAfterStarter": " に変わりました！使いやすさはそのままに、名前が新しくなりました。",
-      "end": "ぜひお試しください →"
+      "title1": "TiDB Cloud Essential",
+      "title2": "はパブリックプレビュー中です。",
+      "end": "ぜひお試しください →",
+      "link": "https://tidbcloud.com/"
     },
     "autoTrans": {
-      "titleBeforeStarter": "TiDB Cloud Serverless が ",
-      "titleAfterStarter": " に変わりました！このページは自動翻訳されたものです。",
+      "title1": "TiDB Cloud Essential",
+      "title2": "はパブリックプレビュー中です。このページは自動翻訳されたものです。",
       "end": "原文はこちらからご覧ください。"
     }
   },

--- a/locale/zh/translation.json
+++ b/locale/zh/translation.json
@@ -174,14 +174,14 @@
       "viewLatestLTSVersion": "查看最新 LTS 版本文档"
     },
     "campaign": {
-      "link": "https://tidbcloud.com/",
-      "titleBeforeStarter": "TiDB Cloud Serverless 现已更名为 ",
-      "titleAfterStarter": "！体验不变，名字焕新。",
-      "end": "立即试用 →"
+      "title1": "TiDB Cloud Essential",
+      "title2": "开放公测中。",
+      "end": "立即试用 →",
+      "link": "https://tidbcloud.com/"
     },
     "autoTrans": {
-      "titleBeforeStarter": "TiDB Cloud Serverless 现已更名为 ",
-      "titleAfterStarter": "！此页面由 AI 自动翻译，英文原文请见",
+      "title1": "TiDB Cloud Essential",
+      "title2": "开放公测中。此页面由 AI 自动翻译，英文原文请见",
       "end": "此处。"
     }
   },

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -142,14 +142,13 @@ const HeaderBanner = (props: HeaderProps) => {
         // }
         logo={"📣"}
         textList={[
-          t("banner.autoTrans.titleBeforeStarter"),
           <BlueAnchorLink
-            to="https://www.pingcap.com/blog/introducing-tidb-cloud-starter-auto-scaling-plan-renamed/ "
+            to="https://www.pingcap.com/blog/tidb-cloud-essential-now-available-public-preview-aws-alibaba-cloud/"
             target="_blank"
           >
-            Starter
+            {t("banner.autoTrans.title1")}
           </BlueAnchorLink>,
-          t("banner.autoTrans.titleAfterStarter"),
+          t("banner.autoTrans.title2"),
           <BlueAnchorLink to={urlAutoTranslation} target="_blank">
             {t("banner.autoTrans.end")}
           </BlueAnchorLink>,
@@ -162,14 +161,13 @@ const HeaderBanner = (props: HeaderProps) => {
     <Banner
       logo={"📣"}
       textList={[
-        t("banner.campaign.titleBeforeStarter"),
         <BlueAnchorLink
-          to="https://www.pingcap.com/blog/introducing-tidb-cloud-starter-auto-scaling-plan-renamed/ "
+          to="https://www.pingcap.com/blog/tidb-cloud-essential-now-available-public-preview-aws-alibaba-cloud/"
           target="_blank"
         >
-          TiDB Cloud Starter
+          {t("banner.campaign.title1")}
         </BlueAnchorLink>,
-        t("banner.campaign.titleAfterStarter"),
+        t("banner.campaign.title2"),
         <BlueAnchorLink to={t("banner.campaign.link")} target="_blank">
           {t("banner.campaign.end")}
         </BlueAnchorLink>,

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -62,6 +62,7 @@ export const BlueAnchorLink = (
       style={{
         color: "var(--tiui-palette-secondary)",
         fontSize: "14px",
+        padding: "0 3px",
         ...props.style,
       }}
     />


### PR DESCRIPTION
close: #642 
- Revised campaign titles in English, Japanese, and Chinese translations to reflect the new name "TiDB Cloud Essential" and its public preview status.
- Updated links in the campaign section to direct users to the new blog post about TiDB Cloud Essential.