### PR TITLE
en: update the punctuation and wording of archived site banner

### DIFF
--- a/locale/en/translation.json
+++ b/locale/en/translation.json
@@ -195,8 +195,8 @@
   },
   "banner": {
     "archive": {
-      "title": "You are viewing the archived documentation of TiDB, which no longer receives updates.",
-      "viewLatestLTSVersion": "View latest LTS version docs"
+      "title": "You are viewing the archived documentation of TiDB, which no longer receives updates. ",
+      "viewLatestLTSVersion": "View the latest LTS version docs"
     },
     "campaign": {
       "title1": "TiDB Cloud Premium",


### PR DESCRIPTION
Added a missing space between the two sentences in the banner of the [archived TiDB doc site](https://docs-archive.pingcap.com/).

<img width="1666" height="176" alt="image" src="https://github.com/user-attachments/assets/0e594778-fc73-47b7-b937-6b07f965058a" />
