### PR TITLE
fix(header): disable Lake links for zh and ja

### DIFF
--- a/src/components/Layout/Header/HeaderNavConfigData.tsx
+++ b/src/components/Layout/Header/HeaderNavConfigData.tsx
@@ -86,6 +86,7 @@ const getDefaultNavConfig = (
             endIcon: <PreviewBadge label={t("navbar.badge.preview")} />,
             to: "/tidbcloudlake",
             selected: (namespace) => namespace === TOCNamespace.TiDBCloudLake,
+            disabled: (lang: string) => lang === "zh" || lang === "ja",
             onClick: () => {
               if (typeof window !== "undefined") {
                 sessionStorage.setItem(CLOUD_MODE_KEY, CloudPlan.Dedicated);


### PR DESCRIPTION
## Summary

- Disable the TiDB Cloud Lake navigation link in the Chinese and Japanese documentation sites.
- Keep the TiDB Cloud Lake entry and its `PREVIEW` badge visible.
- Keep the English documentation entry clickable.

## Rationale

TiDB Cloud Lake is currently in Preview, and Chinese and Japanese documentation is not available yet. To avoid directing users to unavailable localized content, the Chinese and Japanese product-menu entries are now displayed as disabled, non-clickable items.

## Impact

- Chinese and Japanese users see a grayed-out TiDB Cloud Lake entry without a link.
- English users can continue to access the TiDB Cloud Lake documentation from the product menu.
- The existing `PREVIEW` badge remains unchanged.
- No routing or translation keys are changed.

## Test Plan

- `pnpm exec prettier --check src/components/Layout/Header/HeaderNavConfigData.tsx`
- `git diff --check`
- `pnpm exec jest --coverage --roots gatsby --runInBand` (238 tests passed; 8 tests remain blocked by existing TypeScript errors outside this change.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The TiDB Cloud Lake navigation item is now unavailable when the interface language is set to Chinese or Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->