### PR TITLE
feat: filter out premium TOC file during processing

### DIFF
--- a/gatsby/toc-filter.ts
+++ b/gatsby/toc-filter.ts
@@ -68,7 +68,15 @@ export async function getFilesFromTocs(
   const tocNodes = tocQuery.data!.allMdx.nodes;
   const tocFilesMap = new Map<string, Set<string>>();
 
-  tocNodes.forEach((node: TocQueryData["allMdx"]["nodes"][0]) => {
+  // TODO: Remove this filter once premium is public. Currently filtering out TOC-tidb-cloud-premium.md
+  const filteredTocNodes = tocNodes.filter(
+    (node: TocQueryData["allMdx"]["nodes"][0]) => {
+      const relativePath = node.parent?.relativePath || "";
+      return !relativePath.includes("TOC-tidb-cloud-premium.md");
+    }
+  );
+
+  filteredTocNodes.forEach((node: TocQueryData["allMdx"]["nodes"][0]) => {
     const { config } = generateConfig(node.slug);
     const toc = mdxAstToToc(node.mdxAST.children, config);
     const files = extractFilesFromToc(toc);


### PR DESCRIPTION
close #649 

- Added a temporary filter to exclude "TOC-tidb-cloud-premium.md" from the TOC nodes, ensuring that premium content is not displayed until it is publicly available. This change enhances the content management process while maintaining the integrity of the TOC structure.