### PR TITLE
fix: free space before archive build

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -14,6 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     name: Build website
     steps:
+      - name: Maximize build space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune --all --force
+          df -h
+
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
@@ -54,6 +65,11 @@ jobs:
           key: ${{ runner.os }}-archive-gatsby-cache-docs-staging-${{ steps.calc-cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-archive-gatsby-cache-docs-staging-
+
+      - name: Clean up temporary files
+        run: |
+          sudo rm -rf /tmp/*
+          sudo rm -rf /home/runner/work/_temp/*
 
       - name: Build website
         env:


### PR DESCRIPTION
## What changed

- Free preinstalled tool and Docker cache space before the archive build.
- Remove temporary runner files after restoring the Gatsby cache.

## Why

The archive build runner ran out of disk space while generating the Gatsby site.