### PR TITLE
fix(search): show search for Chinese AI docs

### DIFF
--- a/src/components/Layout/Header/HeaderAction.tsx
+++ b/src/components/Layout/Header/HeaderAction.tsx
@@ -26,6 +26,9 @@ export default function HeaderAction(props: {
   const { docInfo, buildType, namespace } = props;
   const { language, t } = useI18next();
   const isAutoTranslation = useIsAutoTranslation(namespace);
+  // Chinese AI docs are auto-translated but are included in the onsite search index.
+  const showSearchOnAutoTranslation =
+    language === Locale.zh && namespace === TOCNamespace.AI;
 
   return (
     <Stack
@@ -33,9 +36,11 @@ export default function HeaderAction(props: {
       spacing={{ xs: 1, md: 2 }}
       sx={{ alignItems: "center" }}
     >
-      {docInfo && !isAutoTranslation && buildType !== "archive" && (
-        <Search placeholder={t("navbar.searchDocs")} docInfo={docInfo} />
-      )}
+      {docInfo &&
+        (!isAutoTranslation || showSearchOnAutoTranslation) &&
+        buildType !== "archive" && (
+          <Search placeholder={t("navbar.searchDocs")} docInfo={docInfo} />
+        )}
       {language === "en" && <TiDBCloudBtnGroup />}
     </Stack>
   );


### PR DESCRIPTION
## Summary

- Show the header search entry on all Chinese AI documentation pages under `/zh/ai/`.
- Keep the auto-translation banner and the behavior of other auto-translated documentation unchanged.

## Why

The header currently hides search for all auto-translated documentation. 
<img width="2670" height="874" alt="image" src="https://github.com/user-attachments/assets/1956ee43-490e-4c90-afea-cd87405c4bb4" />

But Chinese AI documentation is an exception: although it is auto-translated, its content is already available through onsite search. For example, [search results for 全文搜索](https://docs.pingcap.com/zh/search/?q=%E5%85%A8%E6%96%87%E6%90%9C%E7%B4%A2) include relevant content.

Without a search entry in the header, users browsing `/zh/ai/` pages cannot easily access search even though those pages are searchable.

## Validation

The preview for this PR:
<img width="2686" height="870" alt="image" src="https://github.com/user-attachments/assets/e66745e2-f377-4ff5-a07b-ca4082ab63a6" />



- `pnpm exec prettier --check src/components/Layout/Header/HeaderAction.tsx`
- Targeted TypeScript transpilation of `HeaderAction.tsx`
- `git diff --check`

The full Jest suite is currently blocked by pre-existing repository configuration type errors involving `Repo.tidbcloudlake`. The Gatsby build is also blocked during CLI startup in the current local dependency environment.