### PR TITLE
fix(header): remove Ask AI entry

### DIFF
--- a/src/components/Layout/Header/HeaderAction.tsx
+++ b/src/components/Layout/Header/HeaderAction.tsx
@@ -7,7 +7,6 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
-import StarIcon from "media/icons/star.svg";
 
 import CloudIcon from "@mui/icons-material/Cloud";
 import { useTheme } from "@mui/material/styles";
@@ -18,41 +17,6 @@ import { Locale, BuildType, TOCNamespace } from "shared/interface";
 import { Link } from "gatsby";
 import { useIsAutoTranslation } from "shared/useIsAutoTranslation";
 
-const useTiDBAIStatus = () => {
-  const [showTiDBAIButton, setShowTiDBAIButton] = React.useState(true);
-  const [initializingTiDBAI, setInitializingTiDBAI] = React.useState(true);
-
-  React.useEffect(() => {
-    if (!!window.tidbai) {
-      setInitializingTiDBAI(false);
-    }
-
-    const onTiDBAIInitialized = () => {
-      setInitializingTiDBAI(false);
-    };
-    const onTiDBAIError = () => {
-      setInitializingTiDBAI(false);
-      setShowTiDBAIButton(false);
-    };
-    window.addEventListener("tidbaiinitialized", onTiDBAIInitialized);
-    window.addEventListener("tidbaierror", onTiDBAIError);
-
-    const timer = setTimeout(() => {
-      if (!window.tidbai) {
-        setInitializingTiDBAI(false);
-        setShowTiDBAIButton(false);
-      }
-    }, 10000);
-    return () => {
-      clearTimeout(timer);
-      window.removeEventListener("tidbaiinitialized", onTiDBAIInitialized);
-      window.removeEventListener("tidbaierror", onTiDBAIError);
-    };
-  }, []);
-
-  return { showTiDBAIButton, initializingTiDBAI };
-};
-
 export default function HeaderAction(props: {
   supportedLocales: Locale[];
   docInfo?: { type: string; version: string };
@@ -61,40 +25,16 @@ export default function HeaderAction(props: {
 }) {
   const { docInfo, buildType, namespace } = props;
   const { language, t } = useI18next();
-  const { showTiDBAIButton, initializingTiDBAI } = useTiDBAIStatus();
   const isAutoTranslation = useIsAutoTranslation(namespace);
 
-	  return (
-	    <Stack
-	      direction="row"
-	      spacing={{ xs: 1, md: 2 }}
-	      sx={{ alignItems: "center" }}
-	    >
+  return (
+    <Stack
+      direction="row"
+      spacing={{ xs: 1, md: 2 }}
+      sx={{ alignItems: "center" }}
+    >
       {docInfo && !isAutoTranslation && buildType !== "archive" && (
-        <>
-          <Search placeholder={t("navbar.searchDocs")} docInfo={docInfo} />
-          {language === "en" && showTiDBAIButton && (
-            <Button
-              id="header-ask-ai"
-              variant="outlined"
-              startIcon={<StarIcon />}
-              disabled={initializingTiDBAI}
-              size="medium"
-              sx={{
-                fontSize: "14px",
-                display: {
-                  xs: "none",
-                  xl: "flex",
-                },
-              }}
-              onClick={() => {
-                window.tidbai.open = true;
-              }}
-            >
-              Ask AI
-            </Button>
-          )}
-        </>
+        <Search placeholder={t("navbar.searchDocs")} docInfo={docInfo} />
       )}
       {language === "en" && <TiDBCloudBtnGroup />}
     </Stack>


### PR DESCRIPTION
## What changed

- Remove the Ask AI button from the documentation site header.
- Remove the header-only TiDB AI initialization and error-handling code.
- Remove the now-unused star icon import.

## Why

The Ask AI entry should no longer be exposed in the documentation site header. This entry might be added back later after its performance/speed, accuracy, and user experience are improved.

## Impact

The header continues to show documentation search and TiDB Cloud actions, but no longer displays or initializes the Ask AI entry.

## Validation

- `node_modules/.bin/prettier --check src/components/Layout/Header/HeaderAction.tsx`
- `git diff --check`
- `node_modules/.bin/tsc --noEmit` *(blocked by the existing TypeScript 4.5 / `@types/d3-dispatch` syntax incompatibility in `node_modules`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed the “Ask AI” button from the header.
  * Removed TiDB AI initialization and status handling from the header.
* **Unchanged**
  * Documentation search remains available under existing conditions.
  * TiDB Cloud buttons continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->