### PR TITLE
refactor: simplify TOC file extraction logic

### DIFF
--- a/gatsby/path.ts
+++ b/gatsby/path.ts
@@ -58,16 +58,12 @@ export function generateConfig(slug: string): {
   name = name === "_index" ? "" : name;
   let prefix: CloudPlan | undefined = undefined;
 
-  if (repo === Repo.tidbcloud) {
+  // only index page should have a prefix, e.g. /tidbcloud/starter/
+  if (repo === Repo.tidbcloud && !name && !slug.includes("dedicated/")) {
     const simplePrefixes = ["starter", "essential", "premium"];
     prefix = simplePrefixes.find((p) => slug.includes(`${p}/`)) as
       | CloudPlan
       | undefined;
-
-    // dedicated prefix is only used when the name is not empty
-    if (!prefix && slug.includes("dedicated/") && name) {
-      prefix = "dedicated";
-    }
   }
 
   return {

--- a/gatsby/toc-filter.ts
+++ b/gatsby/toc-filter.ts
@@ -1,4 +1,4 @@
-import { EXTENDS_FOLDERS, mdxAstToToc, TocQueryData } from "./toc";
+import { mdxAstToToc, TocQueryData } from "./toc";
 import { generateConfig } from "./path";
 
 // Whitelist of files that should always be built regardless of TOC content
@@ -7,10 +7,7 @@ const WHITELIST = [""];
 /**
  * Extract file paths from TOC navigation structure
  */
-export function extractFilesFromToc(
-  nav: any[],
-  extendsFolders?: string[]
-): string[] {
+export function extractFilesFromToc(nav: any[]): string[] {
   const files: string[] = [];
 
   function traverse(navItems: any[]) {
@@ -26,31 +23,7 @@ export function extractFilesFromToc(
         if (filenameWithExt && filenameWithExt !== "") {
           // Remove .md extension to match the actual file name
           const filename = filenameWithExt.replace(/\.md$/, "");
-
-          // Check if extends folders are specified and found in path segments
-          if (extendsFolders && extendsFolders.length > 0) {
-            let foundExtendsFolder = false;
-            for (const extendsFolder of extendsFolders) {
-              const extendsIndex = pathSegments.indexOf(extendsFolder);
-              if (
-                extendsIndex !== -1 &&
-                extendsIndex < pathSegments.length - 1
-              ) {
-                // Keep the extends folder and everything after it (excluding the .md extension)
-                const pathFromExtends = pathSegments
-                  .slice(extendsIndex, -1)
-                  .join("/");
-                files.push(`${pathFromExtends}/${filename}`);
-                foundExtendsFolder = true;
-                break;
-              }
-            }
-            if (!foundExtendsFolder) {
-              files.push(filename);
-            }
-          } else {
-            files.push(filename);
-          }
+          files.push(filename);
         }
       }
       if (item.children) {
@@ -98,7 +71,7 @@ export async function getFilesFromTocs(
   tocNodes.forEach((node: TocQueryData["allMdx"]["nodes"][0]) => {
     const { config } = generateConfig(node.slug);
     const toc = mdxAstToToc(node.mdxAST.children, config);
-    const files = extractFilesFromToc(toc, EXTENDS_FOLDERS);
+    const files = extractFilesFromToc(toc);
 
     // Create a key for this specific locale/repo/version combination
     const key = `${config.locale}/${config.repo}/${
@@ -157,9 +130,7 @@ export function filterNodesByToc(
     }
 
     // Only build files that are referenced in the corresponding TOC
-    const fullPath = `${
-      node.pathConfig.prefix ? node.pathConfig.prefix + "/" : ""
-    }${node.name}`;
+    const fullPath = node.name;
 
     // Check if the file is directly referenced in TOC
     let isIncluded = filesForThisToc.has(fullPath);

--- a/gatsby/toc.ts
+++ b/gatsby/toc.ts
@@ -9,20 +9,8 @@ import {
   Heading,
 } from "mdast";
 
-import {
-  RepoNav,
-  RepoNavLink,
-  PathConfig,
-  CloudPlan,
-} from "../src/shared/interface";
+import { RepoNav, RepoNavLink, PathConfig } from "../src/shared/interface";
 import { generateUrl } from "./path";
-
-export const EXTENDS_FOLDERS: CloudPlan[] = [
-  "starter",
-  "essential",
-  "dedicated",
-  "premium",
-];
 
 const SKIP_MODE_HEADING = "_BUILD_ALLOWLIST";
 
@@ -209,13 +197,6 @@ function getContentFromLink(
 
     const urlSegs = child.url.split("/");
     let filename = urlSegs[urlSegs.length - 1].replace(".md", "");
-
-    for (const extendsFolder of EXTENDS_FOLDERS) {
-      if (urlSegs.includes(extendsFolder)) {
-        filename = `${extendsFolder}/${filename}`;
-        break;
-      }
-    }
 
     return {
       type: "nav",


### PR DESCRIPTION
- Removed unused extendsFolders parameter from extractFilesFromToc function, streamlining the file extraction process.
- Updated related function calls to reflect the removal of the extendsFolders parameter.
- Adjusted logic in generateConfig to ensure prefixes are only applied to the index page when appropriate, enhancing clarity and maintainability.