### PR TITLE
fix DM archive URL resolution

### DIFF
--- a/gatsby/url-resolver/__tests__/url-resolver.test.ts
+++ b/gatsby/url-resolver/__tests__/url-resolver.test.ts
@@ -214,6 +214,42 @@ describe("calculateFileUrl", () => {
     expect(url).toBe("/en/tidb/dev/page/");
   });
 
+  it("should resolve tidb-data-migration _index with release branch alias", () => {
+    const absolutePath = path.join(
+      sourceBasePath,
+      "zh/tidb-data-migration/release-2.0/_index.md"
+    );
+    const url = calculateFileUrlWithConfig(absolutePath, testConfig);
+    expect(url).toBe("/zh/tidb-data-migration/v2.0");
+  });
+
+  it("should resolve tidb-data-migration pages with release branch alias", () => {
+    const absolutePath = path.join(
+      sourceBasePath,
+      "zh/tidb-data-migration/release-2.0/overview.md"
+    );
+    const url = calculateFileUrlWithConfig(absolutePath, testConfig);
+    expect(url).toBe("/zh/tidb-data-migration/v2.0/overview/");
+  });
+
+  it("should resolve tidb-data-migration v1.0 pages with release branch alias", () => {
+    const absolutePath = path.join(
+      sourceBasePath,
+      "zh/tidb-data-migration/release-1.0/overview.md"
+    );
+    const url = calculateFileUrlWithConfig(absolutePath, testConfig);
+    expect(url).toBe("/zh/tidb-data-migration/v1.0/overview/");
+  });
+
+  it("should resolve tidb-data-migration nested _index with folders", () => {
+    const absolutePath = path.join(
+      sourceBasePath,
+      "zh/tidb-data-migration/release-2.0/releases/_index.md"
+    );
+    const url = calculateFileUrlWithConfig(absolutePath, testConfig);
+    expect(url).toBe("/zh/tidb-data-migration/v2.0/releases");
+  });
+
   it("should resolve api folder", () => {
     const absolutePath = path.join(
       sourceBasePath,
@@ -468,6 +504,61 @@ describe("calculateFileUrl with defaultLanguage: 'en'", () => {
     );
     // release-8.5 -> stable via branch-alias-tidb (exact match takes precedence)
     expect(url).toBe("/tidb/stable/alert-rules");
+  });
+
+  it("should omit /en/ prefix for English tidb-data-migration files", () => {
+    const absolutePath = path.join(
+      sourceBasePath,
+      "en/tidb-data-migration/release-5.3/dm-overview.md"
+    );
+    const url = calculateFileUrlWithConfig(
+      absolutePath,
+      configWithDefaultLang,
+      true
+    );
+    expect(url).toBe("/tidb-data-migration/v5.3/dm-overview");
+  });
+
+  it("should omit /en/ prefix for English tidb-data-migration release indexes", () => {
+    const cases = [
+      ["release-5.3", "/tidb-data-migration/v5.3"],
+      ["release-2.0", "/tidb-data-migration/v2.0"],
+      ["release-1.0", "/tidb-data-migration/v1.0"],
+    ];
+
+    for (const [branch, expected] of cases) {
+      const absolutePath = path.join(
+        sourceBasePath,
+        `en/tidb-data-migration/${branch}/_index.md`
+      );
+      const url = calculateFileUrlWithConfig(
+        absolutePath,
+        configWithDefaultLang,
+        true
+      );
+      expect(url).toBe(expected);
+    }
+  });
+
+  it("should keep /zh/ prefix for Chinese tidb-data-migration release indexes", () => {
+    const cases = [
+      ["release-5.3", "/zh/tidb-data-migration/v5.3"],
+      ["release-2.0", "/zh/tidb-data-migration/v2.0"],
+      ["release-1.0", "/zh/tidb-data-migration/v1.0"],
+    ];
+
+    for (const [branch, expected] of cases) {
+      const absolutePath = path.join(
+        sourceBasePath,
+        `zh/tidb-data-migration/${branch}/_index.md`
+      );
+      const url = calculateFileUrlWithConfig(
+        absolutePath,
+        configWithDefaultLang,
+        true
+      );
+      expect(url).toBe(expected);
+    }
   });
 });
 

