### PR TITLE
feat(nav): render Preview badges consistently

### DIFF
--- a/gatsby/__tests__/toc.test.ts
+++ b/gatsby/__tests__/toc.test.ts
@@ -1,0 +1,71 @@
+import { mdxAstToToc } from "../toc";
+
+describe("mdxAstToToc tag query parsing", () => {
+  it("does not emit a bogus ?undefined query when the image URL has no query string", () => {
+    const toc = mdxAstToToc(
+      [
+        {
+          type: "list",
+          children: [
+            {
+              type: "listItem",
+              children: [
+                {
+                  type: "paragraph",
+                  children: [
+                    { type: "text", value: "Data Service" },
+                    {
+                      type: "image",
+                      alt: "PREVIEW",
+                      url: "/media/tidb-cloud/blank_transparent_placeholder.png",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ] as any,
+      "en/tidbcloud/master/TOC"
+    );
+
+    expect(toc[0].tag).toEqual({
+      value: "PREVIEW",
+      query: undefined,
+    });
+  });
+
+  it("keeps tag query params when the image URL includes them", () => {
+    const toc = mdxAstToToc(
+      [
+        {
+          type: "list",
+          children: [
+            {
+              type: "listItem",
+              children: [
+                {
+                  type: "paragraph",
+                  children: [
+                    { type: "text", value: "Beta Feature" },
+                    {
+                      type: "image",
+                      alt: "BETA",
+                      url: "/media/tidb-cloud/blank_transparent_placeholder.png?color=%232d9cd2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ] as any,
+      "en/tidbcloud/master/TOC"
+    );
+
+    expect(toc[0].tag).toEqual({
+      value: "BETA",
+      query: "?color=%232d9cd2",
+    });
+  });
+});

--- a/gatsby/__tests__/toc.test.ts
+++ b/gatsby/__tests__/toc.test.ts
@@ -35,6 +35,37 @@ describe("mdxAstToToc tag query parsing", () => {
     });
   });
 
+  it("does not create a tag when the TOC image has no alt text", () => {
+    const toc = mdxAstToToc(
+      [
+        {
+          type: "list",
+          children: [
+            {
+              type: "listItem",
+              children: [
+                {
+                  type: "paragraph",
+                  children: [
+                    { type: "text", value: "Data Service" },
+                    {
+                      type: "image",
+                      alt: null,
+                      url: "/media/tidb-cloud/blank_transparent_placeholder.png",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ] as any,
+      "en/tidbcloud/master/TOC"
+    );
+
+    expect(toc[0].tag).toBeUndefined();
+  });
+
   it("keeps tag query params when the image URL includes them", () => {
     const toc = mdxAstToToc(
       [

--- a/gatsby/toc.ts
+++ b/gatsby/toc.ts
@@ -160,10 +160,12 @@ function getContentFromLink(
   // use `image` as tag
   const image = content.children.find((n): n is Image => n.type === "image");
   const imageQuery = image?.url.split("?")[1];
-  const tag = image && {
-    value: image.alt!,
-    query: imageQuery ? `?${imageQuery}` : undefined,
-  };
+  const tag = image?.alt
+    ? {
+        value: image.alt,
+        query: imageQuery ? `?${imageQuery}` : undefined,
+      }
+    : undefined;
 
   if (child.type === "link") {
     if (child.children.length === 0) {

--- a/gatsby/toc.ts
+++ b/gatsby/toc.ts
@@ -2,6 +2,7 @@ import {
   ListItem,
   List,
   Link,
+  Image,
   Paragraph,
   Text,
   Content,
@@ -157,10 +158,11 @@ function getContentFromLink(
 
   const child = content.children[0] as Link | Text;
   // use `image` as tag
-  const image = content.children.find((n) => n.type === "image");
+  const image = content.children.find((n): n is Image => n.type === "image");
+  const imageQuery = image?.url.split("?")[1];
   const tag = image && {
     value: image.alt!,
-    query: `?${image.url.split("?")[1]}`,
+    query: imageQuery ? `?${imageQuery}` : undefined,
   };
 
   if (child.type === "link") {

--- a/locale/en/translation.json
+++ b/locale/en/translation.json
@@ -43,8 +43,7 @@
     "tidbOperatorReleases": "TiDB Operator Releases",
     "tiupReleases": "TiUP Releases",
     "badge": {
-      "preview": "Preview",
-      "beta": "Beta"
+      "preview": "Preview"
     },
     "appdev": "App Dev",
     "asktug": "Forum",

--- a/locale/ja/translation.json
+++ b/locale/ja/translation.json
@@ -43,8 +43,7 @@
     "tidbOperatorReleases": "TiDB Operator リリース",
     "tiupReleases": "TiUP リリース",
     "badge": {
-      "preview": "Preview",
-      "beta": "Beta"
+      "preview": "Preview"
     },
     "appdev": "アプリ開発",
     "asktug": "Forum",

--- a/locale/zh/translation.json
+++ b/locale/zh/translation.json
@@ -41,8 +41,7 @@
     "tidbOperatorReleases": "TiDB Operator 版本发布记录",
     "tiupReleases": "TiUP 版本发布记录",
     "badge": {
-      "preview": "Preview",
-      "beta": "Beta"
+      "preview": "Preview"
     },
     "appdev": "开发指南",
     "asktug": "社区",

--- a/src/components/Badge/PreviewBadge.tsx
+++ b/src/components/Badge/PreviewBadge.tsx
@@ -1,0 +1,30 @@
+import Chip from "@mui/material/Chip";
+import { useTheme } from "@mui/material/styles";
+
+const PreviewBadge = (props: { label: string }) => {
+  const theme = useTheme();
+
+  return (
+    <Chip
+      label={props.label}
+      size="small"
+      variant="outlined"
+      sx={{
+        flexShrink: 0,
+        height: "20px",
+        fontSize: "12px",
+        fontWeight: 400,
+        borderRadius: "10px",
+        pointerEvents: "none",
+        "& .MuiChip-label": {
+          paddingLeft: "8px",
+          paddingRight: "8px",
+          lineHeight: "20px",
+          color: theme.palette.carbon[700],
+        },
+      }}
+    />
+  );
+};
+
+export default PreviewBadge;

--- a/src/components/Badge/PreviewBadge.tsx
+++ b/src/components/Badge/PreviewBadge.tsx
@@ -10,7 +10,6 @@ const PreviewBadge = (props: { label: string }) => {
       size="small"
       variant="outlined"
       sx={{
-        flexShrink: 0,
         height: "20px",
         fontSize: "12px",
         fontWeight: 400,

--- a/src/components/Badge/PreviewBadge.tsx
+++ b/src/components/Badge/PreviewBadge.tsx
@@ -10,15 +10,18 @@ const PreviewBadge = (props: { label: string }) => {
       size="small"
       variant="outlined"
       sx={{
-        height: "20px",
-        fontSize: "12px",
-        fontWeight: 400,
-        borderRadius: "10px",
+        height: "18px",
+        fontSize: "10px",
+        fontWeight: 500,
+        borderRadius: "1000px",
+        borderColor: theme.palette.carbon[400],
         pointerEvents: "none",
+        textTransform: "uppercase",
+        letterSpacing: "0.25px",
         "& .MuiChip-label": {
           paddingLeft: "8px",
           paddingRight: "8px",
-          lineHeight: "20px",
+          lineHeight: "16px",
           color: theme.palette.carbon[700],
         },
       }}

--- a/src/components/Layout/Header/HeaderNavConfigData.tsx
+++ b/src/components/Layout/Header/HeaderNavConfigData.tsx
@@ -2,35 +2,10 @@ import { NavConfig } from "./HeaderNavConfigType";
 import { CLOUD_MODE_KEY } from "shared/useCloudPlan";
 import { CloudPlan, TOCNamespace } from "shared/interface";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import Chip from "@mui/material/Chip";
-import { useTheme } from "@mui/material/styles";
+import PreviewBadge from "components/Badge/PreviewBadge";
 
 import TiDBCloudIcon from "media/icons/cloud-03.svg";
 import TiDBIcon from "media/icons/layers-three-01.svg";
-
-const PreviewBadge = (props: { label: string }) => {
-  const theme = useTheme();
-  return (
-    <Chip
-      label={props.label}
-      size="small"
-      variant="outlined"
-      sx={{
-        height: "20px",
-        fontSize: "12px",
-        fontWeight: 400,
-        borderRadius: "10px",
-        pointerEvents: "none",
-        "& .MuiChip-label": {
-          paddingLeft: "8px",
-          paddingRight: "8px",
-          lineHeight: "20px",
-          color: theme.palette.carbon[700],
-        },
-      }}
-    />
-  );
-};
 
 /**
  * Default navigation configuration

--- a/src/components/Layout/Header/HeaderNavConfigData.tsx
+++ b/src/components/Layout/Header/HeaderNavConfigData.tsx
@@ -32,24 +32,6 @@ const PreviewBadge = (props: { label: string }) => {
   );
 };
 
-const BetaTagBadge = (props: { label: string }) => (
-  <Chip
-    label={props.label}
-    variant="outlined"
-    size="small"
-    sx={{
-      flexShrink: 0,
-      textTransform: "uppercase",
-      pointerEvents: "none",
-      fontSize: "10px",
-      height: "20px",
-      borderColor: "#c0e1f1",
-      color: "#2d9cd2",
-      fontWeight: 500,
-    }}
-  />
-);
-
 /**
  * Default navigation configuration
  */
@@ -167,7 +149,7 @@ const getDefaultNavConfig = (
     leftNavLabel: (
       <>
         {t("navbar.tidbForAI")}
-        <BetaTagBadge label={t("navbar.badge.beta")} />
+        <PreviewBadge label={t("navbar.badge.preview")} />
       </>
     ),
     to: "/ai",

--- a/src/components/Layout/LeftNav/LeftNavTree.tsx
+++ b/src/components/Layout/LeftNav/LeftNavTree.tsx
@@ -193,6 +193,7 @@ export default function ControlledTreeView(props: {
 
   const theme = useTheme();
   const { t } = useTranslation();
+  const previewBadgeLabel = t("navbar.badge.preview");
   const [disableTransition, setDisableTransition] = React.useState(false);
   const previousUrlRef = React.useRef<string | null>(null);
 
@@ -316,7 +317,7 @@ export default function ControlledTreeView(props: {
             ) : (
               <Box sx={{ flexShrink: 0 }} width={16} height={16} />
             )}
-            {generateItemLabel(item, t("navbar.badge.preview"))}
+            {generateItemLabel(item, previewBadgeLabel)}
           </Stack>
         );
       };

--- a/src/components/Layout/LeftNav/LeftNavTree.tsx
+++ b/src/components/Layout/LeftNav/LeftNavTree.tsx
@@ -401,8 +401,8 @@ const generateItemLabel = (
   let tagColor: string | null = null;
   let tagColor02: string | null = null;
 
-  if (!isPreviewTag) {
-    const tagQuery = new URLSearchParams(tag?.query);
+  if (tag && !isPreviewTag) {
+    const tagQuery = new URLSearchParams(tag.query ?? "");
     tagColor = tagQuery.get("color");
     tagColor02 = tagColor ? alpha(tagColor, 0.2) : null;
   }

--- a/src/components/Layout/LeftNav/LeftNavTree.tsx
+++ b/src/components/Layout/LeftNav/LeftNavTree.tsx
@@ -7,6 +7,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import Divider from "@mui/material/Divider";
 import { useTheme } from "@mui/material/styles";
+import { useTranslation } from "gatsby-plugin-react-i18next";
 
 import { RepoNavLink, RepoNav } from "shared/interface";
 import LinkComponent from "components/Link";
@@ -190,6 +191,7 @@ export default function ControlledTreeView(props: {
   });
 
   const theme = useTheme();
+  const { t } = useTranslation();
   const [disableTransition, setDisableTransition] = React.useState(false);
   const previousUrlRef = React.useRef<string | null>(null);
 
@@ -313,7 +315,7 @@ export default function ControlledTreeView(props: {
             ) : (
               <Box sx={{ flexShrink: 0 }} width={16} height={16} />
             )}
-            {generateItemLabel(item)}
+            {generateItemLabel(item, theme, t("navbar.badge.preview"))}
           </Stack>
         );
       };
@@ -389,9 +391,15 @@ export default function ControlledTreeView(props: {
   );
 }
 
-const generateItemLabel = ({ content: contents, tag }: RepoNavLink) => {
+const generateItemLabel = (
+  { content: contents, tag }: RepoNavLink,
+  theme: ReturnType<typeof useTheme>,
+  previewBadgeLabel: string
+) => {
+  const normalizedTagValue = tag?.value?.trim().toUpperCase();
+  const isPreviewTag = normalizedTagValue === "PREVIEW";
   const tagQuery = new URLSearchParams(tag?.query);
-  const tagColor = tagQuery.get("color");
+  const tagColor = isPreviewTag ? null : tagQuery.get("color");
   const tagColor02 = tagColor && alpha(tagColor, 0.2);
   return (
     <Stack sx={{ width: "100%" }} direction="row" gap="4px">
@@ -424,18 +432,36 @@ const generateItemLabel = ({ content: contents, tag }: RepoNavLink) => {
       </Box>
       {tag && (
         <Chip
-          label={tag.value}
+          label={isPreviewTag ? previewBadgeLabel : tag.value}
           variant="outlined"
           size="small"
           sx={{
-            flexShrink: 0,
-            textTransform: "uppercase",
-            pointerEvents: "none",
-            fontSize: "10px",
-            height: "20px",
-            borderColor: tagColor ? tagColor02 : "#c0e1f1",
-            color: tagColor || "#2d9cd2",
-            fontWeight: 500,
+            ...(isPreviewTag
+              ? {
+                  flexShrink: 0,
+                  height: "20px",
+                  fontSize: "12px",
+                  fontWeight: 400,
+                  borderRadius: "10px",
+                  borderColor: theme.palette.carbon[400],
+                  pointerEvents: "none",
+                  "& .MuiChip-label": {
+                    paddingLeft: "8px",
+                    paddingRight: "8px",
+                    lineHeight: "20px",
+                    color: theme.palette.carbon[700],
+                  },
+                }
+              : {
+                  flexShrink: 0,
+                  textTransform: "uppercase",
+                  pointerEvents: "none",
+                  fontSize: "10px",
+                  height: "20px",
+                  borderColor: tagColor ? tagColor02 : "#c0e1f1",
+                  color: tagColor || "#2d9cd2",
+                  fontWeight: 500,
+                }),
           }}
         />
       )}

--- a/src/components/Layout/LeftNav/LeftNavTree.tsx
+++ b/src/components/Layout/LeftNav/LeftNavTree.tsx
@@ -398,9 +398,15 @@ const generateItemLabel = (
 ) => {
   const normalizedTagValue = tag?.value?.trim().toUpperCase();
   const isPreviewTag = normalizedTagValue === "PREVIEW";
-  const tagQuery = new URLSearchParams(tag?.query);
-  const tagColor = isPreviewTag ? null : tagQuery.get("color");
-  const tagColor02 = tagColor && alpha(tagColor, 0.2);
+  let tagColor: string | null = null;
+  let tagColor02: string | null = null;
+
+  if (!isPreviewTag) {
+    const tagQuery = new URLSearchParams(tag?.query);
+    tagColor = tagQuery.get("color");
+    tagColor02 = tagColor ? alpha(tagColor, 0.2) : null;
+  }
+
   return (
     <Stack sx={{ width: "100%" }} direction="row" gap="4px">
       <Box
@@ -438,6 +444,8 @@ const generateItemLabel = (
           sx={{
             ...(isPreviewTag
               ? {
+                  // PREVIEW badges intentionally use a fixed neutral style even if
+                  // the source TOC image URL carries query params such as ?color=...
                   flexShrink: 0,
                   height: "20px",
                   fontSize: "12px",

--- a/src/components/Layout/LeftNav/LeftNavTree.tsx
+++ b/src/components/Layout/LeftNav/LeftNavTree.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "gatsby-plugin-react-i18next";
 
 import { RepoNavLink, RepoNav } from "shared/interface";
 import LinkComponent from "components/Link";
+import PreviewBadge from "components/Badge/PreviewBadge";
 import { scrollToElementIfInView } from "shared/utils";
 import { alpha, Chip } from "@mui/material";
 
@@ -315,7 +316,7 @@ export default function ControlledTreeView(props: {
             ) : (
               <Box sx={{ flexShrink: 0 }} width={16} height={16} />
             )}
-            {generateItemLabel(item, theme, t("navbar.badge.preview"))}
+            {generateItemLabel(item, t("navbar.badge.preview"))}
           </Stack>
         );
       };
@@ -393,7 +394,6 @@ export default function ControlledTreeView(props: {
 
 const generateItemLabel = (
   { content: contents, tag }: RepoNavLink,
-  theme: ReturnType<typeof useTheme>,
   previewBadgeLabel: string
 ) => {
   const normalizedTagValue = tag?.value?.trim().toUpperCase();
@@ -401,6 +401,7 @@ const generateItemLabel = (
   let tagColor: string | null = null;
   let tagColor02: string | null = null;
 
+  // PREVIEW intentionally ignores source color overrides to match shared badges.
   if (tag && !isPreviewTag) {
     const tagQuery = new URLSearchParams(tag.query ?? "");
     tagColor = tagQuery.get("color");
@@ -436,43 +437,25 @@ const generateItemLabel = (
           );
         })}
       </Box>
-      {tag && (
+      {tag && isPreviewTag ? (
+        <PreviewBadge label={previewBadgeLabel} />
+      ) : tag ? (
         <Chip
-          label={isPreviewTag ? previewBadgeLabel : tag.value}
+          label={tag.value}
           variant="outlined"
           size="small"
           sx={{
-            ...(isPreviewTag
-              ? {
-                  // PREVIEW badges intentionally use a fixed neutral style even if
-                  // the source TOC image URL carries query params such as ?color=...
-                  flexShrink: 0,
-                  height: "20px",
-                  fontSize: "12px",
-                  fontWeight: 400,
-                  borderRadius: "10px",
-                  borderColor: theme.palette.carbon[400],
-                  pointerEvents: "none",
-                  "& .MuiChip-label": {
-                    paddingLeft: "8px",
-                    paddingRight: "8px",
-                    lineHeight: "20px",
-                    color: theme.palette.carbon[700],
-                  },
-                }
-              : {
-                  flexShrink: 0,
-                  textTransform: "uppercase",
-                  pointerEvents: "none",
-                  fontSize: "10px",
-                  height: "20px",
-                  borderColor: tagColor ? tagColor02 : "#c0e1f1",
-                  color: tagColor || "#2d9cd2",
-                  fontWeight: 500,
-                }),
+            flexShrink: 0,
+            textTransform: "uppercase",
+            pointerEvents: "none",
+            fontSize: "10px",
+            height: "20px",
+            borderColor: tagColor ? tagColor02 : "#c0e1f1",
+            color: tagColor || "#2d9cd2",
+            fontWeight: 500,
           }}
         />
-      )}
+      ) : null}
     </Stack>
   );
 };

--- a/src/components/Layout/VersionSelect/CloudVersionSelect.tsx
+++ b/src/components/Layout/VersionSelect/CloudVersionSelect.tsx
@@ -42,11 +42,20 @@ const CLOUD_VERSIONS = [
         variant="outlined"
         size="small"
         sx={{
-          fontSize: "12px",
-          height: "20px",
+          fontSize: "10px",
+          fontWeight: 500,
+          height: "18px",
+          borderRadius: "1000px",
           pointerEvents: "none",
           borderColor: "#DCE3E5",
           color: "#6F787B",
+          textTransform: "uppercase",
+          letterSpacing: "0.25px",
+          "& .MuiChip-label": {
+            paddingLeft: "8px",
+            paddingRight: "8px",
+            lineHeight: "16px",
+          },
         }}
       />
     ),


### PR DESCRIPTION
## Purpose

Render PREVIEW labels consistently across documentation navigation, including TOC image tags and the TiDB for AI left navigation title, using the existing neutral, localized Preview badge style.

## Scope

- Detect PREVIEW TOC tags case-insensitively and render a fixed neutral badge style.
- Reuse the existing PreviewBadge for the TiDB for AI directory title.
- Remove the now-unused BetaTagBadge component and Beta locale entries.
- Preserve the generic BETA and custom tag color behavior for TOC compatibility.
- Avoid generating a ?undefined tag query for TOC image URLs without query parameters.
- Add TOC parser coverage for image tags with and without query parameters or alt text.

## Validation

- Prettier checks for updated components, parser, tests, and locale files.
- JSON parsing for English, Chinese, and Japanese locale files.
- Runtime assertion that TiDB for AI uses the shared PreviewBadge and preview translation key.
- Jest coverage for the TOC tag parser and existing TOC namespace behavior.

## Notes

PREVIEW TOC tags intentionally ignore a source color query parameter so their badge appearance remains consistent.