### PR TITLE
feat(nav): add BYOC preview badge and adjust order

### DIFF
--- a/src/components/Layout/Header/HeaderNavConfigData.tsx
+++ b/src/components/Layout/Header/HeaderNavConfigData.tsx
@@ -79,7 +79,7 @@ const getDefaultNavConfig = (
             type: "item",
             label: t("navbar.tidbCloudByoc"),
             endIcon: <PreviewBadge label={t("navbar.badge.preview")} />,
-            to: `/tidbcloud/premium/?${CLOUD_MODE_KEY}=${CloudPlan.Byoc}`,
+            to: `/tidbcloud/byoc?${CLOUD_MODE_KEY}=${CloudPlan.Byoc}`,
             selected: (namespace) =>
               namespace === TOCNamespace.TiDBCloud &&
               cloudPlan === CloudPlan.Byoc,

--- a/src/components/Layout/Header/HeaderNavConfigData.tsx
+++ b/src/components/Layout/Header/HeaderNavConfigData.tsx
@@ -77,6 +77,20 @@ const getDefaultNavConfig = (
           },
           {
             type: "item",
+            label: t("navbar.tidbCloudByoc"),
+            endIcon: <PreviewBadge label={t("navbar.badge.preview")} />,
+            to: `/tidbcloud/premium/?${CLOUD_MODE_KEY}=${CloudPlan.Byoc}`,
+            selected: (namespace) =>
+              namespace === TOCNamespace.TiDBCloud &&
+              cloudPlan === CloudPlan.Byoc,
+            onClick: () => {
+              if (typeof window !== "undefined") {
+                sessionStorage.setItem(CLOUD_MODE_KEY, CloudPlan.Byoc);
+              }
+            },
+          },
+          {
+            type: "item",
             label: t("navbar.tidbCloudDedicated"),
             to:
               cloudPlan === CloudPlan.Dedicated || !cloudPlan
@@ -100,19 +114,6 @@ const getDefaultNavConfig = (
             onClick: () => {
               if (typeof window !== "undefined") {
                 sessionStorage.setItem(CLOUD_MODE_KEY, CloudPlan.Dedicated);
-              }
-            },
-          },
-          {
-            type: "item",
-            label: t("navbar.tidbCloudByoc"),
-            to: `/tidbcloud/premium/?${CLOUD_MODE_KEY}=${CloudPlan.Byoc}`,
-            selected: (namespace) =>
-              namespace === TOCNamespace.TiDBCloud &&
-              cloudPlan === CloudPlan.Byoc,
-            onClick: () => {
-              if (typeof window !== "undefined") {
-                sessionStorage.setItem(CLOUD_MODE_KEY, CloudPlan.Byoc);
               }
             },
           },

--- a/src/components/Layout/VersionSelect/CloudVersionSelect.tsx
+++ b/src/components/Layout/VersionSelect/CloudVersionSelect.tsx
@@ -55,6 +55,20 @@ const CLOUD_VERSIONS = [
   {
     label: "BYOC",
     value: CloudPlan.Byoc,
+    icon: (
+      <Chip
+        label="Preview"
+        variant="outlined"
+        size="small"
+        sx={{
+          fontSize: "12px",
+          height: "20px",
+          pointerEvents: "none",
+          borderColor: "#DCE3E5",
+          color: "#6F787B",
+        }}
+      />
+    ),
   },
 ];
 

--- a/src/components/Layout/VersionSelect/CloudVersionSelect.tsx
+++ b/src/components/Layout/VersionSelect/CloudVersionSelect.tsx
@@ -90,9 +90,7 @@ const VersionItems = (props: {
     const searchParams = new URLSearchParams();
     searchParams.set(CLOUD_MODE_KEY, version);
     if (version === CloudPlan.Byoc) {
-      return `/${pathConfig.repo}/${
-        CloudPlan.Premium
-      }/?${searchParams.toString()}`;
+      return `/${pathConfig.repo}/${CloudPlan.Byoc}?${searchParams.toString()}`;
     }
     return version === CloudPlan.Dedicated
       ? `/${pathConfig.repo}/`


### PR DESCRIPTION
- Added the `Preview` badge for `TiDB Cloud BYOC`
- Moved `TiDB Cloud BYOC` to the position next to (after) `TiDB Cloud Essential`
- Configured the landing page of BYOC to its own `_index.md` page

Related PR: https://github.com/pingcap/docs/pull/23212