--- a/gatsby/url-resolver/config.ts
+++ b/gatsby/url-resolver/config.ts
@@ -123,6 +123,28 @@ export const defaultUrlResolverConfig: UrlResolverConfig = {
         ignoreIf: ["_index", "_docHome"],
       },
     },
+    // tidb-data-migration index pages with folders (avoid URL collision)
+    {
+      sourcePattern:
+        "/{lang}/tidb-data-migration/{branch}/{...folders}/{filename}",
+      targetPattern:
+        "/{lang}/tidb-data-migration/{branch:branch-alias-tidb-data-migration}/{folders}",
+      conditions: { filename: ["_index"] },
+      filenameTransform: {
+        ignoreIf: ["_index"],
+      },
+    },
+    // tidb-data-migration with branch and optional folders
+    // /en/tidb-data-migration/release-5.3/{...folders}/{filename} -> /en/tidb-data-migration/v5.3/{filename}
+    {
+      sourcePattern:
+        "/{lang}/tidb-data-migration/{branch}/{...folders}/{filename}",
+      targetPattern:
+        "/{lang}/tidb-data-migration/{branch:branch-alias-tidb-data-migration}/{filename}",
+      filenameTransform: {
+        ignoreIf: ["_index", "_docHome"],
+      },
+    },
     // Fallback: /{lang}/{repo}/{...any}/{filename} -> /{lang}/{repo}/{filename}
     {
       sourcePattern: "/{lang}/{repo}/{...any}/{filename}",
@@ -160,6 +182,16 @@ export const defaultUrlResolverConfig: UrlResolverConfig = {
         // Examples:
         //   release-1.6 -> v1.6
         //   release-1.5 -> v1.5
+        //   release-2.0 -> v2.0
+        "release-*": "v*",
+      },
+    },
+    // Branch alias for tidb-data-migration: used in {branch:branch-alias-tidb-data-migration}
+    "branch-alias-tidb-data-migration": {
+      mappings: {
+        // Wildcard pattern: release-* -> v*
+        // Examples:
+        //   release-5.3 -> v5.3
         //   release-2.0 -> v2.0
         "release-*": "v*",
       },


### PR DESCRIPTION
## Summary

Fix the broken URL of archived data migration docs such as https://docs-archive.pingcap.com/tidb-data-migration/v5.3/

- Add a dedicated URL resolver rule for TiDB Data Migration release branches.
- Map DM `release-*` branches to versioned archive paths such as `/tidb-data-migration/v5.3/`, `/tidb-data-migration/v2.0/`, and `/tidb-data-migration/v1.0/`.
- Preserve folder paths for DM subfolder `_index.md` pages to avoid future URL collisions.
- Add resolver tests for English and Chinese DM v5.3, v2.0, and v1.0 archive index paths, plus representative DM page and nested index paths.

## Root cause

DM pages were falling through to the generic fallback rule, which drops the branch segment. As a result, `release-5.3`, `release-2.0`, and `release-1.0` pages were generated under `/tidb-data-migration/` or `/zh/tidb-data-migration/` instead of their versioned archive paths.

## Affected archive links

- `/tidb-data-migration/v5.3/`
- `/tidb-data-migration/v2.0/`
- `/tidb-data-migration/v1.0/`
- `/zh/tidb-data-migration/v5.3/`
- `/zh/tidb-data-migration/v2.0/`
- `/zh/tidb-data-migration/v1.0/`

## Tests

- `NODE_PATH=/Users/grcai/Documents/GitHub/website-docs/node_modules /Users/grcai/Documents/GitHub/website-docs/node_modules/.bin/jest gatsby/url-resolver/__tests__/url-resolver.test.ts --runInBand`
- Resolver smoke test using local `/Users/grcai/Documents/GitHub/docs-staging/docs.json` for all six affected DM archive index paths and a nested DM index path.
