### PR TITLE
feat: support sticky table headers

### DIFF
--- a/src/components/MDXComponents/ExpandableTable.tsx
+++ b/src/components/MDXComponents/ExpandableTable.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import clsx from "clsx";
 import {
   CloseLargeIcon,
   ExpandCornersIcon,
@@ -21,14 +22,6 @@ type TablePropsWithRef = React.TableHTMLAttributes<HTMLTableElement> & {
 };
 
 const StickyHeaderTableContext = React.createContext(false);
-
-const hasClassName = (className: string | undefined, name: string) =>
-  className?.split(/\s+/).includes(name) ?? false;
-
-const addClassName = (className: string | undefined, name: string): string =>
-  hasClassName(className, name)
-    ? className ?? name
-    : `${className ?? ""} ${name}`.trim();
 
 const findTableHead = (children: React.ReactNode): React.ReactNode => {
   for (const child of React.Children.toArray(children)) {
@@ -74,13 +67,15 @@ export function ExpandableTable(
   const stickyHeaderScrollRef = React.useRef<HTMLDivElement | null>(null);
   const tableRef = React.useRef<HTMLTableElement | null>(null);
   const stickyHeaderOptIn = React.useContext(StickyHeaderTableContext);
-  const isStickyHeader =
-    stickyHeaderOptIn || hasClassName(tableProps.className, "sticky-header");
+  const hasStickyHeaderClass =
+    tableProps.className?.split(/\s+/).includes("sticky-header") ?? false;
+  const isStickyHeader = stickyHeaderOptIn || hasStickyHeaderClass;
   const stickyTableProps = {
     ...tableProps,
-    className: isStickyHeader
-      ? addClassName(tableProps.className, "sticky-header")
-      : tableProps.className,
+    className: clsx(
+      tableProps.className,
+      isStickyHeader && !hasStickyHeaderClass && "sticky-header"
+    ),
   };
   const tableHead = findTableHead(tableProps.children);
   const hasStickyHeaderClone = Boolean(stickyHeaderMetrics && tableHead);
@@ -245,17 +240,15 @@ export function ExpandableTable(
     };
   }, [isStickyHeader]);
 
-  // The cloned header is visual-only: it is aria-hidden and pointer-events are
-  // disabled in CSS, so sticky table headers should not contain controls.
+  // The cloned header is visual-only and aria-hidden, so sticky table headers
+  // should not contain controls.
   const stickyHeader =
     isStickyHeader && stickyHeaderMetrics && tableHead ? (
       <div
-        className={[
+        className={clsx(
           "sticky-header-scroll",
-          stickyHeaderActive ? "" : "sticky-header-scroll-hidden",
-        ]
-          .filter(Boolean)
-          .join(" ")}
+          !stickyHeaderActive && "sticky-header-scroll-hidden"
+        )}
         ref={stickyHeaderScrollRef}
         aria-hidden="true"
         style={{
@@ -265,10 +258,7 @@ export function ExpandableTable(
       >
         <table
           {...stickyTableProps}
-          className={addClassName(
-            stickyTableProps.className,
-            "sticky-header-clone"
-          )}
+          className={clsx(stickyTableProps.className, "sticky-header-clone")}
           style={{
             ...stickyTableProps.style,
             width: stickyHeaderMetrics.tableWidth,
@@ -303,12 +293,11 @@ export function ExpandableTable(
           <table
             {...stickyTableProps}
             ref={tableRef}
-            className={[
-              addClassName(stickyTableProps.className, "sticky-header-source"),
-              stickyHeaderActive ? "sticky-header-source-hidden" : "",
-            ]
-              .filter(Boolean)
-              .join(" ")}
+            className={clsx(
+              stickyTableProps.className,
+              "sticky-header-source",
+              stickyHeaderActive && "sticky-header-source-hidden"
+            )}
           />
         </>
       ) : (

--- a/src/components/MDXComponents/ExpandableTable.tsx
+++ b/src/components/MDXComponents/ExpandableTable.tsx
@@ -70,6 +70,7 @@ export function ExpandableTable(
   const [open, setOpen] = React.useState(false);
   const [stickyHeaderMetrics, setStickyHeaderMetrics] =
     React.useState<StickyHeaderMetrics | null>(null);
+  const [stickyHeaderActive, setStickyHeaderActive] = React.useState(false);
   const stickyHeaderScrollRef = React.useRef<HTMLDivElement | null>(null);
   const tableRef = React.useRef<HTMLTableElement | null>(null);
   const stickyHeaderOptIn = React.useContext(StickyHeaderTableContext);
@@ -122,6 +123,59 @@ export function ExpandableTable(
       tableScroll?.removeEventListener("scroll", syncStickyHeader);
     };
   }, [isStickyHeader, stickyHeaderMetrics]);
+
+  React.useEffect(() => {
+    if (!isStickyHeader || !hasStickyHeaderClone || !stickyHeaderMetrics) {
+      setStickyHeaderActive(false);
+      return;
+    }
+
+    let rafId: number | null = null;
+    const updateStickyHeaderActive = () => {
+      rafId = null;
+      const table = tableRef.current;
+      const stickyHeader = stickyHeaderScrollRef.current;
+      if (!table || !stickyHeader) {
+        setStickyHeaderActive(false);
+        return;
+      }
+
+      const stickyTop = Number.parseFloat(
+        window.getComputedStyle(stickyHeader).top
+      );
+      const stickyHeaderTop = Number.isFinite(stickyTop) ? stickyTop : 0;
+      const tableRect = table.getBoundingClientRect();
+      const nextActive =
+        tableRect.top <= stickyHeaderTop &&
+        tableRect.bottom > stickyHeaderTop + stickyHeaderMetrics.headerHeight;
+
+      if (nextActive) {
+        stickyHeader.scrollLeft = table.scrollLeft;
+      }
+      setStickyHeaderActive((current) =>
+        current === nextActive ? current : nextActive
+      );
+    };
+
+    const scheduleUpdate = () => {
+      if (rafId != null) {
+        window.cancelAnimationFrame(rafId);
+      }
+      rafId = window.requestAnimationFrame(updateStickyHeaderActive);
+    };
+
+    scheduleUpdate();
+    window.addEventListener("scroll", scheduleUpdate, { passive: true });
+    window.addEventListener("resize", scheduleUpdate);
+
+    return () => {
+      if (rafId != null) {
+        window.cancelAnimationFrame(rafId);
+      }
+      window.removeEventListener("scroll", scheduleUpdate);
+      window.removeEventListener("resize", scheduleUpdate);
+    };
+  }, [isStickyHeader, hasStickyHeaderClone, stickyHeaderMetrics]);
 
   React.useEffect(() => {
     if (!isStickyHeader) return;
@@ -196,7 +250,12 @@ export function ExpandableTable(
   const stickyHeader =
     isStickyHeader && stickyHeaderMetrics && tableHead ? (
       <div
-        className="sticky-header-scroll"
+        className={[
+          "sticky-header-scroll",
+          stickyHeaderActive ? "" : "sticky-header-scroll-hidden",
+        ]
+          .filter(Boolean)
+          .join(" ")}
         ref={stickyHeaderScrollRef}
         aria-hidden="true"
         style={{
@@ -246,7 +305,7 @@ export function ExpandableTable(
             ref={tableRef}
             className={[
               addClassName(stickyTableProps.className, "sticky-header-source"),
-              hasStickyHeaderClone ? "sticky-header-source-hidden" : "",
+              stickyHeaderActive ? "sticky-header-source-hidden" : "",
             ]
               .filter(Boolean)
               .join(" ")}

--- a/src/components/MDXComponents/ExpandableTable.tsx
+++ b/src/components/MDXComponents/ExpandableTable.tsx
@@ -16,14 +16,18 @@ type StickyHeaderMetrics = {
   columnWidths: number[];
 };
 
+type TablePropsWithRef = React.TableHTMLAttributes<HTMLTableElement> & {
+  ref?: React.Ref<HTMLTableElement>;
+};
+
 const StickyHeaderTableContext = React.createContext(false);
 
 const hasClassName = (className: string | undefined, name: string) =>
   className?.split(/\s+/).includes(name) ?? false;
 
-const addClassName = (className: string | undefined, name: string) =>
+const addClassName = (className: string | undefined, name: string): string =>
   hasClassName(className, name)
-    ? className
+    ? className ?? name
     : `${className ?? ""} ${name}`.trim();
 
 const findTableHead = (children: React.ReactNode): React.ReactNode => {
@@ -62,10 +66,7 @@ export function StickyHeaderTable({
 export function ExpandableTable(
   props: React.TableHTMLAttributes<HTMLTableElement>
 ) {
-  const { ref: _ref, ...tableProps } =
-    props as React.TableHTMLAttributes<HTMLTableElement> & {
-      ref?: React.Ref<HTMLTableElement>;
-    };
+  const { ref: _ref, ...tableProps } = props as TablePropsWithRef;
   const [open, setOpen] = React.useState(false);
   const [stickyHeaderMetrics, setStickyHeaderMetrics] =
     React.useState<StickyHeaderMetrics | null>(null);
@@ -188,8 +189,10 @@ export function ExpandableTable(
       window.removeEventListener("resize", scheduleMeasure);
       resizeObserver?.disconnect();
     };
-  }, [isStickyHeader, tableProps.children]);
+  }, [isStickyHeader]);
 
+  // The cloned header is visual-only: it is aria-hidden and pointer-events are
+  // disabled in CSS, so sticky table headers should not contain controls.
   const stickyHeader =
     isStickyHeader && stickyHeaderMetrics && tableHead ? (
       <div
@@ -221,6 +224,7 @@ export function ExpandableTable(
         </table>
       </div>
     ) : null;
+  const modalTableProps = isStickyHeader ? stickyTableProps : tableProps;
 
   return (
     <div className="expandable-table">
@@ -249,7 +253,7 @@ export function ExpandableTable(
           />
         </>
       ) : (
-        <table {...tableProps} />
+        <table {...props} />
       )}
       {open && (
         <div
@@ -272,7 +276,7 @@ export function ExpandableTable(
               <CloseLargeIcon />
             </button>
             <div className="expandable-modal-scroll">
-              <table {...stickyTableProps} />
+              <table {...modalTableProps} />
             </div>
           </div>
         </div>

--- a/src/components/MDXComponents/ExpandableTable.tsx
+++ b/src/components/MDXComponents/ExpandableTable.tsx
@@ -16,6 +16,16 @@ type StickyHeaderMetrics = {
   columnWidths: number[];
 };
 
+const StickyHeaderTableContext = React.createContext(false);
+
+const hasClassName = (className: string | undefined, name: string) =>
+  className?.split(/\s+/).includes(name) ?? false;
+
+const addClassName = (className: string | undefined, name: string) =>
+  hasClassName(className, name)
+    ? className
+    : `${className ?? ""} ${name}`.trim();
+
 const findTableHead = (children: React.ReactNode): React.ReactNode => {
   for (const child of React.Children.toArray(children)) {
     if (!React.isValidElement<TableChildProps>(child)) continue;
@@ -37,6 +47,18 @@ const findTableHead = (children: React.ReactNode): React.ReactNode => {
   return null;
 };
 
+export function StickyHeaderTable({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  return (
+    <StickyHeaderTableContext.Provider value={true}>
+      {children}
+    </StickyHeaderTableContext.Provider>
+  );
+}
+
 export function ExpandableTable(
   props: React.TableHTMLAttributes<HTMLTableElement>
 ) {
@@ -47,12 +69,17 @@ export function ExpandableTable(
   const [open, setOpen] = React.useState(false);
   const [stickyHeaderMetrics, setStickyHeaderMetrics] =
     React.useState<StickyHeaderMetrics | null>(null);
-  const tableScrollRef = React.useRef<HTMLDivElement | null>(null);
   const stickyHeaderScrollRef = React.useRef<HTMLDivElement | null>(null);
   const tableRef = React.useRef<HTMLTableElement | null>(null);
-  const isStickyHeader = tableProps.className
-    ?.split(/\s+/)
-    .includes("sticky-header");
+  const stickyHeaderOptIn = React.useContext(StickyHeaderTableContext);
+  const isStickyHeader =
+    stickyHeaderOptIn || hasClassName(tableProps.className, "sticky-header");
+  const stickyTableProps = {
+    ...tableProps,
+    className: isStickyHeader
+      ? addClassName(tableProps.className, "sticky-header")
+      : tableProps.className,
+  };
   const tableHead = findTableHead(tableProps.children);
   const hasStickyHeaderClone = Boolean(stickyHeaderMetrics && tableHead);
 
@@ -80,12 +107,11 @@ export function ExpandableTable(
     if (!isStickyHeader) return;
 
     const syncStickyHeader = () => {
-      if (!stickyHeaderScrollRef.current || !tableScrollRef.current) return;
-      stickyHeaderScrollRef.current.scrollLeft =
-        tableScrollRef.current.scrollLeft;
+      if (!stickyHeaderScrollRef.current || !tableRef.current) return;
+      stickyHeaderScrollRef.current.scrollLeft = tableRef.current.scrollLeft;
     };
 
-    const tableScroll = tableScrollRef.current;
+    const tableScroll = tableRef.current;
     tableScroll?.addEventListener("scroll", syncStickyHeader, {
       passive: true,
     });
@@ -107,7 +133,10 @@ export function ExpandableTable(
       if (!table || !tableHead || !headerCells || headerCells.length === 0) {
         return;
       }
-      const tableWidth = table.getBoundingClientRect().width;
+      const tableWidth = Math.max(
+        table.getBoundingClientRect().width,
+        table.scrollWidth
+      );
       const headerHeight = tableHead.getBoundingClientRect().height;
       if (tableWidth === 0 || headerHeight === 0) return;
 
@@ -173,10 +202,13 @@ export function ExpandableTable(
         }}
       >
         <table
-          {...tableProps}
-          className={`${tableProps.className ?? ""} sticky-header-clone`.trim()}
+          {...stickyTableProps}
+          className={addClassName(
+            stickyTableProps.className,
+            "sticky-header-clone"
+          )}
           style={{
-            ...tableProps.style,
+            ...stickyTableProps.style,
             width: stickyHeaderMetrics.tableWidth,
           }}
         >
@@ -205,15 +237,16 @@ export function ExpandableTable(
       {isStickyHeader ? (
         <>
           {stickyHeader}
-          <div className="sticky-header-table-scroll" ref={tableScrollRef}>
-            <table
-              {...tableProps}
-              ref={tableRef}
-              className={`${tableProps.className ?? ""} sticky-header-source ${
-                hasStickyHeaderClone ? "sticky-header-source-hidden" : ""
-              }`.trim()}
-            />
-          </div>
+          <table
+            {...stickyTableProps}
+            ref={tableRef}
+            className={[
+              addClassName(stickyTableProps.className, "sticky-header-source"),
+              hasStickyHeaderClone ? "sticky-header-source-hidden" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          />
         </>
       ) : (
         <table {...tableProps} />
@@ -239,7 +272,7 @@ export function ExpandableTable(
               <CloseLargeIcon />
             </button>
             <div className="expandable-modal-scroll">
-              <table {...tableProps} />
+              <table {...stickyTableProps} />
             </div>
           </div>
         </div>

--- a/src/components/MDXComponents/ExpandableTable.tsx
+++ b/src/components/MDXComponents/ExpandableTable.tsx
@@ -4,10 +4,57 @@ import {
   ExpandCornersIcon,
 } from "components/MDXComponents/ExpandIcons";
 
+type TableChildProps = {
+  children?: React.ReactNode;
+  mdxType?: string;
+  originalType?: string;
+};
+
+type StickyHeaderMetrics = {
+  tableWidth: number;
+  headerHeight: number;
+  columnWidths: number[];
+};
+
+const findTableHead = (children: React.ReactNode): React.ReactNode => {
+  for (const child of React.Children.toArray(children)) {
+    if (!React.isValidElement<TableChildProps>(child)) continue;
+
+    if (
+      child.type === "thead" ||
+      child.props.mdxType === "thead" ||
+      child.props.originalType === "thead"
+    ) {
+      return child;
+    }
+
+    if (child.type === React.Fragment) {
+      const tableHead = findTableHead(child.props.children);
+      if (tableHead) return tableHead;
+    }
+  }
+
+  return null;
+};
+
 export function ExpandableTable(
   props: React.TableHTMLAttributes<HTMLTableElement>
 ) {
+  const { ref: _ref, ...tableProps } =
+    props as React.TableHTMLAttributes<HTMLTableElement> & {
+      ref?: React.Ref<HTMLTableElement>;
+    };
   const [open, setOpen] = React.useState(false);
+  const [stickyHeaderMetrics, setStickyHeaderMetrics] =
+    React.useState<StickyHeaderMetrics | null>(null);
+  const tableScrollRef = React.useRef<HTMLDivElement | null>(null);
+  const stickyHeaderScrollRef = React.useRef<HTMLDivElement | null>(null);
+  const tableRef = React.useRef<HTMLTableElement | null>(null);
+  const isStickyHeader = tableProps.className
+    ?.split(/\s+/)
+    .includes("sticky-header");
+  const tableHead = findTableHead(tableProps.children);
+  const hasStickyHeaderClone = Boolean(stickyHeaderMetrics && tableHead);
 
   React.useEffect(() => {
     if (!open) return;
@@ -29,6 +76,120 @@ export function ExpandableTable(
     };
   }, [open]);
 
+  React.useEffect(() => {
+    if (!isStickyHeader) return;
+
+    const syncStickyHeader = () => {
+      if (!stickyHeaderScrollRef.current || !tableScrollRef.current) return;
+      stickyHeaderScrollRef.current.scrollLeft =
+        tableScrollRef.current.scrollLeft;
+    };
+
+    const tableScroll = tableScrollRef.current;
+    tableScroll?.addEventListener("scroll", syncStickyHeader, {
+      passive: true,
+    });
+    syncStickyHeader();
+
+    return () => {
+      tableScroll?.removeEventListener("scroll", syncStickyHeader);
+    };
+  }, [isStickyHeader, stickyHeaderMetrics]);
+
+  React.useEffect(() => {
+    if (!isStickyHeader) return;
+
+    let rafId: number | null = null;
+    const measure = () => {
+      const table = tableRef.current;
+      const tableHead = table?.tHead;
+      const headerCells = tableHead?.querySelectorAll("th");
+      if (!table || !tableHead || !headerCells || headerCells.length === 0) {
+        return;
+      }
+      const tableWidth = table.getBoundingClientRect().width;
+      const headerHeight = tableHead.getBoundingClientRect().height;
+      if (tableWidth === 0 || headerHeight === 0) return;
+
+      const nextMetrics = {
+        tableWidth,
+        headerHeight,
+        columnWidths: Array.from(headerCells).map(
+          (cell) => cell.getBoundingClientRect().width
+        ),
+      };
+
+      setStickyHeaderMetrics((current) => {
+        if (
+          current?.tableWidth === nextMetrics.tableWidth &&
+          current.headerHeight === nextMetrics.headerHeight &&
+          current.columnWidths.length === nextMetrics.columnWidths.length &&
+          current.columnWidths.every(
+            (width, index) => width === nextMetrics.columnWidths[index]
+          )
+        ) {
+          return current;
+        }
+
+        return nextMetrics;
+      });
+    };
+
+    const scheduleMeasure = () => {
+      if (rafId != null) {
+        window.cancelAnimationFrame(rafId);
+      }
+      rafId = window.requestAnimationFrame(measure);
+    };
+
+    scheduleMeasure();
+    window.addEventListener("resize", scheduleMeasure);
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(scheduleMeasure);
+    if (tableRef.current && resizeObserver) {
+      resizeObserver.observe(tableRef.current);
+    }
+
+    return () => {
+      if (rafId != null) {
+        window.cancelAnimationFrame(rafId);
+      }
+      window.removeEventListener("resize", scheduleMeasure);
+      resizeObserver?.disconnect();
+    };
+  }, [isStickyHeader, tableProps.children]);
+
+  const stickyHeader =
+    isStickyHeader && stickyHeaderMetrics && tableHead ? (
+      <div
+        className="sticky-header-scroll"
+        ref={stickyHeaderScrollRef}
+        aria-hidden="true"
+        style={{
+          height: stickyHeaderMetrics.headerHeight,
+          marginBottom: -stickyHeaderMetrics.headerHeight,
+        }}
+      >
+        <table
+          {...tableProps}
+          className={`${tableProps.className ?? ""} sticky-header-clone`.trim()}
+          style={{
+            ...tableProps.style,
+            width: stickyHeaderMetrics.tableWidth,
+          }}
+        >
+          <colgroup>
+            {stickyHeaderMetrics.columnWidths.map((width, index) => (
+              <col key={index} style={{ width }} />
+            ))}
+          </colgroup>
+          {tableHead}
+        </table>
+      </div>
+    ) : null;
+
   return (
     <div className="expandable-table">
       <div className="expandable-table-toolbar">
@@ -41,7 +202,22 @@ export function ExpandableTable(
           <ExpandCornersIcon />
         </button>
       </div>
-      <table {...props} />
+      {isStickyHeader ? (
+        <>
+          {stickyHeader}
+          <div className="sticky-header-table-scroll" ref={tableScrollRef}>
+            <table
+              {...tableProps}
+              ref={tableRef}
+              className={`${tableProps.className ?? ""} sticky-header-source ${
+                hasStickyHeaderClone ? "sticky-header-source-hidden" : ""
+              }`.trim()}
+            />
+          </div>
+        </>
+      ) : (
+        <table {...tableProps} />
+      )}
       {open && (
         <div
           className="expandable-modal-backdrop"
@@ -63,7 +239,7 @@ export function ExpandableTable(
               <CloseLargeIcon />
             </button>
             <div className="expandable-modal-scroll">
-              <table {...props} />
+              <table {...tableProps} />
             </div>
           </div>
         </div>

--- a/src/components/MDXComponents/index.tsx
+++ b/src/components/MDXComponents/index.tsx
@@ -40,5 +40,5 @@ export {
 } from "components/MDXComponents/ResourceCard";
 
 export { TargetLink as Link } from "./Link";
-export { ExpandableTable as table } from "./ExpandableTable";
+export { ExpandableTable as table, StickyHeaderTable } from "./ExpandableTable";
 export { ExpandableImage as img } from "./ExpandableImage";

--- a/src/styles/docTemplate.css
+++ b/src/styles/docTemplate.css
@@ -5,6 +5,12 @@
 @import "github-markdown-css/github-markdown-light.css";
 
 .PingCAP-Doc {
+  --pc-docs-sticky-table-top: 56px;
+
+  &.doc-feature-banner {
+    --pc-docs-sticky-table-top: 96px;
+  }
+
   .doc-global-home {
     background-image: url(../../images/docHome/home-hero-bg.svg);
     background-position: top;
@@ -46,6 +52,28 @@
 
     .expandable-table {
       margin: 16px 0;
+    }
+
+    table.sticky-header,
+    .expandable-table-modal-content table.sticky-header {
+      display: table;
+      width: 100%;
+      min-width: 100%;
+      overflow: visible;
+    }
+
+    table.sticky-header thead th {
+      position: sticky;
+      top: var(--pc-docs-sticky-table-top);
+      z-index: 2;
+      background-color: #fff;
+    }
+
+    .expandable-table-modal-content table.sticky-header thead th {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      background-color: #fff;
     }
 
     .expandable-table-toolbar {
@@ -304,7 +332,6 @@
     margin-top: 8px;
   }
 }
-
 
 
 

--- a/src/styles/docTemplate.css
+++ b/src/styles/docTemplate.css
@@ -100,9 +100,42 @@
       top: 0;
       z-index: 2;
       border-top-color: transparent;
-      box-shadow:
-        inset 0 1px 0 #d1d9e0,
-        inset 0 -1px 0 #d1d9e0;
+      border-bottom-color: transparent;
+      box-shadow: none;
+    }
+
+    .expandable-table-modal-content table.sticky-header thead th::before {
+      content: "";
+      position: absolute;
+      right: 0;
+      top: -8px;
+      left: 0;
+      height: 9px;
+      background: linear-gradient(
+        to bottom,
+        #fff 0,
+        #fff 8px,
+        #d1d9e0 8px,
+        #d1d9e0 9px
+      );
+      pointer-events: none;
+    }
+
+    .expandable-table-modal-content table.sticky-header thead th::after {
+      content: "";
+      position: absolute;
+      right: 0;
+      bottom: -1px;
+      left: 0;
+      height: 2px;
+      background: linear-gradient(
+        to bottom,
+        #d1d9e0 0,
+        #d1d9e0 1px,
+        #fff 1px,
+        #fff 2px
+      );
+      pointer-events: none;
     }
 
     .expandable-table-toolbar {

--- a/src/styles/docTemplate.css
+++ b/src/styles/docTemplate.css
@@ -67,6 +67,8 @@
       top: var(--pc-docs-sticky-table-top);
       z-index: 2;
       background-color: #fff;
+      border-bottom-color: transparent;
+      box-shadow: inset 0 -1px 0 #d1d9e0;
     }
 
     .expandable-table-modal-content table.sticky-header thead th {
@@ -74,6 +76,8 @@
       top: 0;
       z-index: 2;
       background-color: #fff;
+      border-bottom-color: transparent;
+      box-shadow: inset 0 -1px 0 #d1d9e0;
     }
 
     .expandable-table-toolbar {

--- a/src/styles/docTemplate.css
+++ b/src/styles/docTemplate.css
@@ -48,11 +48,6 @@
       margin: 16px 0;
     }
 
-    .sticky-header-table-scroll {
-      max-width: 100%;
-      overflow-x: auto;
-    }
-
     .sticky-header-scroll {
       position: sticky;
       top: var(--pc-docs-sticky-table-top);
@@ -62,18 +57,12 @@
       pointer-events: none;
     }
 
-    table.sticky-header-source,
     .expandable-table-modal-content table.sticky-header {
-      display: table;
-      width: 100%;
-      min-width: 100%;
-      max-width: none;
       overflow: visible;
     }
 
     table.sticky-header-clone {
       display: table;
-      min-width: 100%;
       max-width: none;
       margin: 0;
       overflow: visible;
@@ -368,4 +357,3 @@
     margin-top: 8px;
   }
 }
-

--- a/src/styles/docTemplate.css
+++ b/src/styles/docTemplate.css
@@ -5,12 +5,6 @@
 @import "github-markdown-css/github-markdown-light.css";
 
 .PingCAP-Doc {
-  --pc-docs-sticky-table-top: 56px;
-
-  &.doc-feature-banner {
-    --pc-docs-sticky-table-top: 96px;
-  }
-
   .doc-global-home {
     background-image: url(../../images/docHome/home-hero-bg.svg);
     background-position: top;
@@ -54,30 +48,68 @@
       margin: 16px 0;
     }
 
-    table.sticky-header,
+    .sticky-header-table-scroll {
+      max-width: 100%;
+      overflow-x: auto;
+    }
+
+    .sticky-header-scroll {
+      position: sticky;
+      top: var(--pc-docs-sticky-table-top);
+      z-index: 2;
+      max-width: 100%;
+      overflow: hidden;
+      pointer-events: none;
+    }
+
+    table.sticky-header-source,
     .expandable-table-modal-content table.sticky-header {
       display: table;
       width: 100%;
       min-width: 100%;
+      max-width: none;
       overflow: visible;
     }
 
-    table.sticky-header thead th {
-      position: sticky;
-      top: var(--pc-docs-sticky-table-top);
-      z-index: 2;
+    table.sticky-header-clone {
+      display: table;
+      min-width: 100%;
+      max-width: none;
+      margin: 0;
+      overflow: visible;
+    }
+
+    table.sticky-header-clone thead th,
+    .expandable-table-modal-content table.sticky-header thead th {
       background-color: #fff;
       border-bottom-color: transparent;
       box-shadow: inset 0 -1px 0 #d1d9e0;
+    }
+
+    table.sticky-header-source-hidden thead th {
+      border-bottom-color: transparent;
+    }
+
+    table.sticky-header-source-hidden tbody tr:first-child {
+      border-top-color: transparent;
+    }
+
+    table.sticky-header-source-hidden tbody tr:first-child td {
+      border-top-color: transparent;
+    }
+
+    table.sticky-header-source-hidden thead {
+      opacity: 0;
     }
 
     .expandable-table-modal-content table.sticky-header thead th {
       position: sticky;
       top: 0;
       z-index: 2;
-      background-color: #fff;
-      border-bottom-color: transparent;
-      box-shadow: inset 0 -1px 0 #d1d9e0;
+      border-top-color: transparent;
+      box-shadow:
+        inset 0 1px 0 #d1d9e0,
+        inset 0 -1px 0 #d1d9e0;
     }
 
     .expandable-table-toolbar {
@@ -336,6 +368,4 @@
     margin-top: 8px;
   }
 }
-
-
 

--- a/src/styles/docTemplate.css
+++ b/src/styles/docTemplate.css
@@ -54,7 +54,6 @@
       z-index: 2;
       max-width: 100%;
       overflow: hidden;
-      pointer-events: none;
     }
 
     .sticky-header-scroll-hidden {

--- a/src/styles/docTemplate.css
+++ b/src/styles/docTemplate.css
@@ -57,6 +57,10 @@
       pointer-events: none;
     }
 
+    .sticky-header-scroll-hidden {
+      visibility: hidden;
+    }
+
     .expandable-table-modal-content table.sticky-header {
       overflow: visible;
     }

--- a/src/templates/DocTemplate.tsx
+++ b/src/templates/DocTemplate.tsx
@@ -36,6 +36,7 @@ import ScrollToTopBtn from "components/Button/ScrollToTopBtn";
 import { DOC_HOME_URL } from "shared/resources";
 import { useIsAutoTranslation } from "shared/useIsAutoTranslation";
 import { useReportReadingRate } from "shared/useReportReadingRate";
+import { getHeaderStickyHeight } from "shared/headerHeight";
 import {
   CloudPlanProvider,
   useCloudPlan,
@@ -268,6 +269,7 @@ function DocTemplate({
       />
       <Box
         sx={{
+          "--pc-docs-sticky-table-top": getHeaderStickyHeight(bannerVisible),
           display: "flex",
         }}
         className={clsx("PingCAP-Doc", {


### PR DESCRIPTION
Fix https://github.com/pingcap/docs/issues/21276

## Purpose
Make long documentation tables easier to read by keeping table headers visible while readers scroll through table rows. 

> Note: This behavior is opt-in and only applies to tables that explicitly specify sticky headers.

## Changes
- Add sticky table header support for MDX tables through a new StickyHeaderTable export and the sticky-header class.
- Extend ExpandableTable to measure header and column sizes, render a visual-only cloned header in page view, and keep it aligned with horizontal scrolling.
- Add styles for sticky headers in both normal document pages and expanded table modals, using the site header height as the sticky offset.

## How to use
- For HTML tables in Markdown files, add `className="sticky-header"` to the table element.
- For Markdown table syntax in Markdown files, wrap the table with the `StickyHeaderTable` MDX wrapper:

	```mdx
	<StickyHeaderTable>
	
	| Column A | Column B |
	| --- | --- |
	| Value A | Value B |
	
	</StickyHeaderTable>
	```

## Benefits
Readers can keep column context in large or wide documentation tables without losing the existing expandable table behavior.

## Testing
- pnpm test --runInBand