### PR TITLE
feat: treat `main` branch as `dev` version for Operator docs

### DIFF
--- a/gatsby/path.ts
+++ b/gatsby/path.ts
@@ -85,21 +85,12 @@ export function generateConfig(slug: string): {
 
 function branchToVersion(repo: Repo, branch: string) {
   switch (repo) {
-    case Repo.tidb: {
-      const stable = CONFIG.docs[repo].stable;
-      switch (branch) {
-        case "master":
-          return "dev";
-        case stable:
-          return "stable";
-        default:
-          return branch.replace("release-", "v");
-      }
-    }
+    case Repo.tidb:
     case Repo.operator: {
+      const devBranch = repo === Repo.operator ? "main" : "master";
       const stable = CONFIG.docs[repo].stable;
       switch (branch) {
-        case "main":
+        case devBranch:
           return "dev";
         case stable:
           return "stable";

--- a/gatsby/utils.ts
+++ b/gatsby/utils.ts
@@ -21,24 +21,22 @@ export function getStable(doc: Repo) {
   return undefined;
 }
 
-function renameVersion(version: string, stable: string | undefined) {
-  switch (version) {
-    case "master":
-    case "main":
-      return "dev";
-    case stable:
-      return "stable";
-    default:
-      return version.replace("release-", "v");
-  }
-}
-
 export function renameVersionByDoc(doc: Repo, version: string) {
   switch (doc) {
     case "tidb":
     case "tidb-data-migration":
-    case "tidb-in-kubernetes":
-      return renameVersion(version, getStable(doc));
+    case "tidb-in-kubernetes": {
+      const devBranch = doc === "tidb-in-kubernetes" ? "main" : "master";
+      const stable = getStable(doc);
+      switch (version) {
+        case devBranch:
+          return "dev";
+        case stable:
+          return "stable";
+        default:
+          return version.replace("release-", "v");
+      }
+    }
     case "tidbcloud":
       return;
   }

--- a/src/shared/resources.ts
+++ b/src/shared/resources.ts
@@ -497,7 +497,7 @@ export const TIDB_ZH_VERSIONS = CONFIG["docs"]["tidb"]["languages"]["zh"][
 
 export const OP_EN_VERSIONS = CONFIG["docs"]["tidb-in-kubernetes"]["languages"][
   "en"
-]["versions"].map((d) => convertVersionName(d, OP_EN_STABLE_VERSION));
+]["versions"].map((d) => convertVersionName(d, OP_EN_STABLE_VERSION, "tidb-in-kubernetes"));
 
 export const CLOUD_EN_VERSIONS = [];
 

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -182,21 +182,12 @@ export function getBannerByType(type: "home" | "tidb" | "tidb-cloud") {
 
 function branchToVersion(repo: Repo, branch: string) {
   switch (repo) {
-    case Repo.tidb: {
-      const stable = CONFIG.docs[repo].stable;
-      switch (branch) {
-        case "master":
-          return "dev";
-        case stable:
-          return "stable";
-        default:
-          return branch.replace("release-", "v");
-      }
-    }
+    case Repo.tidb:
     case Repo.operator: {
+      const devBranch = repo === Repo.operator ? "main" : "master";
       const stable = CONFIG.docs[repo].stable;
       switch (branch) {
-        case "main":
+        case devBranch:
           return "dev";
         case stable:
           return "stable";
@@ -224,10 +215,10 @@ export const AllVersion = Object.keys(CONFIG.docs).reduce((acc, val) => {
   return acc;
 }, {} as Record<Repo, Record<Locale, (string | null)[]>>);
 
-export function convertVersionName(version: string, stable: string) {
+export function convertVersionName(version: string, stable: string, repo?: string) {
+  const devBranch = repo === "tidb-in-kubernetes" ? "main" : "master";
   switch (version) {
-    case "master":
-    case "main":
+    case devBranch:
       return "dev";
     case stable:
       return "stable";


### PR DESCRIPTION
Update the version handling logic to treat the `main` branch as `dev` version specifically for TiDB Operator documentation.
